### PR TITLE
Correct inaccurate revenue claim in job list

### DIFF
--- a/src/data/applied-ai-experience.ts
+++ b/src/data/applied-ai-experience.ts
@@ -84,7 +84,7 @@ export const appliedAiExperience: ExperienceData[] = [
     location: "Remote",
     logo: "https://zackproser.b-cdn.net/images/mind-on-fire.webp" as any,
     url: "https://mindonfire.net",
-    description: "Advised startups on AI integration, growth engineering, and developer content; generated six-figure revenue.",
+    description: "Advised startups on AI integration, growth engineering, and developer content.",
     achievements: [],
     technologies: []
   }


### PR DESCRIPTION
Remove the "generated six-figure revenue" claim from the Mind on Fire job entry as it was inaccurate.

---
<a href="https://cursor.com/background-agent?bcId=bc-f794bbb8-1f89-47b6-88ba-9e10302df286">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f794bbb8-1f89-47b6-88ba-9e10302df286">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

