### PR TITLE
Add blog typeahead filtering with ContentCards

### DIFF
--- a/src/app/blog/blog-client.tsx
+++ b/src/app/blog/blog-client.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { useState } from "react"
+import { Search } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { ContentCard } from "@/components/ContentCard"
+import type { ArticleWithSlug } from "@/types"
+
+interface BlogClientProps {
+  articles: ArticleWithSlug[]
+  years: string[]
+  allTags: string[]
+}
+
+export default function BlogClient({ articles, years, allTags }: BlogClientProps) {
+  const [searchTerm, setSearchTerm] = useState("")
+  const [selectedYear, setSelectedYear] = useState("")
+  const [selectedTag, setSelectedTag] = useState("")
+
+  const filteredArticles = articles.filter((article) => {
+    const term = searchTerm.toLowerCase()
+    const matchesSearch = term
+      ? (article.title?.toLowerCase().includes(term) ||
+         article.description?.toLowerCase().includes(term))
+      : true
+    const matchesYear = selectedYear && selectedYear !== "All Years"
+      ? article.date.startsWith(selectedYear)
+      : true
+    const matchesTag = selectedTag && selectedTag !== "All Tags"
+      ? Array.isArray(article.tags) && article.tags.includes(selectedTag)
+      : true
+    return matchesSearch && matchesYear && matchesTag
+  })
+
+  return (
+    <div>
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={18} />
+          <Input
+            placeholder="Search articles..."
+            className="pl-10"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+        <Select value={selectedYear} onValueChange={setSelectedYear}>
+          <SelectTrigger>
+            <SelectValue placeholder="Year" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="All Years">All Years</SelectItem>
+            {years.map((year) => (
+              <SelectItem key={year} value={year}>{year}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={selectedTag} onValueChange={setSelectedTag}>
+          <SelectTrigger>
+            <SelectValue placeholder="Tag" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="All Tags">All Tags</SelectItem>
+            {allTags.map((tag) => (
+              <SelectItem key={tag} value={tag}>{tag}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
+        <div className="mx-auto mt-16 grid max-w-none grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-3">
+          {filteredArticles.map((article, index) => (
+            <ContentCard key={index} article={article} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,68 +1,32 @@
 import { Metadata } from 'next'
 import { SimpleLayout } from '@/components/SimpleLayout'
-import { ContentCard } from '@/components/ContentCard'
+import BlogClient from './blog-client'
 import { createMetadata } from '@/utils/createMetadata'
-import { Suspense } from 'react'
 import { getAllContent } from '@/lib/content-handlers'
-import { ExtendedMetadata } from '@/types'
-import ArticleSearch from '@/components/ArticleSearch'
 
-// Base metadata using createMetadata
 const baseMetadata = createMetadata({
   title: 'Modern Coding - Research',
   description: 'Staff AI engineer - technical writing and development blog',
 })
 
-// Export final metadata including metadataBase
 export const metadata: Metadata = {
   ...baseMetadata,
   metadataBase: new URL('https://zackproser.com'),
 }
 
-function ArticleGrid({ articles }: { articles: ExtendedMetadata[] }) {
-  return (
-    <div className="mx-auto mt-16 grid max-w-none grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-3">
-      {articles.map((article, index) => {
-        // Simply use the index as the key
-        return (
-          <ContentCard 
-            key={index} 
-            article={article} 
-          />
-        );
-      })}
-    </div>
-  )
-}
-
 export default async function ArticlesIndex() {
-  // Use our helper function to get all blog post metadata
-  const articles = await getAllContent('blog');
-  
-  // Add debugging to log the articles being loaded
-  // console.log(`Loaded ${articles.length} blog articles`); // Commented out verbose log
-  
-  // Log the first few articles for debugging
-  /* // Commented out verbose log
-  articles.slice(0, 3).forEach((article, index) => {
-    console.log(`Article ${index + 1}:`, {
-      title: article.title,
-      slug: article.slug,
-      type: article.type
-    });
-  });
-  */
-  
+  const articles = await getAllContent('blog')
+
+  const years = [...new Set(articles.map((a) => new Date(a.date).getFullYear().toString()))]
+    .sort((a, b) => parseInt(b) - parseInt(a))
+  const allTags = [...new Set(articles.flatMap((a) => a.tags ?? []))].sort()
+
   return (
     <SimpleLayout
       title="I write to learn, and publish to share"
       intro="All of my technical tutorials, musings and developer rants"
     >
-      <div className="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
-        <Suspense fallback={<div>Loading articles...</div>}>
-          <ArticleGrid articles={articles} />
-        </Suspense>
-      </div>
+      <BlogClient articles={articles} years={years} allTags={allTags} />
     </SimpleLayout>
   )
 }


### PR DESCRIPTION
## Summary
- implement blog filtering client that uses existing `ContentCard` layout
- wrap blog index page in `SimpleLayout` and provide search UI

## Testing
- `npm test` *(fails: jest not found)*
