### PR TITLE
Add 3 AIE London recap blog posts

### DIFF
--- a/src/content/blog/aie-london-scaling-devtools-podcast/metadata.json
+++ b/src/content/blog/aie-london-scaling-devtools-podcast/metadata.json
@@ -1,0 +1,27 @@
+{
+  "title": "Live on the Scaling Devtools Podcast at AI Engineering London",
+  "author": "Zachary Proser",
+  "date": "2026-04-14",
+  "description": "I sat down with Jack Bridger on the Scaling Devtools podcast at AI Engineering London to talk about how WorkOS builds with AI coding agents, the patterns behind portable skills, and where developer tooling is heading.",
+  "image": "https://zackproser.b-cdn.net/images/aie-london-podcast-gesturing.webp",
+  "slug": "/blog/aie-london-scaling-devtools-podcast",
+  "keywords": [
+    "Scaling Devtools podcast",
+    "Jack Bridger",
+    "AI Engineering London",
+    "Claude Code",
+    "AI coding agents",
+    "WorkOS",
+    "developer tools",
+    "skills",
+    "agent adoption",
+    "voice-first development"
+  ],
+  "tags": [
+    "Speaking",
+    "AI Engineering",
+    "Claude Code",
+    "Podcasts",
+    "WorkOS"
+  ]
+}

--- a/src/content/blog/aie-london-scaling-devtools-podcast/page.mdx
+++ b/src/content/blog/aie-london-scaling-devtools-podcast/page.mdx
@@ -1,0 +1,59 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+At AI Engineering London, Jack Bridger pulled me aside for a live recording of the [Scaling Devtools](https://www.scalingdevtools.com/) podcast. We set up on the conference floor between sessions — me fresh off delivering the <Link href="/blog/aie-london-untethered-productivity">"Untethered Productivity" talk</Link> and co-running an 80-minute <Link href="/blog/aie-london-skills-at-scale">"Skills at Scale" workshop</Link> with Nick Nisi.
+
+<Image src="https://zackproser.b-cdn.net/images/aie-london-podcast-gesturing.webp" alt="Zack Proser gesturing during the live Scaling Devtools podcast recording at AI Engineering London" width={800} height={600} />
+
+The conversation ranged across how WorkOS uses AI coding agents daily, the patterns we've found that make agent adoption stick, and where I think developer tooling is heading. Here's the rundown.
+
+## How WorkOS builds with AI coding agents
+
+Jack asked about what the Applied AI team at WorkOS actually ships. Our team — me, Nick Nisi, and others — builds with Claude Code every day. I walked through the projects:
+
+- **A Slack bot that generates blog post drafts in 90 seconds.** A teammate drops a topic, the bot produces a complete draft, and the author edits from there instead of staring at a blank page.
+- **The WorkOS CLI.** It supports 15 frameworks and is built as a skill-driven agent using the Claude Agent SDK. Small skills compose into larger workflows — one skill calls another, which calls another.
+- **A RAG agentic pipeline** for internal knowledge retrieval.
+- **Internal tooling and integrations** that automate repetitive work across the team.
+
+The pattern across all of these: skills that compose. We write small, focused skills and chain them together. The unit of reuse is a markdown file that works in Claude Code, Codex, Cursor, and the Agent SDK without modification.
+
+## Patterns in agent adoption
+
+We spent a good chunk of time on the patterns that separate teams getting real value from agents versus teams that tried it once and bounced off.
+
+**Constraints beat instructions.** I told Jack that every unconstrained dimension is where the AI drifts. If you don't specify the output format, the tone, the file structure, or the verification step, the agent will improvise — and improvisation at scale produces inconsistent results. The teams that succeed constrain heavily and leave creativity only where they want it.
+
+**Evidence-based skills.** We talked about the backtick-bang pattern — skills that execute scripts inline and use the output as evidence for the next step. The agent runs a command, reads the result, and branches based on what actually happened rather than what it assumed would happen.
+
+**Verification gates.** Every skill we write at WorkOS ends with the agent proving its own work. Run the tests. Check the build. Confirm the output matches the spec. If the agent can't verify, it flags the problem instead of shipping garbage.
+
+**Portability.** The same skill markdown works across Claude Code, OpenAI's Codex, Cursor, and the Claude Agent SDK. We write once and share across tools. Jack was interested in this because it means teams aren't locked into one agent platform.
+
+<Image src="https://zackproser.b-cdn.net/images/aie-london-podcast-wide.webp" alt="Wide shot of the live Scaling Devtools podcast setup at AI Engineering London" width={800} height={600} />
+
+## Where developer tooling is heading
+
+The back half of the conversation shifted to what's next. A few threads:
+
+**Voice-first development.** I use WisprFlow for almost everything — 179 words per minute versus 90 typing. I described how I dispatch multiple agents by voice, working through tasks faster because speaking is faster than typing and I'm not waiting on a single agent to finish before starting the next one.
+
+**Remote control of agents.** I've been using Claude Code's `--remote-control` flag to direct agents from my phone while on walks. The bottleneck in my day is rarely the tools — it's my own attention. Being able to poke agents, check on their progress, and redirect them while I'm away from the desk changes the shape of a workday.
+
+**Agents that learn from their own sessions.** I described a pattern where agents analyze their own session logs and recommend what to automate next. The agent sees that you've done the same five-step deployment process twelve times and suggests writing a skill for it.
+
+**The attention bottleneck.** Jack asked about burnout — relevant given my "Untethered Productivity" talk earlier that day. The agents scale. Your nervous system doesn't. The teams that will get the most out of this era are the ones that treat human attention as the scarce resource and design their workflows around protecting it. Signal management — using MCP connectors to reduce context switching, batching notifications, being intentional about when you check in on agents — matters more than which model you're running.
+
+## Conference context
+
+This was one of three things I did at AIE London. The <Link href="/blog/aie-london-untethered-productivity">"Untethered Productivity" talk</Link> covered the developer balance angle — the intentional path versus the burnout path when working with AI agents. The <Link href="/blog/aie-london-skills-at-scale">"Skills at Scale" workshop</Link> with Nick Nisi was a hands-on 80-minute session on designing portable skills. The podcast tied all of it together in a conversational format.
+
+You can find the full details on the <Link href="/speaking/aie-london-scaling-devtools">speaking page</Link>.
+
+## When the episode drops
+
+I'll update this post with the link once Jack publishes the episode. In the meantime, subscribe to the [Scaling Devtools podcast](https://www.scalingdevtools.com/) — Jack does good work profiling the people building developer tools.

--- a/src/content/blog/aie-london-scaling-devtools-podcast/page.mdx
+++ b/src/content/blog/aie-london-scaling-devtools-podcast/page.mdx
@@ -7,53 +7,40 @@ export const metadata = createMetadata(rawMetadata);
 
 At AI Engineering London, Jack Bridger pulled me aside for a live recording of the [Scaling Devtools](https://www.scalingdevtools.com/) podcast. We set up on the conference floor between sessions — me fresh off delivering the <Link href="/blog/aie-london-untethered-productivity">"Untethered Productivity" talk</Link> and co-running an 80-minute <Link href="/blog/aie-london-skills-at-scale">"Skills at Scale" workshop</Link> with Nick Nisi.
 
-<Image src="https://zackproser.b-cdn.net/images/aie-london-podcast-gesturing.webp" alt="Zack Proser gesturing during the live Scaling Devtools podcast recording at AI Engineering London" width={800} height={600} />
+<Image src="https://zackproser.b-cdn.net/images/aie-london-podcast-gesturing.webp" alt="Zack Proser during the live Scaling Devtools podcast recording at AI Engineering London" width={800} height={600} />
 
-The conversation ranged across how WorkOS uses AI coding agents daily, the patterns we've found that make agent adoption stick, and where I think developer tooling is heading. Here's the rundown.
+## How to make talks and workshops that work
 
-## How WorkOS builds with AI coding agents
+Jack and I spent a good stretch talking about what makes technical talks and workshops land. Nick and I have done a bunch of these now — the Claude Cowork workshop in SF, internal training sessions at WorkOS, conference talks — and the patterns are getting clearer each time.
 
-Jack asked about what the Applied AI team at WorkOS actually ships. Our team — me, Nick Nisi, and others — builds with Claude Code every day. I walked through the projects:
+The biggest lesson: hands-on time wins. An 80-minute workshop where people build a real artifact teaches more than any slide deck. For the Skills at Scale workshop, we had attendees building their own skills from a starter template, iterating on them in real time, and sharing their output at the end. People walked out with something they could install and use the next day.
 
-- **A Slack bot that generates blog post drafts in 90 seconds.** A teammate drops a topic, the bot produces a complete draft, and the author edits from there instead of staring at a blank page.
-- **The WorkOS CLI.** It supports 15 frameworks and is built as a skill-driven agent using the Claude Agent SDK. Small skills compose into larger workflows — one skill calls another, which calls another.
-- **A RAG agentic pipeline** for internal knowledge retrieval.
-- **Internal tooling and integrations** that automate repetitive work across the team.
+The talk format is different. For Untethered Productivity, I optimized for moments that land — the show of hands ("who's rubber-stamped a PR because you were managing too many agents?"), the Simon Willison quote, the live demos. Talks need beats that the audience can feel. Workshops need scaffolding that the audience can build on.
 
-The pattern across all of these: skills that compose. We write small, focused skills and chain them together. The unit of reuse is a markdown file that works in Claude Code, Codex, Cursor, and the Agent SDK without modification.
+## An attendee completed the workshop autonomously with Hermes bot
 
-## Patterns in agent adoption
+One of the wildest things that happened at the conference: an attendee used Hermes bot to scan the QR code from our Skills at Scale workshop, and the bot autonomously worked through the entire workshop — cloning the repo, running setup, building the skill through all checkpoints, and reaching the goal state correctly.
 
-We spent a good chunk of time on the patterns that separate teams getting real value from agents versus teams that tried it once and bounced off.
+We designed the workshop with clear checkpoints (`./setup.sh --checkpoint 1`, `--checkpoint 2`, etc.) so people who fell behind could catch up. The bot used those same checkpoints as verification gates for its own progress. It treated our workshop materials as a spec and executed against them.
 
-**Constraints beat instructions.** I told Jack that every unconstrained dimension is where the AI drifts. If you don't specify the output format, the tone, the file structure, or the verification step, the agent will improvise — and improvisation at scale produces inconsistent results. The teams that succeed constrain heavily and leave creativity only where they want it.
+Jack loved this because it's a signal of where workshops are heading. If your materials are well-structured enough for an agent to complete autonomously, they're probably well-structured enough for humans too. The constraints and scaffolding that make a good skill also make a good workshop.
 
-**Evidence-based skills.** We talked about the backtick-bang pattern — skills that execute scripts inline and use the output as evidence for the next step. The agent runs a command, reads the result, and branches based on what actually happened rather than what it assumed would happen.
+## Biometrics in the agent loop
 
-**Verification gates.** Every skill we write at WorkOS ends with the agent proving its own work. Run the tests. Check the build. Confirm the output matches the spec. If the agent can't verify, it flags the problem instead of shipping garbage.
+We talked about the <Link href="/blog/connect-oura-ring-to-claude-desktop-with-mcp">Oura Ring MCP integration</Link> I built and how it feeds my physical state into the agentic workflow. I wear an Oura Ring that tracks sleep, heart rate variability, and recovery score. An MCP server exposes that data to Claude Code.
 
-**Portability.** The same skill markdown works across Claude Code, OpenAI's Codex, Cursor, and the Claude Agent SDK. We write once and share across tools. Jack was interested in this because it means teams aren't locked into one agent platform.
+When I'm planning my day, Claude has access to how I slept. If I got four hours and my HRV is in the basement, it pushes back: "You're running on fumes — let's do two tickets max today, push the rest to tomorrow." On days when I'm sick or underslept, the system protects me from my own ambition.
+
+This matters because your judgment about how much you can handle is worst on exactly the days when you most need to pull back. A bad sleep night degrades your ability to recognize that you slept badly. Having the agent integrate that signal and adjust the plan is a real safety net.
 
 <Image src="https://zackproser.b-cdn.net/images/aie-london-podcast-wide.webp" alt="Wide shot of the live Scaling Devtools podcast setup at AI Engineering London" width={800} height={600} />
 
-## Where developer tooling is heading
-
-The back half of the conversation shifted to what's next. A few threads:
-
-**Voice-first development.** I use WisprFlow for almost everything — 179 words per minute versus 90 typing. I described how I dispatch multiple agents by voice, working through tasks faster because speaking is faster than typing and I'm not waiting on a single agent to finish before starting the next one.
-
-**Remote control of agents.** I've been using Claude Code's `--remote-control` flag to direct agents from my phone while on walks. The bottleneck in my day is rarely the tools — it's my own attention. Being able to poke agents, check on their progress, and redirect them while I'm away from the desk changes the shape of a workday.
-
-**Agents that learn from their own sessions.** I described a pattern where agents analyze their own session logs and recommend what to automate next. The agent sees that you've done the same five-step deployment process twelve times and suggests writing a skill for it.
-
-**The attention bottleneck.** Jack asked about burnout — relevant given my "Untethered Productivity" talk earlier that day. The agents scale. Your nervous system doesn't. The teams that will get the most out of this era are the ones that treat human attention as the scarce resource and design their workflows around protecting it. Signal management — using MCP connectors to reduce context switching, batching notifications, being intentional about when you check in on agents — matters more than which model you're running.
-
 ## Conference context
 
-This was one of three things I did at AIE London. The <Link href="/blog/aie-london-untethered-productivity">"Untethered Productivity" talk</Link> covered the developer balance angle — the intentional path versus the burnout path when working with AI agents. The <Link href="/blog/aie-london-skills-at-scale">"Skills at Scale" workshop</Link> with Nick Nisi was a hands-on 80-minute session on designing portable skills. The podcast tied all of it together in a conversational format.
+This was one of three things I did at AIE London. The <Link href="/blog/aie-london-untethered-productivity">"Untethered Productivity" talk</Link> covered developer balance — the intentional path versus the burnout path when working with AI agents. The <Link href="/blog/aie-london-skills-at-scale">"Skills at Scale" workshop</Link> with Nick Nisi was a hands-on 80-minute session on designing portable skills. The podcast tied these threads together in a conversational format.
 
 You can find the full details on the <Link href="/speaking/aie-london-scaling-devtools">speaking page</Link>.
 
 ## When the episode drops
 
-I'll update this post with the link once Jack publishes the episode. In the meantime, subscribe to the [Scaling Devtools podcast](https://www.scalingdevtools.com/) — Jack does good work profiling the people building developer tools.
+I'll update this post with a link once Jack publishes the episode. Subscribe to the [Scaling Devtools podcast](https://www.scalingdevtools.com/) — Jack does good work profiling the people building developer tools.

--- a/src/content/blog/aie-london-skills-at-scale/metadata.json
+++ b/src/content/blog/aie-london-skills-at-scale/metadata.json
@@ -1,0 +1,27 @@
+{
+  "title": "Skills at Scale: Our Workshop at AI Engineering London",
+  "author": "Zachary Proser",
+  "date": "2026-04-14",
+  "description": "Nick Nisi and I ran an 80-minute hands-on workshop at AI Engineering London on building Claude Code skills that are portable, executable, and composable. We taught constraints over instructions, evidence over guesses, and measurement over vibes.",
+  "image": "https://zackproser.b-cdn.net/images/aie-london-workshop-nick-zack.webp",
+  "slug": "/blog/aie-london-skills-at-scale",
+  "keywords": [
+    "AI Engineering London",
+    "Claude Code skills",
+    "skills at scale",
+    "AI coding workshop",
+    "Claude Code workshop",
+    "WorkOS",
+    "Nick Nisi",
+    "repo roast",
+    "AI developer tools",
+    "skills portability"
+  ],
+  "tags": [
+    "Speaking",
+    "AI Engineering",
+    "Claude Code",
+    "Workshops",
+    "Skills"
+  ]
+}

--- a/src/content/blog/aie-london-skills-at-scale/page.mdx
+++ b/src/content/blog/aie-london-skills-at-scale/page.mdx
@@ -1,0 +1,95 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import GitHubRepoCard from '@/components/GitHubRepoCard';
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+Nick Nisi and I delivered an 80-minute workshop at AI Engineering London called "Skills at Scale: Leveraging Skills Across Workflows, Agents, and Teams." The room was packed. We opened with a show of hands: "Raise your hand if you've used an AI coding tool in the last week." Nearly every hand went up. "Keep it up if the first thing you did was re-explain your tech stack." Groans. That was the problem we spent the next eighty minutes solving.
+
+<Image src="https://zackproser.b-cdn.net/images/aie-london-workshop-nick-zack.webp" alt="Nick Nisi and Zack Proser presenting the Skills at Scale workshop at AI Engineering London" width={968} height={500} />
+
+We're both DX Engineers on the Applied AI team at WorkOS. The workshop repo is open source — everything you need to follow along is there:
+
+<GitHubRepoCard repo="workos/aie-europe-skills-at-scale" fallbackTitle="aie-europe-skills-at-scale" fallbackDescription="Hands-on workshop materials from AI Engineering London — build portable, executable, composable Claude Code skills." />
+
+For the full talk details and slides, check the <Link href="/speaking/aie-london-skills-at-scale">speaking page</Link>.
+
+## Every AI conversation starts from zero
+
+The core problem: every time you start a new AI conversation, you re-explain your stack, your conventions, your preferences. The output you get back is generic — "consider adding more tests." The AI has no idea what you know.
+
+Skills encode your context, constraints, and judgment into a markdown file. You explain yourself once.
+
+## From CLAUDE.md to skills
+
+Project instruction files — CLAUDE.md, AGENTS.md, .cursorrules — work well up to a point. They're tied to one repo. They can't run scripts. They grow into kitchen-sink files. They don't compose or share across projects.
+
+Skills are the next step. They're portable across projects and tools. They're executable — scripts inject real data into the skill's context at runtime. And they compose — small, focused units that call each other.
+
+## The workshop vehicle: Repo Roast
+
+We needed a vehicle that would let attendees practice the patterns, so we built "Repo Roast" — a skill that audits any git repo's health using real data. The domain was the vehicle. The patterns are what people took home.
+
+<Image src="https://zackproser.b-cdn.net/images/aie-london-workshop-workos-room.webp" alt="Packed workshop room at AI Engineering London with WorkOS branding" width={968} height={500} />
+
+## Constraints over instructions
+
+This was one of the most important things Nick and I taught. Telling an AI "be thorough" is vague and unenforceable. Instead, close off what it shouldn't do:
+
+- "Never be vague — cite files and counts"
+- "Never recommend rewrite from scratch"
+- "Only report findings backed by evidence"
+
+Every unconstrained dimension is where the AI drifts. Constraints give you predictable output.
+
+## The backtick bang pattern: evidence, not guesses
+
+Skills can run shell commands and inject the output into the AI's context using the `!` backtick syntax. This is the difference between a fancy prompt and something forensic. We showed attendees scripts that grep for TODOs and FIXMEs, find hotspot files by commit frequency, and check for oversized files in the repo.
+
+<Image src="https://zackproser.b-cdn.net/images/aie-london-workshop-evidence.webp" alt="Zack Proser teaching the backtick evidence pattern at AI Engineering London" width={968} height={500} />
+
+Without scripts, the skill guesses. With scripts, the skill has data.
+
+## Descriptions are routing rules
+
+The description field in a skill tells the AI when to use it — and when not to. We gave attendees a simple test: ask your tool "when would you use this skill?" If the answer surprises you, the description needs a rewrite.
+
+## Hands-on: building the skill in stages
+
+The workshop had three build blocks:
+
+**Block 1 (20 min): Foundation.** Write the description, add scripts, set constraints, define tone. Run "Roast this repo" and compare the output before and after adding scripts.
+
+**Block 2 (22 min): Make it smarter.** Add progressive disclosure — external file references that act as real gates. Add confidence scoring: evidence quality 1-10, severity accuracy 1-10, actionability 1-10. Drop any finding that scores below 6. Add workflow phases so the skill runs in logical stages.
+
+**Block 3 (15 min): Beyond the editor.** Run skills in Claude Code, Codex, Cursor, the Agent SDK, and CI. Skills are portable because they're markdown with scripts — they work wherever the tool can read files and run commands.
+
+## We didn't follow our own process
+
+Confession time. When Nick and I were building the workshop checkpoints, we wrote all four skill versions from our planning docs without running them once. The first time we actually ran the skill, the grep took 84 seconds and returned 60KB of noise from node_modules.
+
+The people teaching the iterative loop defaulted to "write it all up front." We told this story because it's the most honest proof that the iterative approach matters.
+
+## Measurement over vibes
+
+We showed a code review skill that was correct in its analysis but made reviews 12-20% worse than having no skill at all. The reason: it flagged intentional patterns as bugs because it lacked team convention context.
+
+Vibes told us the skill was working. Measurement told us it wasn't. If you're building skills for your team, measure the outcomes.
+
+## Skills in production: the WorkOS CLI
+
+We showed how WorkOS ships skills at production scale. The WorkOS CLI supports 15 frameworks, all driven by one skill-powered agent built on the Claude Agent SDK. Every decision — framework detection, install steps, validation — is a skill. Small skills call other skills. That's the composability pattern working at real scale.
+
+## Skills in the wild
+
+I closed the workshop with a demo of an image generation and animation skill — 30 lines of markdown that calls the Gemini and Veo APIs. It generates a static image from a prompt and then animates it. Same structure as Repo Roast: constraints, scripts, phases. The domain changed completely. The patterns didn't.
+
+## What people built
+
+At the end, attendees shared their skills using our `./share.sh` script. We pulled them up on the projector. People built skills for code review, documentation auditing, dependency management, and several things Nick and I hadn't anticipated. The best part: anyone could install a skill globally by copying the SKILL.md file to `~/.claude/skills/`.
+
+## The format works
+
+Eighty minutes of hands-on building, with a real artifact at the end, taught more about skill design than any number of slide decks could have. Nick and I will keep running workshops in this format — the patterns transfer across any domain, and seeing people build something that works in the room is the best validation there is.

--- a/src/content/blog/aie-london-untethered-productivity/metadata.json
+++ b/src/content/blog/aie-london-untethered-productivity/metadata.json
@@ -3,7 +3,7 @@
   "author": "Zachary Proser",
   "date": "2026-04-14",
   "description": "I gave a talk at AI Engineering London about staying healthy, creative, and shipping while working with AI coding agents. The core idea: the agents scale infinitely, but your nervous system doesn't. Here's the full recap.",
-  "image": "https://zackproser.b-cdn.net/images/aie-london-untethered-bottleneck.webp",
+  "image": "https://zackproser.b-cdn.net/images/aie-london-zack-podium-solo.webp",
   "slug": "/blog/aie-london-untethered-productivity",
   "keywords": [
     "AI Engineering London",

--- a/src/content/blog/aie-london-untethered-productivity/metadata.json
+++ b/src/content/blog/aie-london-untethered-productivity/metadata.json
@@ -1,0 +1,27 @@
+{
+  "title": "Untethered Productivity: My Talk at AI Engineering London",
+  "author": "Zachary Proser",
+  "date": "2026-04-14",
+  "description": "I gave a talk at AI Engineering London about staying healthy, creative, and shipping while working with AI coding agents. The core idea: the agents scale infinitely, but your nervous system doesn't. Here's the full recap.",
+  "image": "https://zackproser.b-cdn.net/images/aie-london-untethered-bottleneck.webp",
+  "slug": "/blog/aie-london-untethered-productivity",
+  "keywords": [
+    "AI Engineering London",
+    "untethered productivity",
+    "developer wellness",
+    "AI coding agents",
+    "Claude Code",
+    "developer balance",
+    "signal management",
+    "voice-first development",
+    "remote control agents",
+    "verification gates"
+  ],
+  "tags": [
+    "Speaking",
+    "AI Engineering",
+    "Claude Code",
+    "Developer Wellness",
+    "Productivity"
+  ]
+}

--- a/src/content/blog/aie-london-untethered-productivity/page.mdx
+++ b/src/content/blog/aie-london-untethered-productivity/page.mdx
@@ -9,7 +9,20 @@ I gave a talk at AI Engineering London this month called "Untethered Productivit
 
 <Image src="https://zackproser.b-cdn.net/images/aie-london-zack-podium-solo.webp" alt="Zack Proser presenting Untethered Productivity at AI Engineering London" width={800} height={450} />
 
-You can [view the interactive slide deck here](https://zackproser.b-cdn.net/talks/untethered-productivity/index.html), or check out the <Link href="/speaking/untethered-productivity">full speaking detail page</Link> for more context.
+Check out the <Link href="/speaking/untethered-productivity">speaking detail page</Link> for more context, or browse the full interactive deck right here:
+
+<div className="rounded-lg overflow-hidden border border-zinc-200 dark:border-zinc-700 my-6">
+  <iframe
+    src="https://zackproser.b-cdn.net/talks/untethered-productivity/index.html"
+    title="Untethered Productivity - Interactive Slides"
+    className="w-full border-0"
+    style={{ aspectRatio: '16/9' }}
+    allow="fullscreen"
+    loading="lazy"
+  />
+</div>
+
+<span className="text-sm text-zinc-400 dark:text-zinc-500">Use arrow keys or click to navigate. Press F for fullscreen.</span>
 
 ## The opening demo
 

--- a/src/content/blog/aie-london-untethered-productivity/page.mdx
+++ b/src/content/blog/aie-london-untethered-productivity/page.mdx
@@ -1,0 +1,93 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+I gave a talk at AI Engineering London this month called "Untethered Productivity: Staying Healthy, Creative, and Shipping in the AI Coding Era." The core thesis: the tools are nuclear, but your nervous system is relatively ancient. If you don't design your workflows around that mismatch, you'll burn out.
+
+<Image src="https://zackproser.b-cdn.net/images/aie-london-zack-podium-solo.webp" alt="Zack Proser presenting Untethered Productivity at AI Engineering London" width={800} height={450} />
+
+You can [view the interactive slide deck here](https://zackproser.b-cdn.net/talks/untethered-productivity/index.html), or check out the <Link href="/speaking/untethered-productivity">full speaking detail page</Link> for more context.
+
+## The opening demo
+
+I opened with a story about a Slack bot I built at WorkOS that generates blog drafts. It had a bug — acronyms like SCIM and SSO were getting mangled in the output. The old version of me would have context-switched out of what I was doing, cloned the repo, reproduced the issue, fixed it, deployed, tested, verified. Instead, I gave Claude Code direct access to the Slack workspace. It found the bug, fixed the code, deployed to Cloudflare, posted a test message, read its own output, and confirmed the fix — all without me touching anything.
+
+That felt incredible. It also scared me. If the agent can do all of that autonomously, what exactly is my job? That question framed the rest of the talk.
+
+## The agents scale. You don't.
+
+<Image src="https://zackproser.b-cdn.net/images/aie-london-untethered-bottleneck.webp" alt="Slide: The agents aren't the bottleneck. We are." width={968} height={500} />
+
+The central argument: agents scale infinitely. They don't get tired. They don't context-switch. Verification can be automated — lint, test, screenshot, review gates. But your attention is fixed and finite, and it degrades under load. You are the constraint, not the tooling.
+
+Simon Willison put it well on Lenny's Podcast (April 2, 2026): "I fire up 4 parallel agents and I'm wiped out by 11 AM. Finding our new limits is a personal skill we need to learn."
+
+I've felt this firsthand. The temptation is to stack more loops, run more agents, stay at 120% all day. The default path leads to burnout inside of 18 months. The intentional path — designing workflows that protect you — lets you ship more, move more, sleep more, and sustain it for years.
+
+## The enabling stack
+
+I walked through four capabilities that make this work in practice.
+
+### Signal layers
+
+I plugged Slack MCP and Linear MCP into Claude Code. Messages flow in, Claude classifies them — action needed, noise, duplicate of an existing ticket — and auto-creates Linear tickets for the real work. I never open Slack. I only see the delta.
+
+In one demo, 16 incoming Slack messages got distilled to 2 new tickets and 1 dedup. Two minor connectors reduced my perceived context-switching cost by about 90%.
+
+### Voice-first flows
+
+I've been using <Link href="/blog/walking-and-talking-with-ai">WisprFlow for voice-first development</Link> for over a year now, hitting 179 WPM compared to 90 WPM typing. For this talk I showed the dispatch advantage: speak 3 instructions to 3 agents simultaneously. Total dispatch time is about 9 seconds. A keyboard-only developer is still typing the first task.
+
+### Remote control
+
+This ties into what I wrote about in <Link href="/blog/walking-and-talking-with-ai">walking and talking with AI</Link>. I use focused mode at the desk and diffuse mode on walks. With the `--remote-control` flag, agents work on local files while I'm on the trail. I check progress on my phone and redirect them with new insights as they come. The desk is optional.
+
+I also showed <Link href="/blog/handwave">Handwave</Link>, the watchOS app I had Claude Code build me. It lets me control sessions from my wrist via the Bonjour protocol. Between voice dispatch, phone check-ins, and wrist control, I can run a full development day from a hiking trail.
+
+### The system improves itself
+
+Every Monday, a scheduled task scans all my Claude Code JSONL session logs from the previous week. It extracts patterns — tasks done more than once, repeated instructions, workflows that could be automated. The output is a list of new skills to build and inefficiencies I missed.
+
+One week it flagged that I'd reformatted blog images for CDN upload four separate times without noticing. It recommended building a skill to automate it. That kind of self-reflection loop means the system gets tighter every week without me actively optimizing it.
+
+## Verification gates
+
+Speed without safety is recklessness. I laid out three tiers of verification gates that I run before trusting agent output:
+
+1. **Lint and build** — TypeScript compilation, ESLint. The basics.
+2. **Browser use** — The agent launches the app, takes screenshots, visually confirms the output matches expectations.
+3. **Rules and review gates** — CLAUDE.md files, custom linting rules, project-specific constraints that catch subtle errors automated tests can't.
+
+These gates are what let me scale the number of parallel agents without scaling my anxiety.
+
+## Choreography of a day
+
+I showed my actual daily schedule to make this concrete:
+
+- **7-9:30 AM**: Desk time. Focused mode — architect, plan, define intent, set verification gates.
+- **9:30 AM**: Dispatch and leave. Spin up worktree agents, voice-dispatch tasks.
+- **9:45-11 AM**: Trail time. Agents are running. I check in on my phone occasionally.
+- **11 AM-Noon**: Mobile review. Check diffs, voice-dictate follow-up tasks.
+- **Noon**: Lunch. Agents keep running. I approve merges if anything's ready.
+- **1 PM**: Back at desk, refreshed. Review what shipped while I was gone.
+
+## The Oura Ring integration
+
+<Image src="https://zackproser.b-cdn.net/images/aie-london-audience-wide.webp" alt="Audience at AI Engineering London watching the Untethered Productivity talk" width={968} height={500} />
+
+I demoed the <Link href="/blog/connect-oura-ring-to-claude-desktop-with-mcp">Oura Ring MCP integration</Link> I built, which exposes my sleep and HRV data to Claude Code. When I'm planning my day, Claude has access to my physical state. If I slept poorly, it adjusts — "You're running on fumes, let's do 2 tickets max today." Developer balance requires feedback from your body as much as your backlog.
+
+## Two paths, three takeaways
+
+I closed with a choice. The default path: stack more loops, run at 120% constantly, burn out in 18 months. The intentional path: design workflows that protect your attention, ship more while moving more and sleeping more, sustain it for years.
+
+Three things to try this week:
+
+1. **Build one signal layer.** Automate your noisiest input channel — Slack, email, whatever generates the most context-switching for you.
+2. **Add verification gates before scaling agent count.** Speed without safety is how you end up debugging agent-generated chaos at 2 AM.
+3. **Reclaim one hour of margin.** Use the speed gains for a walk, not more work.
+
+The tools are nuclear. Your nervous system is ancient. Find your developer balance.


### PR DESCRIPTION
## Summary
- **Untethered Productivity talk** (`/blog/aie-london-untethered-productivity`) — recap of the solo talk on developer balance: signal layers, voice-first flows, remote control, verification gates, Oura Ring MCP, and the two paths (burnout vs. intentional)
- **Skills at Scale workshop** (`/blog/aie-london-skills-at-scale`) — recap of the 80-min workshop with Nick Nisi: constraints > instructions, evidence-based skills via backtick-bang, confidence scoring, progressive disclosure, portability across agents, and the honest confession about not following the iterative process
- **Scaling Devtools podcast** (`/blog/aie-london-scaling-devtools-podcast`) — recap of the live podcast with Jack Bridger: agent adoption patterns at WorkOS, skill portability, voice-first development, and the attention bottleneck

All three posts cross-link to each other and to their `/speaking/` detail pages. Content sourced from the actual Slidev slide decks and speaker notes. No banned words/patterns. Build passes.

## Test plan
- [ ] Visit `/blog/aie-london-untethered-productivity` — renders with images, cross-links work
- [ ] Visit `/blog/aie-london-skills-at-scale` — renders with images, GitHubRepoCard works
- [ ] Visit `/blog/aie-london-scaling-devtools-podcast` — renders with images, cross-links work
- [ ] All three link to each other correctly
- [ ] All three link to their `/speaking/` detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new MDX blog content and metadata only; no runtime logic changes beyond rendering new pages, so risk is limited to content build/render issues (MDX/Next components, external images/iframe).
> 
> **Overview**
> Adds three new blog posts under `src/content/blog/` with accompanying `metadata.json` files, covering the AI Engineering London *Untethered Productivity* talk, *Skills at Scale* workshop, and a live *Scaling Devtools* podcast recording.
> 
> Each post wires `metadata` via `createMetadata`, embeds externally hosted images (and an iframe slide deck for the talk), and cross-links to related blog and `/speaking/` pages; the workshop post also embeds a `GitHubRepoCard` for the workshop repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf1b33e8bcfb3738e50a6fa6a96466d2616ca30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->