### PR TITLE
Implement referrer tagging for email sign-ups

### DIFF
--- a/src/components/Newsletter.jsx
+++ b/src/components/Newsletter.jsx
@@ -1,5 +1,6 @@
 import React, {useState} from 'react'
 import { Button } from '@/components/Button'
+import { useRouter } from 'next/router'
 
 function MailIcon(props) {
   return (
@@ -28,6 +29,11 @@ export const Newsletter = function() {
 
   const [formSuccess, setSuccess] = React.useState(false);
 
+  // Get access to the router in order to fetch query params off it
+  const router = useRouter()
+
+  const referrer = router.query.referrer || 'unknown/direct'
+
   // Handle the submit event on form submit.
   const handleSubmit = async (event) => {
     // Stop the form from submitting and refreshing the page.
@@ -39,6 +45,7 @@ export const Newsletter = function() {
     // Get data from the form.
     const data = {
       email: form.email.value,
+      referrer
     }
 
     // Send the form data to our API and get a response.

--- a/src/pages/api/form.js
+++ b/src/pages/api/form.js
@@ -15,6 +15,9 @@ export default async function handler(req, res) {
   const data = {
     api_key: emailOctopusAPIKey, 
     email_address: newMemberEmailAddress,
+    fields: {
+      Referrer: body.referrer,
+    },
     status: "SUBSCRIBED"
   } 
 

--- a/src/pages/subscribe/index.jsx
+++ b/src/pages/subscribe/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container } from '@/components/Container'
+import { useRouter } from 'next/router'
 import Image from 'next/image'
 import portraitImage from '@/images/zachary-proser.png'
 import Head from 'next/head'
@@ -7,7 +8,13 @@ import Head from 'next/head'
 import { SimpleLayout } from '@/components/SimpleLayout'
 
 function SubscribeWidget() {
+
   const [formSuccess, setSuccess] = React.useState(false);
+
+  // Get access to the router in order to fetch query params off it
+  const router = useRouter()
+
+  const referrer = router.query.referrer || 'unknown/direct'
 
   // Handle the submit event on form submit.
   const handleSubmit = async (event) => {
@@ -16,10 +23,11 @@ function SubscribeWidget() {
 
     // Cast the event target to an html form
     const form = event.target
-
+    
     // Get data from the form.
     const data = {
       email: form.email.value,
+      referrer,
     }
 
     // Send the form data to our API and get a response.


### PR DESCRIPTION
Allow the /subscribe page and the `Newsletter` component to capture the referrer query param, if present, and send it through the form backend so it can be stored with the contact. 