### PR TITLE
Add blog post on interview desensitization

### DIFF
--- a/src/content/blog/systematic-desensitization-coding-interviews/metadata.json
+++ b/src/content/blog/systematic-desensitization-coding-interviews/metadata.json
@@ -1,0 +1,7 @@
+{
+  "author": "Zachary Proser",
+  "date": "2025-07-30",
+  "title": "Systematic Desensitization for Coding Interviews: How I Finally Made Peace with Live Coding",
+  "description": "How a lightweight ChatGPT voice setup helped me reduce live coding anxiety and build confidence",
+  "image": "https://zackproser.b-cdn.net/images/coming-out-of-your-shell.webp"
+}

--- a/src/content/blog/systematic-desensitization-coding-interviews/page.mdx
+++ b/src/content/blog/systematic-desensitization-coding-interviews/page.mdx
@@ -1,0 +1,52 @@
+import Image from 'next/image'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+
+<Image src="https://zackproser.b-cdn.net/images/coming-out-of-your-shell.webp" alt="Stepping out of my shell to conquer live coding anxiety" width={800} height={600} />
+<figcaption>Stepping out of my shell to conquer live coding anxiety.</figcaption>
+
+For years, I carried a low-level dread of live coding interviews. Even after a decade of shipping production software, that old whiteboard-style pressure always triggered the same mental noise: *What if I freeze?* *What if I fumble the explanation?* *What if this is when I look like a fraud?*
+
+Recently, I stumbled on a practice routine that changed everything.
+
+## The Setup: Lightweight, Instant, and Transformative
+
+I pointed my Pixel 8 at my laptop running Google Colab, then fired up a ChatGPT voice session in advanced mode. No special gear. No interview partner. Suddenly I had a private, interactive mock interview rig I could use anytime with zero friction and zero stakes.
+
+## What It Let Me Do
+
+With this setup, I could:
+
+* Practice solving Python problems aloud, just like in a real interview
+* Pause the session to ask follow-up questions or clarify concepts
+* Deconstruct complexity claims ("Why is this O(n)? Can we prove it?")
+* Build fluency around verbal reasoning and tradeoffs
+* Rehearse edge cases and reflect on design decisions in real time
+
+ChatGPT became the interviewer and I became the candidate in the hot seat.
+
+## Why It Works: Exposure Without Shame
+
+The novelty isn't the tech—it's the emotional dynamic. Because this practice environment is lightweight and private, I don't feel self-conscious when I fumble or need to restart. There's no judgment and no ticking clock. It's systematic desensitization: controlled exposure that chips away at the fear of being judged while coding.
+
+## The Outcome: More Confidence, Less Panic
+
+Each session leaves me a little calmer. I'm not memorizing answers; I'm getting comfortable with ambiguity, silence, and mid-solution pivots. It's a low-cost way to reinforce fundamentals, get quick feedback, and push into tougher problems without burning out.
+
+## How You Can Try This
+
+You don't need much to replicate it:
+
+1. Open a coding environment—Google Colab, VS Code, whatever you like
+2. Launch ChatGPT in voice mode with advanced features
+3. Record your screen if you want visual feedback
+4. Start talking and solving—narrate, question, revise, and reflect
+5. Repeat, noticing how each session feels a little easier than the last
+
+You can even ask ChatGPT to role-play different interviewer styles: skeptical, friendly, curious, or silent.
+
+## Closing Thought
+
+This isn't just about acing an interview—it's about reclaiming the mental real estate that fear was occupying. If live coding anxiety has been holding you back, this gentle, high-leverage approach can help you move through it. Confidence isn't innate; it's built one conversation, one problem, one quiet win at a time.


### PR DESCRIPTION
## Summary
- document how to build confidence for live coding interviews using ChatGPT voice mode

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '.prisma/client/index-browser')*

------
https://chatgpt.com/codex/tasks/task_e_68898cc7b000832da7308d53aae5bb6c