### PR TITLE
Add AI workshop blog post

### DIFF
--- a/src/content/blog/ai-pipelines-and-agents-mastra/page.mdx
+++ b/src/content/blog/ai-pipelines-and-agents-mastra/page.mdx
@@ -1,0 +1,36 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { createMetadata } from '@/utils/createMetadata'
+import aieWorkshop from '@/images/aie-workshop-room.webp'
+import aieFisheye from '@/images/aie-workshop-fisheye.webp'
+import zackAndNick from '@/images/zack-and-nick.webp'
+import a16z1 from '@/images/a16z-1.webp'
+
+export const metadata = createMetadata({
+  author: 'Zachary Proser',
+  date: '2025-06-03',
+  title: 'AI Pipelines and Agents in Pure TypeScript with Mastra.ai',
+  description: 'Nick Nisi and I taught 70 engineers how to build AI workflows and agents with Mastra.ai at the AI Engineer World Fair in San Francisco.',
+  image: aieWorkshop,
+  slug: '/blog/ai-pipelines-and-agents-mastra',
+})
+
+<Image src={aieWorkshop} alt="Nick Nisi presenting with me" />
+
+On June 3rd, 2025, my colleague **Nick Nisi** and I hosted a two hour workshop at the **AI Engineer World Fair** in San Francisco. The event gathered more than 70 engineers eager to build AI powered workflows in their own products.
+
+Mastra.ai provided an early preview of their workflow tooling, which allows you to orchestrate tasks using pure TypeScript. We showed how to chain those workflows together into pipelines and grant access to them through natural language driven agents.
+
+<Image src={zackAndNick} alt="Zack and Nick ready to teach" />
+
+The hands-on format let attendees build a simple pipeline from scratch, then wrap it with an agent interface. Seeing the agents successfully complete tasks through our pipelines was an awesome moment for everyone in the room.
+
+We tied the workshop back to lessons from my [earlier talk at a16z](/blog/a16z-sf-dec-2023-ai-apps-production) about taking prototypes to production. This time, it was all coded live in TypeScript with the Mastra.ai SDK.
+
+<Image src={a16z1} alt="Speaking at the a16z meetup" />
+
+<Image src={aieFisheye} alt="Workshop room fisheye view" />
+
+By the end, every seat in the workshop was filled and participants were trading ideas on how to use Mastra.ai in their own workflows. It was easily one of my favorite experiences as a speaker since that [a16z meetup](/blog/a16z-sf-dec-2023-ai-apps-production).
+
+If you want to see more events like this one, check out my <Link href="/speaking">speaking page</Link>.

--- a/src/content/blog/ai-pipelines-and-agents-mastra/page.mdx
+++ b/src/content/blog/ai-pipelines-and-agents-mastra/page.mdx
@@ -4,7 +4,6 @@ import { createMetadata } from '@/utils/createMetadata'
 import aieWorkshop from '@/images/aie-workshop-room.webp'
 import aieFisheye from '@/images/aie-workshop-fisheye.webp'
 import zackAndNick from '@/images/zack-and-nick.webp'
-import a16z1 from '@/images/a16z-1.webp'
 
 export const metadata = createMetadata({
   author: 'Zachary Proser',
@@ -21,16 +20,19 @@ On June 3rd, 2025, my colleague **Nick Nisi** and I hosted a two hour workshop a
 
 Mastra.ai provided an early preview of their workflow tooling, which allows you to orchestrate tasks using pure TypeScript. We showed how to chain those workflows together into pipelines and grant access to them through natural language driven agents.
 
+All of the materials are open source in the [mastra-agents-meme-generator](https://github.com/workos/mastra-agents-meme-generator) repo. We built the full app first, wrote up the steps in `workshop.md`, and staged each phase on a separate git branch so everyone could work at their own pace.
+
 <Image src={zackAndNick} alt="Zack and Nick ready to teach" />
 
 The hands-on format let attendees build a simple pipeline from scratch, then wrap it with an agent interface. Seeing the agents successfully complete tasks through our pipelines was an awesome moment for everyone in the room.
 
+One of us stayed on the mic while the other roamed the room answering questions and fixing issues. This tag-team approach kept everyone moving forward and made sure no one fell behind.
+
 We tied the workshop back to lessons from my [earlier talk at a16z](/blog/a16z-sf-dec-2023-ai-apps-production) about taking prototypes to production. This time, it was all coded live in TypeScript with the Mastra.ai SDK.
 
-<Image src={a16z1} alt="Speaking at the a16z meetup" />
 
 <Image src={aieFisheye} alt="Workshop room fisheye view" />
 
-By the end, every seat in the workshop was filled and participants were trading ideas on how to use Mastra.ai in their own workflows. It was easily one of my favorite experiences as a speaker since that [a16z meetup](/blog/a16z-sf-dec-2023-ai-apps-production).
+By the end, almost every attendee succeeded in getting the finished agent running. The energy in the room was incredible, and we were fired up by how many developers were brainstorming ways to use Mastra.ai in their own workflows. We can't wait to run more of these sessions in the future. If you want to follow along yourself, head to the [mastra-agents-meme-generator](https://github.com/workos/mastra-agents-meme-generator) repo.
 
 If you want to see more events like this one, check out my <Link href="/speaking">speaking page</Link>.


### PR DESCRIPTION
## Summary
- add new blog post on "AI Pipelines and Agents in Pure TypeScript with Mastra.ai"

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d1764ef8832d8f25951a14861cb2