### PR TITLE
Implement email gated content

### DIFF
--- a/src/components/ArticleContent.tsx
+++ b/src/components/ArticleContent.tsx
@@ -68,7 +68,14 @@ export default function ArticleContent({
         <EmailSignupGate
           header={paywallHeader}
           body={paywallBody}
-        />
+        >
+          <NewsletterWrapper
+            title={paywallHeader || 'Join the newsletter to continue'}
+            body={paywallBody || 'Enter your email to unlock this content.'}
+            successMessage="Thanks for subscribing! Refresh to view the full article."
+            position="gate"
+          />
+        </EmailSignupGate>
       ) : (
         <Paywall
           content={content}

--- a/src/content/blog/vercel-ai-sdk/page.mdx
+++ b/src/content/blog/vercel-ai-sdk/page.mdx
@@ -18,7 +18,10 @@ export const metadata = createMetadata({
     title: "The Vercel AI SDK: A worthwhile investment in bleeding edge GenAI",
     description: "The Vercel AI SDK takes some time to get used it. It is time well spent.",
     image: vercelAISDK,
-    slug: 'vercel-ai-sdk'
+    slug: 'vercel-ai-sdk',
+    commerce: {
+        requiresEmail: true
+    }
 });
 
 <Image 


### PR DESCRIPTION
## Summary
- add optional `requiresEmail` to commerce config
- create helper to verify email subscription
- update ArticleContent to show newsletter signup gate
- check subscription in blog and course pages
- extend renderPaywalledContent to handle subscription logic
- demonstrate gating on `/blog/vercel-ai-sdk`

## Testing
- `npx jest` *(fails: connect EHOSTUNREACH)*
- `npx next lint` *(fails: connect EHOSTUNREACH)*