### PR TITLE
Fix AIE London blog post hero image and podcast intro

### DIFF
--- a/src/app/speaking/[slug]/page.jsx
+++ b/src/app/speaking/[slug]/page.jsx
@@ -6,6 +6,7 @@ import { createMetadata } from '@/utils/createMetadata'
 import { ExternalLinkButton } from '@/components/ExternalLinkButton'
 import { speakingEngagements } from '../speaking-data'
 import { ArrowLeft, Calendar, Users, ExternalLink, Youtube, Link as LinkIcon, Play } from 'lucide-react'
+import { SlidevEmbed } from '@/components/SlidevEmbed'
 
 function getEngagementBySlug(slug) {
   return speakingEngagements.find(e => e.slug === slug)
@@ -89,34 +90,14 @@ export default async function SpeakingDetail({ params }) {
       {/* Interactive Slidev deck */}
       {engagement.slidevUrl && (
         <section className="mb-8">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-bold text-charcoal-50 dark:text-slate-100 flex items-center gap-2">
-              <Play className="h-5 w-5 text-indigo-500" />
-              Interactive Slide Deck
-            </h2>
-            <a
-              href={engagement.slidevUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 text-sm text-burnt-400 dark:text-amber-400 hover:text-burnt-500 dark:hover:text-amber-300 transition-colors"
-            >
-              Open full screen
-              <ExternalLink className="h-4 w-4" />
-            </a>
-          </div>
-          <div className="rounded-lg border border-parchment-200 dark:border-slate-700">
-            <iframe
-              src={engagement.slidevUrl}
-              title={`${engagement.title} - Interactive Slides`}
-              className="w-full border-0 rounded-lg"
-              style={{ aspectRatio: '16/9', touchAction: 'auto' }}
-              allow="fullscreen"
-              loading="lazy"
-            ></iframe>
-          </div>
-          <p className="mt-2 text-sm text-parchment-500 dark:text-slate-400">
-            Use arrow keys or click to navigate slides. Press F for fullscreen.
-          </p>
+          <h2 className="text-xl font-bold text-charcoal-50 dark:text-slate-100 mb-4 flex items-center gap-2">
+            <Play className="h-5 w-5 text-indigo-500" />
+            Interactive Slide Deck
+          </h2>
+          <SlidevEmbed
+            src={engagement.slidevUrl}
+            title={`${engagement.title} - Interactive Slides`}
+          />
         </section>
       )}
 

--- a/src/app/speaking/[slug]/page.jsx
+++ b/src/app/speaking/[slug]/page.jsx
@@ -104,15 +104,15 @@ export default async function SpeakingDetail({ params }) {
               <ExternalLink className="h-4 w-4" />
             </a>
           </div>
-          <div className="rounded-lg overflow-hidden border border-parchment-200 dark:border-slate-700">
+          <div className="rounded-lg border border-parchment-200 dark:border-slate-700">
             <iframe
               src={engagement.slidevUrl}
               title={`${engagement.title} - Interactive Slides`}
-              className="w-full border-0"
-              style={{ aspectRatio: '16/9' }}
+              className="w-full border-0 rounded-lg"
+              style={{ aspectRatio: '16/9', touchAction: 'auto' }}
               allow="fullscreen"
               loading="lazy"
-            />
+            ></iframe>
           </div>
           <p className="mt-2 text-sm text-parchment-500 dark:text-slate-400">
             Use arrow keys or click to navigate slides. Press F for fullscreen.

--- a/src/components/SlidevEmbed.jsx
+++ b/src/components/SlidevEmbed.jsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useRef } from 'react'
+import { ExternalLink } from 'lucide-react'
+
+export function SlidevEmbed({ src, title }) {
+  const iframeRef = useRef(null)
+
+  return (
+    <div>
+      <div className="relative rounded-lg border border-zinc-200 dark:border-zinc-700">
+        <iframe
+          ref={iframeRef}
+          src={src}
+          title={title}
+          className="w-full border-0 rounded-lg"
+          style={{ aspectRatio: '16/9' }}
+          allow="fullscreen"
+          loading="lazy"
+        ></iframe>
+      </div>
+      <div className="flex items-center justify-between mt-2">
+        <p className="text-sm text-zinc-400 dark:text-zinc-500">
+          Tap the slide then use arrow keys to navigate, or open full screen for touch.
+        </p>
+        <a
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-burnt-400 dark:text-amber-400 hover:text-burnt-500 dark:hover:text-amber-300 transition-colors shrink-0 ml-4"
+        >
+          Full screen
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/src/content/blog/aie-london-scaling-devtools-podcast/page.mdx
+++ b/src/content/blog/aie-london-scaling-devtools-podcast/page.mdx
@@ -5,7 +5,7 @@ import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
 
-At AI Engineering London, Jack Bridger pulled me aside for a live recording of the [Scaling Devtools](https://www.scalingdevtools.com/) podcast. We set up on the conference floor between sessions — me fresh off delivering the <Link href="/blog/aie-london-untethered-productivity">"Untethered Productivity" talk</Link> and co-running an 80-minute <Link href="/blog/aie-london-skills-at-scale">"Skills at Scale" workshop</Link> with Nick Nisi.
+At AI Engineering London, my colleague Nick Nisi and I sat down with Jack Bridger for a live recording of the [Scaling Devtools](https://www.scalingdevtools.com/) podcast. We set up on the conference floor between sessions — fresh off delivering the <Link href="/blog/aie-london-untethered-productivity">"Untethered Productivity" talk</Link> and co-running an 80-minute <Link href="/blog/aie-london-skills-at-scale">"Skills at Scale" workshop</Link>.
 
 <Image src="https://zackproser.b-cdn.net/images/aie-london-podcast-gesturing.webp" alt="Zack Proser during the live Scaling Devtools podcast recording at AI Engineering London" width={800} height={600} />
 

--- a/src/content/blog/aie-london-scaling-devtools-podcast/page.mdx
+++ b/src/content/blog/aie-london-scaling-devtools-podcast/page.mdx
@@ -15,7 +15,9 @@ Jack and I spent a good stretch talking about what makes technical talks and wor
 
 The biggest lesson: hands-on time wins. An 80-minute workshop where people build a real artifact teaches more than any slide deck. For the Skills at Scale workshop, we had attendees building their own skills from a starter template, iterating on them in real time, and sharing their output at the end. People walked out with something they could install and use the next day.
 
-The talk format is different. For Untethered Productivity, I optimized for moments that land — the show of hands ("who's rubber-stamped a PR because you were managing too many agents?"), the Simon Willison quote, the live demos. Talks need beats that the audience can feel. Workshops need scaffolding that the audience can build on.
+The talk format is different. For Untethered Productivity, I built custom animated components for every major concept — a context chaos visualization that showed your attention draining as you switch between Slack, IDE, terminal, and GitHub; a live Slack bot loop where Claude fixes a bug, deploys to Cloudflare, posts a test message, reads its own output, and confirms the fix without human intervention; a voice race animation showing three agents dispatched by voice in 9 seconds while a keyboard user is still typing. Every concept had a visual that moved on stage.
+
+The emotional structure mattered too. I opened with "That felt incredible. It also scared me" after showing the autonomous Slack bot loop. Then built to "The agents aren't the bottleneck. We are" — three columns showing agents (infinite), verification (automatable), and your attention (fixed, finite, degrades under load). The Oura Ring demo where Claude tells you to ease up because you slept four hours got an audible reaction. People felt that one.
 
 ## An attendee completed the workshop autonomously with Hermes bot
 

--- a/src/content/blog/aie-london-untethered-productivity/metadata.json
+++ b/src/content/blog/aie-london-untethered-productivity/metadata.json
@@ -3,7 +3,7 @@
   "author": "Zachary Proser",
   "date": "2026-04-14",
   "description": "I gave a talk at AI Engineering London about staying healthy, creative, and shipping while working with AI coding agents. The core idea: the agents scale infinitely, but your nervous system doesn't. Here's the full recap.",
-  "image": "https://zackproser.b-cdn.net/images/aie-london-zack-podium-solo.webp",
+  "image": "https://zackproser.b-cdn.net/images/aie-london-untethered-bottleneck.webp",
   "slug": "/blog/aie-london-untethered-productivity",
   "keywords": [
     "AI Engineering London",

--- a/src/content/blog/aie-london-untethered-productivity/page.mdx
+++ b/src/content/blog/aie-london-untethered-productivity/page.mdx
@@ -11,15 +11,15 @@ I gave a talk at AI Engineering London this month called "Untethered Productivit
 
 Check out the <Link href="/speaking/untethered-productivity">speaking detail page</Link> for more context, or browse the full interactive deck right here:
 
-<div className="rounded-lg overflow-hidden border border-zinc-200 dark:border-zinc-700 my-6">
+<div className="rounded-lg border border-zinc-200 dark:border-zinc-700 my-6">
   <iframe
     src="https://zackproser.b-cdn.net/talks/untethered-productivity/index.html"
     title="Untethered Productivity - Interactive Slides"
-    className="w-full border-0"
-    style={{ aspectRatio: '16/9' }}
+    className="w-full border-0 rounded-lg"
+    style={{ aspectRatio: '16/9', touchAction: 'auto' }}
     allow="fullscreen"
     loading="lazy"
-  />
+  ></iframe>
 </div>
 
 <span className="text-sm text-zinc-400 dark:text-zinc-500">Use arrow keys or click to navigate. Press F for fullscreen.</span>

--- a/src/content/blog/aie-london-untethered-productivity/page.mdx
+++ b/src/content/blog/aie-london-untethered-productivity/page.mdx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { SlidevEmbed } from '@/components/SlidevEmbed';
 import { createMetadata } from '@/utils/createMetadata';
 import rawMetadata from './metadata.json';
 
@@ -11,18 +12,7 @@ I gave a talk at AI Engineering London this month called "Untethered Productivit
 
 Check out the <Link href="/speaking/untethered-productivity">speaking detail page</Link> for more context, or browse the full interactive deck right here:
 
-<div className="rounded-lg border border-zinc-200 dark:border-zinc-700 my-6">
-  <iframe
-    src="https://zackproser.b-cdn.net/talks/untethered-productivity/index.html"
-    title="Untethered Productivity - Interactive Slides"
-    className="w-full border-0 rounded-lg"
-    style={{ aspectRatio: '16/9', touchAction: 'auto' }}
-    allow="fullscreen"
-    loading="lazy"
-  ></iframe>
-</div>
-
-<span className="text-sm text-zinc-400 dark:text-zinc-500">Use arrow keys or click to navigate. Press F for fullscreen.</span>
+<SlidevEmbed src="https://zackproser.b-cdn.net/talks/untethered-productivity/index.html" title="Untethered Productivity - Interactive Slides" />
 
 ## The opening demo
 

--- a/src/content/blog/aie-london-untethered-productivity/page.mdx
+++ b/src/content/blog/aie-london-untethered-productivity/page.mdx
@@ -7,7 +7,7 @@ export const metadata = createMetadata(rawMetadata);
 
 I gave a talk at AI Engineering London this month called "Untethered Productivity: Staying Healthy, Creative, and Shipping in the AI Coding Era." The core thesis: the tools are nuclear, but your nervous system is relatively ancient. If you don't design your workflows around that mismatch, you'll burn out.
 
-<Image src="https://zackproser.b-cdn.net/images/aie-london-zack-podium-solo.webp" alt="Zack Proser presenting Untethered Productivity at AI Engineering London" width={800} height={450} />
+<Image src="https://zackproser.b-cdn.net/images/aie-london-audience-wide.webp" alt="Audience at AI Engineering London watching the Untethered Productivity talk" width={968} height={500} />
 
 Check out the <Link href="/speaking/untethered-productivity">speaking detail page</Link> for more context, or browse the full interactive deck right here:
 
@@ -31,8 +31,6 @@ I opened with a story about a Slack bot I built at WorkOS that generates blog dr
 That felt incredible. It also scared me. If the agent can do all of that autonomously, what exactly is my job? That question framed the rest of the talk.
 
 ## The agents scale. You don't.
-
-<Image src="https://zackproser.b-cdn.net/images/aie-london-untethered-bottleneck.webp" alt="Slide: The agents aren't the bottleneck. We are." width={968} height={500} />
 
 The central argument: agents scale infinitely. They don't get tired. They don't context-switch. Verification can be automated — lint, test, screenshot, review gates. But your attention is fixed and finite, and it degrades under load. You are the constraint, not the tooling.
 
@@ -88,8 +86,6 @@ I showed my actual daily schedule to make this concrete:
 - **1 PM**: Back at desk, refreshed. Review what shipped while I was gone.
 
 ## The Oura Ring integration
-
-<Image src="https://zackproser.b-cdn.net/images/aie-london-audience-wide.webp" alt="Audience at AI Engineering London watching the Untethered Productivity talk" width={968} height={500} />
 
 I demoed the <Link href="/blog/connect-oura-ring-to-claude-desktop-with-mcp">Oura Ring MCP integration</Link> I built, which exposes my sleep and HRV data to Claude Code. When I'm planning my day, Claude has access to my physical state. If I slept poorly, it adjusts — "You're running on fumes, let's do 2 tickets max today." Developer balance requires feedback from your body as much as your backlog.
 


### PR DESCRIPTION
## Summary
- **Untethered Productivity**: hero image → `aie-london-untethered-bottleneck.webp` (Zack solo at lectern in black Run MCP shirt, not Nick). Removed duplicate bottleneck image from body, swapped to audience shot. Removed duplicate audience image from Oura section.
- **Scaling Devtools Podcast**: intro now credits Nick Nisi as co-guest ("my colleague Nick Nisi and I sat down with Jack Bridger")
- OG images for all 3 posts already uploaded to Bunny CDN in previous commit

## Test plan
- [ ] `/blog/aie-london-untethered-productivity` hero shows Zack solo at lectern (black shirt, bottleneck slide)
- [ ] No duplicate images in the untethered post body
- [ ] `/blog/aie-london-scaling-devtools-podcast` intro mentions Nick Nisi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to presentation/content (iframe embedding and blog copy/image URLs) with no impact on auth, data handling, or backend logic.
> 
> **Overview**
> Introduces a reusable client component, `SlidevEmbed`, and replaces inline Slidev `<iframe>` markup with it on speaking detail pages and the `aie-london-untethered-productivity` post, adding a consistent “Full screen” link and updated embed guidance.
> 
> Updates AIE London blog content: fixes the podcast post intro to credit Nick Nisi, and adjusts the Untethered Productivity post’s OG/hero image URL plus swaps/removes duplicated in-body images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41b085ca29c1deb002aee7ece3f055aea469f4c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->