### PR TITLE
Implement email gated content

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { ArticleLayout } from '@/components/ArticleLayout'
 import React from 'react'
 import { CheckCircle } from 'lucide-react'
 import { metadataLogger as logger } from '@/utils/logger'
+import { isEmailSubscribed } from '@/lib/newsletter'
 
 // Content type for this handler
 const CONTENT_TYPE = 'blog'
@@ -80,6 +81,11 @@ export default async function Page({ params }: PageProps) {
   } else {
     logger.debug(`Content (${slug}) is not marked as paid.`);
   }
+
+  let isSubscribed = false;
+  if (content?.commerce?.requiresEmail) {
+    isSubscribed = await isEmailSubscribed(session?.user?.email || null);
+  }
   
   logger.info(`Rendering page for slug: ${slug}, Paid: ${!!content?.commerce?.isPaid}, Purchased: ${hasPurchased}`);
 
@@ -96,7 +102,7 @@ export default async function Page({ params }: PageProps) {
           {React.createElement(MdxContent)}
         </div>
       ) : (
-        renderPaywalledContent(MdxContent, content, hasPurchased)
+        renderPaywalledContent(MdxContent, content, hasPurchased, isSubscribed)
       )}
     </ArticleLayout>
     </>

--- a/src/app/learn/courses/[slug]/page.tsx
+++ b/src/app/learn/courses/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   renderPaywalledContent,
   getDefaultPaywallText
 } from '@/lib/content-handlers'
+import { isEmailSubscribed } from '@/lib/newsletter'
 
 // Content type for this handler
 const CONTENT_TYPE = 'learn/courses'
@@ -48,9 +49,14 @@ export default async function CourseSlugPage({ params }: PageProps) {
   // Get user ID from session
   const session = await auth()
   const userId = session?.user.id
-  
+
   // Check if user has purchased access
   const userHasPurchased = await hasUserPurchased(userId, CONTENT_TYPE, slug)
+
+  let isSubscribed = false
+  if (content?.commerce?.requiresEmail) {
+    isSubscribed = await isEmailSubscribed(session?.user?.email || null)
+  }
   
   // Check if content requires payment
   if (content?.commerce?.isPaid) {
@@ -64,7 +70,7 @@ export default async function CourseSlugPage({ params }: PageProps) {
           {/* Note: We pass MdxContent to renderPaywalledContent below, 
               so no need to render it separately here unless you want a specific preview structure */}
           {/* <MdxContent /> */} 
-          {renderPaywalledContent(MdxContent, content, userHasPurchased)} 
+          {renderPaywalledContent(MdxContent, content, userHasPurchased, isSubscribed)}
           {/* Pass the entire content object to Paywall */}
           <Paywall 
             content={content}
@@ -81,7 +87,7 @@ export default async function CourseSlugPage({ params }: PageProps) {
   return (
     <>
       {/* Render potentially paywalled content (will render full if purchased or not paid) */}
-      {renderPaywalledContent(MdxContent, content, userHasPurchased)}
+      {renderPaywalledContent(MdxContent, content, userHasPurchased, isSubscribed)}
     </>
   )
 } 

--- a/src/components/ArticleContent.tsx
+++ b/src/components/ArticleContent.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Paywall from './Paywall'
+import NewsletterWrapper from './NewsletterWrapper'
 import { StaticImageData } from 'next/image'
 import { Content } from '@/types'
 
@@ -14,24 +15,28 @@ interface ArticleContentProps {
   paywallBody?: string
   buttonText?: string
   content: Content
+  requiresEmail?: boolean
+  isSubscribed?: boolean
 }
 
 export default function ArticleContent({ 
-  children, 
+  children,
   showFullContent,
   previewLength = 150,
   previewElements = 3,
   paywallHeader,
   paywallBody,
   buttonText,
-  content
+  content,
+  requiresEmail = false,
+  isSubscribed = false
 }: ArticleContentProps) {
   if (!content.slug) {
     console.warn('ArticleContent: content.slug is missing, rendering full content')
     return <>{children}</>
   }
 
-  if (showFullContent) {
+  if (showFullContent || (requiresEmail && isSubscribed)) {
     return <>{children}</>
   }
 
@@ -58,12 +63,21 @@ export default function ArticleContent({
       <div className="article-preview">
         {preview}
       </div>
-      <Paywall 
-        content={content}
-        paywallHeader={paywallHeader}
-        paywallBody={paywallBody}
-        buttonText={buttonText}
-      />
+      {requiresEmail ? (
+        <NewsletterWrapper
+          title={paywallHeader || 'Join the newsletter to continue'}
+          body={paywallBody || 'Enter your email to unlock this content.'}
+          successMessage="Thanks for subscribing! Refresh to view the full article."
+          position="gate"
+        />
+      ) : (
+        <Paywall
+          content={content}
+          paywallHeader={paywallHeader}
+          paywallBody={paywallBody}
+          buttonText={buttonText}
+        />
+      )}
     </>
   )
-} 
+}

--- a/src/lib/content-handlers.ts
+++ b/src/lib/content-handlers.ts
@@ -447,10 +447,14 @@ export function getDefaultPaywallText(contentType: string): {
 export function renderPaywalledContent(
   MdxContent: React.ComponentType,
   content: Content, // Use the processed Content type
-  hasPurchased: boolean
+  hasPurchased: boolean,
+  isSubscribed: boolean
 ) {
   // Determine if we should show the full content
-  const showFullContent = !content.commerce?.isPaid || hasPurchased;
+  const showFullContent =
+    (!content.commerce?.isPaid && !content.commerce?.requiresEmail) ||
+    hasPurchased ||
+    (content.commerce?.requiresEmail && isSubscribed);
 
   // Get default paywall text based on content type
   const defaultText = getDefaultPaywallText(content.type);
@@ -476,6 +480,8 @@ export function renderPaywalledContent(
       paywallHeader: content.commerce?.paywallHeader || defaultText.header,
       paywallBody: content.commerce?.paywallBody || defaultText.body,
       buttonText: content.commerce?.buttonText || defaultText.buttonText,
+      requiresEmail: content.commerce?.requiresEmail,
+      isSubscribed: isSubscribed,
       // Pass content object itself if ArticleContent needs more data
       content: content,
     }

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -1,0 +1,28 @@
+import { logger } from '@/utils/logger'
+
+/**
+ * Check if an email address is subscribed to the main EmailOctopus list.
+ * Returns true when the contact exists and has status 'SUBSCRIBED'.
+ */
+export async function isEmailSubscribed(email: string | null | undefined): Promise<boolean> {
+  if (!email) return false
+
+  try {
+    const apiKey = process.env.EMAIL_OCTOPUS_API_KEY
+    const listId = process.env.EMAIL_OCTOPUS_LIST_ID
+    if (!apiKey || !listId) return false
+
+    const endpoint = `https://emailoctopus.com/api/1.6/lists/${listId}/contacts/${encodeURIComponent(email)}?api_key=${apiKey}`
+    const res = await fetch(endpoint)
+    if (!res.ok) {
+      logger.warn(`EmailOctopus lookup failed for ${email}: ${res.status}`)
+      return false
+    }
+
+    const data = await res.json()
+    return data.status === 'SUBSCRIBED'
+  } catch (err) {
+    logger.error('Failed to check email subscription', err)
+    return false
+  }
+}

--- a/src/types/commerce.ts
+++ b/src/types/commerce.ts
@@ -3,6 +3,11 @@ import { StaticImageData } from 'next/image'
 // Commerce-related types
 export interface CommerceConfig {
   isPaid: boolean
+  /**
+   * When true, the content is free but requires the user to submit
+   * their email and be subscribed to the newsletter.
+   */
+  requiresEmail?: boolean
   price: number
   stripe_price_id?: string
   previewLength?: number


### PR DESCRIPTION
## Summary
- add optional `requiresEmail` to commerce config
- create helper to verify email subscription
- update ArticleContent to show newsletter signup gate
- check subscription in blog and course pages
- extend renderPaywalledContent to handle subscription logic

## Testing
- `npx jest` *(fails: connect EHOSTUNREACH)*
- `npx next lint` *(fails: connect EHOSTUNREACH)*