### PR TITLE
Fix sitemap for admin routes

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,4 +1,12 @@
 import { redirect } from "next/navigation"
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function AnalyticsPage() {
   redirect("/admin")

--- a/src/app/admin/categories/page.tsx
+++ b/src/app/admin/categories/page.tsx
@@ -1,11 +1,19 @@
 "use client"
 
+import type { Metadata } from 'next'
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Plus, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { CategoryList } from "@/components/admin/category-list"
 import { AddCategoryForm } from "@/components/admin/add-category-form"
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function CategoriesAdminPage() {
   const [isAddingCategory, setIsAddingCategory] = useState(false)

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { Metadata } from 'next'
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { 
@@ -7,6 +8,13 @@ import {
   Wrench, 
   Tags
 } from "lucide-react"
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function AdminDashboard() {
   const adminModules = [

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,4 +1,12 @@
 import { redirect } from "next/navigation"
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function SettingsPage() {
   redirect("/admin")

--- a/src/app/admin/tools/page.tsx
+++ b/src/app/admin/tools/page.tsx
@@ -1,5 +1,6 @@
 // Remove client-side imports
 // import { useState } from "react"
+import type { Metadata } from 'next'
 import { Button } from "@/components/ui/button"
 // import { AddToolForm } from "@/components/admin/add-tool-form"
 // import { ToolsList } from "@/components/admin/tools-list"
@@ -8,6 +9,13 @@ import Link from "next/link"
 import { getAllTools } from "@/actions/tool-actions"
 import type { Tool } from "@prisma/client"
 import { ToolsAdminClient } from "@/components/admin/tools-admin-client" // Import the client component
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default async function ToolsAdminPage() {
   console.log("ADMIN TOOLS PAGE (Prod Test): Attempting to fetch tools..."); // Add log

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,4 +1,12 @@
 import { redirect } from "next/navigation"
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function UsersPage() {
   redirect("/admin")

--- a/src/lib/content-handlers.ts
+++ b/src/lib/content-handlers.ts
@@ -616,7 +616,8 @@ export async function getProductByDirectorySlug(directorySlug: string): Promise<
  * @returns Array of valid page routes (string[]).
  */
 export async function getAppPageRoutesPaths(): Promise<string[]> {
-  const excludeDirs = ['api', 'rss', '[name]', '[slug]', '_lib']; // Added _lib, adjust excludeDirs as needed
+  // Exclude internal directories from sitemap generation
+  const excludeDirs = ['api', 'rss', '[name]', '[slug]', '_lib', 'admin'];
   const validPageFiles = ['page.tsx', 'page.jsx', 'page.js', 'page.mdx', 'page.md']; // Includes MDX/MD pages
   const routes = new Set<string>();
 


### PR DESCRIPTION
## Summary
- exclude `admin` directory when scanning pages for sitemap generation
- mark all admin pages with `noindex`

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*