### PR TITLE
Improve newsletter admin auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_SITE_URL=https://zackproser.com
+ADMIN_EMAILS=zackproser@gmail.com

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,17 +1,11 @@
-import { redirect } from 'next/navigation'
-import { auth } from '../../../auth'
+import { requireAdmin } from '@/lib/require-admin'
 
 export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const session = await auth()
-  
-  // Check if user is authenticated and has the correct email
-  if (!session || session.user?.email !== 'zackproser@gmail.com') {
-    redirect('/auth/login?callbackUrl=/admin')
-  }
+  await requireAdmin('/admin')
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-950 via-purple-900 to-blue-900">

--- a/src/app/admin/newsletter/page.tsx
+++ b/src/app/admin/newsletter/page.tsx
@@ -1,14 +1,8 @@
-import { redirect } from 'next/navigation'
 import NewsletterBuilder from "@/components/newsletter-admin/newsletter-builder"
-import { auth } from '../../../../auth'
+import { requireAdmin } from '@/lib/require-admin'
 
 export default async function NewsletterAdminPage() {
-  const session = await auth()
-  
-  // Check if user is authenticated and has the correct email
-  if (!session || session.user?.email !== 'zackproser@gmail.com') {
-    redirect('/auth/login?callbackUrl=/admin/newsletter')
-  }
+  await requireAdmin('/admin/newsletter')
 
   return (
     <div className="w-full p-0">

--- a/src/lib/require-admin.ts
+++ b/src/lib/require-admin.ts
@@ -1,0 +1,15 @@
+export async function requireAdmin(callbackUrl: string = '/admin') {
+  const { auth } = await import('../../auth')
+  const { redirect } = await import('next/navigation')
+
+  const session = await auth()
+  const adminEmails = process.env.ADMIN_EMAILS
+    ? process.env.ADMIN_EMAILS.split(',').map(e => e.trim()).filter(Boolean)
+    : []
+
+  if (!session || !adminEmails.includes(session.user?.email || '')) {
+    redirect(`/auth/login?callbackUrl=${callbackUrl}`)
+  }
+
+  return session
+}


### PR DESCRIPTION
## Summary
- add `ADMIN_EMAILS` example variable
- create a helper to centralize newsletter admin checks
- use the new helper in `/admin` layout and newsletter page

## Testing
- `npm test` *(fails: jest not found)*