### PR TITLE
Fix gruvbox code theme

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -257,29 +257,4 @@ h4, h5, h6 { @apply text-blue-600 dark:text-blue-400; }
   background: #555;
 }
 
-/* Style inline code within prose blocks */
-.prose :where(code):not(:where([class~="not-prose"] *)) {
-  color: #222;
-  background: #f5f5f7;
-}
-
-@media (prefers-color-scheme: dark) {
-  .prose :where(code):not(:where([class~="not-prose"] *)) {
-    color: #f5f5f7;
-    background: #222;
-  }
-}
-
-/* Code blocks: readable in both modes */
-pre[class*="language-"], code[class*="language-"] {
-  background: #f5f5f7;
-  color: #222;
-}
-
-@media (prefers-color-scheme: dark) {
-  pre[class*="language-"], code[class*="language-"] {
-    background: #222 !important;
-    color: #f5f5f7 !important;
-  }
-}
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,4 +1,4 @@
-@import './gruvbox.css';
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+@import './gruvbox.css';


### PR DESCRIPTION
## Summary
- remove inline code/prism overrides from global CSS
- load gruvbox after Tailwind styles so it wins

## Testing
- `pnpm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68420b9ba84c832da469d34ab40c4ce6