### PR TITLE
Improve email gate logic

### DIFF
--- a/src/app/learn/courses/[slug]/page.tsx
+++ b/src/app/learn/courses/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   renderPaywalledContent,
   getDefaultPaywallText
 } from '@/lib/content-handlers'
+import { isEmailSubscribed } from '@/lib/newsletter'
 
 // Content type for this handler
 const CONTENT_TYPE = 'learn/courses'
@@ -48,9 +49,14 @@ export default async function CourseSlugPage({ params }: PageProps) {
   // Get user ID from session
   const session = await auth()
   const userId = session?.user.id
-  
+
   // Check if user has purchased access
   const userHasPurchased = await hasUserPurchased(userId, CONTENT_TYPE, slug)
+
+  let isSubscribed = false
+  if (content?.commerce?.requiresEmail) {
+    isSubscribed = await isEmailSubscribed(session?.user?.email || null)
+  }
   
   // Check if content requires payment
   if (content?.commerce?.isPaid) {
@@ -64,7 +70,7 @@ export default async function CourseSlugPage({ params }: PageProps) {
           {/* Note: We pass MdxContent to renderPaywalledContent below, 
               so no need to render it separately here unless you want a specific preview structure */}
           {/* <MdxContent /> */} 
-          {renderPaywalledContent(MdxContent, content, userHasPurchased)} 
+          {renderPaywalledContent(MdxContent, content, userHasPurchased, isSubscribed)}
           {/* Pass the entire content object to Paywall */}
           <Paywall 
             content={content}
@@ -81,7 +87,7 @@ export default async function CourseSlugPage({ params }: PageProps) {
   return (
     <>
       {/* Render potentially paywalled content (will render full if purchased or not paid) */}
-      {renderPaywalledContent(MdxContent, content, userHasPurchased)}
+      {renderPaywalledContent(MdxContent, content, userHasPurchased, isSubscribed)}
     </>
   )
 } 

--- a/src/components/ArticleContent.tsx
+++ b/src/components/ArticleContent.tsx
@@ -2,6 +2,8 @@
 
 import React from 'react'
 import Paywall from './Paywall'
+import NewsletterWrapper from './NewsletterWrapper'
+import EmailSignupGate from './EmailSignupGate'
 import { StaticImageData } from 'next/image'
 import { Content } from '@/types'
 
@@ -14,24 +16,28 @@ interface ArticleContentProps {
   paywallBody?: string
   buttonText?: string
   content: Content
+  requiresEmail?: boolean
+  isSubscribed?: boolean
 }
 
 export default function ArticleContent({ 
-  children, 
+  children,
   showFullContent,
   previewLength = 150,
   previewElements = 3,
   paywallHeader,
   paywallBody,
   buttonText,
-  content
+  content,
+  requiresEmail = false,
+  isSubscribed = false
 }: ArticleContentProps) {
   if (!content.slug) {
     console.warn('ArticleContent: content.slug is missing, rendering full content')
     return <>{children}</>
   }
 
-  if (showFullContent) {
+  if (showFullContent || (requiresEmail && isSubscribed)) {
     return <>{children}</>
   }
 
@@ -58,12 +64,19 @@ export default function ArticleContent({
       <div className="article-preview">
         {preview}
       </div>
-      <Paywall 
-        content={content}
-        paywallHeader={paywallHeader}
-        paywallBody={paywallBody}
-        buttonText={buttonText}
-      />
+      {requiresEmail ? (
+        <EmailSignupGate
+          header={paywallHeader}
+          body={paywallBody}
+        />
+      ) : (
+        <Paywall
+          content={content}
+          paywallHeader={paywallHeader}
+          paywallBody={paywallBody}
+          buttonText={buttonText}
+        />
+      )}
     </>
   )
-} 
+}

--- a/src/components/ArticleLayout.tsx
+++ b/src/components/ArticleLayout.tsx
@@ -23,12 +23,14 @@ interface ArticleLayoutProps {
     miniPaywallDescription?: string | null
   }
   serverHasPurchased?: boolean
+  hideNewsletter?: boolean
 }
 
 export function ArticleLayout({
   children,
   metadata,
   serverHasPurchased = false,
+  hideNewsletter = false,
 }: ArticleLayoutProps) {
   const router = useRouter()
   const { data: session } = useSession()
@@ -192,10 +194,12 @@ export function ArticleLayout({
                 {children}
               </Prose>
             </article>
-            <NewsletterWrapper 
-              title={'If you made it this far, you can do anything!'} 
-              body={'I publish technical content for developers who want to skill up, and break down AI, vector databases and tools for investors'} 
-            />
+            {!hideNewsletter && (
+              <NewsletterWrapper
+                title={'If you made it this far, you can do anything!'}
+                body={'I publish technical content for developers who want to skill up, and break down AI, vector databases and tools for investors'}
+              />
+            )}
             <Suspense fallback={<div>Loading...</div>}>
               <GiscusWrapper />
             </Suspense>

--- a/src/components/EmailSignupGate.tsx
+++ b/src/components/EmailSignupGate.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import NewsletterWrapper from './NewsletterWrapper'
+
+interface EmailSignupGateProps {
+  header?: string
+  body?: string
+}
+
+export default function EmailSignupGate({
+  header,
+  body
+}: EmailSignupGateProps) {
+  return (
+    <div className="my-8 p-8 bg-gradient-to-br from-zinc-100 to-zinc-200 dark:from-zinc-800 dark:to-zinc-900 rounded-xl shadow-xl border border-zinc-300 dark:border-zinc-700">
+      <NewsletterWrapper
+        title={header || 'Sign in & subscribe to read for free'}
+        body={body || 'Sign in to zackproser.com and subscribe to unlock this article.'}
+        successMessage="Thanks for subscribing! Refresh to view the full article."
+        position="paywall"
+      />
+    </div>
+  )
+}

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -1,0 +1,28 @@
+import { logger } from '@/utils/logger'
+
+/**
+ * Check if an email address is subscribed to the main EmailOctopus list.
+ * Returns true when the contact exists and has status 'SUBSCRIBED'.
+ */
+export async function isEmailSubscribed(email: string | null | undefined): Promise<boolean> {
+  if (!email) return false
+
+  try {
+    const apiKey = process.env.EMAIL_OCTOPUS_API_KEY
+    const listId = process.env.EMAIL_OCTOPUS_LIST_ID
+    if (!apiKey || !listId) return false
+
+    const endpoint = `https://emailoctopus.com/api/1.6/lists/${listId}/contacts/${encodeURIComponent(email)}?api_key=${apiKey}`
+    const res = await fetch(endpoint)
+    if (!res.ok) {
+      logger.warn(`EmailOctopus lookup failed for ${email}: ${res.status}`)
+      return false
+    }
+
+    const data = await res.json()
+    return data.status === 'SUBSCRIBED'
+  } catch (err) {
+    logger.error('Failed to check email subscription', err)
+    return false
+  }
+}

--- a/src/types/commerce.ts
+++ b/src/types/commerce.ts
@@ -3,6 +3,11 @@ import { StaticImageData } from 'next/image'
 // Commerce-related types
 export interface CommerceConfig {
   isPaid: boolean
+  /**
+   * When true, the content is free but requires the user to submit
+   * their email and be subscribed to the newsletter.
+   */
+  requiresEmail?: boolean
   price: number
   stripe_price_id?: string
   previewLength?: number


### PR DESCRIPTION
## Summary
- introduce `EmailSignupGate` component for email paywall styling
- update `ArticleContent` to show new gate
- allow `ArticleLayout` to optionally hide newsletter capture
- hide duplicate capture when email paywall active
- tweak paywall text for email-gated posts

## Testing
- `npx jest` *(fails: connect EHOSTUNREACH)*
- `npx next lint` *(fails: connect EHOSTUNREACH)*