### PR TITLE
Fix light mode colors

### DIFF
--- a/src/components/ConsultancyNav.jsx
+++ b/src/components/ConsultancyNav.jsx
@@ -115,7 +115,7 @@ export function ConsultancyNav() {
   }, [])
 
   return (
-    <header className="w-full h-16 sm:h-18 flex bg-gradient-to-r from-blue-600 to-blue-700 dark:from-gray-900 dark:to-gray-800 sticky top-0 shadow-md relative z-50">
+    <header className="w-full h-16 sm:h-18 flex bg-gradient-to-r from-blue-600 to-blue-700 dark:from-gray-800 dark:to-gray-700 sticky top-0 shadow-md relative z-50">
       <div className="container mx-auto px-4 flex items-center justify-between">
         <Link className="flex items-center justify-center shrink-0" href="/">
           <svg 

--- a/typography.ts
+++ b/typography.ts
@@ -27,8 +27,8 @@ export default function typographyStyles({ theme }: PluginUtils) {
     },
     DEFAULT: {
       css: {
-        '--tw-prose-body': theme('colors.black'),
-        '--tw-prose-headings': theme('colors.zinc.900'),
+        '--tw-prose-body': theme('colors.zinc.900'),
+        '--tw-prose-headings': theme('colors.blue.700'),
         '--tw-prose-links': theme('colors.teal.500'),
         '--tw-prose-links-hover': theme('colors.teal.600'),
         '--tw-prose-underline': theme('colors.teal.500 / 0.2'),
@@ -48,7 +48,7 @@ export default function typographyStyles({ theme }: PluginUtils) {
         '--tw-prose-td-borders': theme('colors.zinc.100'),
 
         '--tw-prose-invert-body': theme('colors.zinc.400'),
-        '--tw-prose-invert-headings': theme('colors.zinc.200'),
+        '--tw-prose-invert-headings': theme('colors.blue.300'),
         '--tw-prose-invert-links': theme('colors.teal.400'),
         '--tw-prose-invert-links-hover': theme('colors.teal.400'),
         '--tw-prose-invert-underline': theme('colors.teal.400 / 0.3'),


### PR DESCRIPTION
## Summary
- make body text dark zinc and headings blue for prose
- lighten top navigation bar in dark mode

## Testing
- `pnpm install`
- `npm test` *(fails: Cannot find module '../build/Release/canvas.node')*

------
https://chatgpt.com/codex/tasks/task_e_688ad87e65f4832d848f8edd7fd3becc