### PR TITLE
Fix newsletter paywall duplication

### DIFF
--- a/src/components/EmailSignupGate.tsx
+++ b/src/components/EmailSignupGate.tsx
@@ -12,12 +12,13 @@ export default function EmailSignupGate({
   body
 }: EmailSignupGateProps) {
   return (
-    <div className="my-8 p-8 bg-gradient-to-br from-zinc-100 to-zinc-200 dark:from-zinc-800 dark:to-zinc-900 rounded-xl shadow-xl border border-zinc-300 dark:border-zinc-700">
+    <div className="my-8 p-10 max-w-xl mx-auto text-center bg-gradient-to-br from-zinc-100 to-zinc-200 dark:from-zinc-800 dark:to-zinc-900 rounded-xl shadow-xl border border-zinc-300 dark:border-zinc-700">
       <NewsletterWrapper
-        title={header || 'Sign in & subscribe to read for free'}
-        body={body || 'Sign in to zackproser.com and subscribe to unlock this article.'}
+        title={header || 'Unlock This Free Article'}
+        body={body || 'Join my mailing list to access the rest of this article for free.'}
         successMessage="Thanks for subscribing! Refresh to view the full article."
         position="paywall"
+        disableSticky
       />
     </div>
   )

--- a/src/components/NewsletterWrapper.tsx
+++ b/src/components/NewsletterWrapper.tsx
@@ -13,20 +13,29 @@ interface NewsletterWrapperProps {
   onSubscribe?: () => void;
   position?: string;
   className?: string;
+  /**
+   * When true, the sticky sidebar variant of the newsletter
+   * will not be rendered. Useful for paywall flows where only
+   * a single signup form should be displayed.
+   */
+  disableSticky?: boolean;
 }
 
-const NewsletterWrapper = ({ 
-  title, 
-  body, 
+const NewsletterWrapper = ({
+  title,
+  body,
   successMessage,
   onSubscribe,
   position = "content",
-  className
+  className,
+  disableSticky = false
 }: NewsletterWrapperProps) => {
   const [showSticky, setShowSticky] = useState(false);
   const [isDismissed, setIsDismissed] = useState(false);
 
   useEffect(() => {
+    if (disableSticky) return;
+
     // Check if user has previously dismissed the newsletter
     const hasUserDismissed = localStorage.getItem('newsletter-dismissed');
     if (hasUserDismissed) {
@@ -43,7 +52,7 @@ const NewsletterWrapper = ({
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [disableSticky]);
 
   const handleDismiss = () => {
     setIsDismissed(true);
@@ -65,7 +74,7 @@ const NewsletterWrapper = ({
       />
       
       {/* Sticky Newsletter */}
-      {showSticky && !isDismissed && (
+      {showSticky && !isDismissed && !disableSticky && (
         <div className="fixed bottom-4 right-4 z-50 w-96 shadow-xl animate-slide-up">
           <button
             onClick={handleDismiss}


### PR DESCRIPTION
## Summary
- suppress sticky variant via `disableSticky` prop on `NewsletterWrapper`
- enlarge `EmailSignupGate` form and clarify that content is free

## Testing
- `npx jest` *(fails: connect EHOSTUNREACH)*