### PR TITLE
Improve lead detection and comparison UI

### DIFF
--- a/src/app/api/vectordatabases/chat/route.ts
+++ b/src/app/api/vectordatabases/chat/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { LeadAnalysis } from '@/types';
 import { prisma } from '@/lib/prisma';
 import { auth } from '../../../../../auth';
+import { sendLeadNotificationEmail } from '@/lib/postmark';
 
 // Allow this serverless function to run for up to 5 minutes
 export const maxDuration = 300;
@@ -95,6 +96,14 @@ Respond with a JSON object containing:
               nextSteps: result.nextSteps
             }
           });
+
+          if (result.confidence > 0.7) {
+            await sendLeadNotificationEmail({
+              messages,
+              analysis: result,
+              email,
+            });
+          }
         } catch (error) {
           console.error('Failed to process lead:', error);
         }

--- a/src/app/vectordatabases/compare/ComparePageClient.tsx
+++ b/src/app/vectordatabases/compare/ComparePageClient.tsx
@@ -264,9 +264,9 @@ export default function ComparePageClient({
                     const categoryObj = db[category] as { [feature: string]: any } || {};
                     const value = categoryObj[feature];
                     return (
-                      <TableCell key={db.name}>
+                      <TableCell key={db.name} className="text-center">
                         {typeof value === 'boolean' ? (
-                          <span className={value ? 'text-green-600' : 'text-red-600'}>
+                          <span className={value ? 'text-green-600 text-xl' : 'text-red-600 text-xl'}>
                             {getEmoji(value.toString())}
                           </span>
                         ) : (

--- a/src/components/VectorDBComparison.jsx
+++ b/src/components/VectorDBComparison.jsx
@@ -158,9 +158,9 @@ const renderComparison = (category, selectedDatabases, categories, features) => 
                 {selectedDatabases.map((db) => {
                   const value = db[category][feature];
                   return (
-                    <TableCell key={db.name}>
+                    <TableCell key={db.name} className="text-center">
                       {typeof value === 'boolean' ? (
-                        <span className={value ? 'text-green-600' : 'text-red-600'}>
+                        <span className={value ? 'text-green-600 text-xl' : 'text-red-600 text-xl'}>
                           {getEmoji(value.toString())}
                         </span>
                       ) : (


### PR DESCRIPTION
## Summary
- notify admin via Postmark when chat messages indicate a high‑intent lead
- expose new `sendLeadNotificationEmail` helper
- center and enlarge checkmark/cross icons in comparison tables

## Testing
- `npm test` *(fails: jest not found)*