### PR TITLE
Fix Slidev click-to-advance on tablet/touch browsers

### DIFF
--- a/src/app/speaking/speaking-data.js
+++ b/src/app/speaking/speaking-data.js
@@ -37,7 +37,7 @@ export const speakingEngagements = [
     image: 'https://zackproser.b-cdn.net/images/aie-london-untethered-bottleneck.webp',
     audience: 'AI engineers and developers',
     topics: ['AI Coding Agents', 'Developer Wellness', 'Claude Code', 'Productivity', 'Signal Management'],
-    slidevUrl: 'https://zackproser.b-cdn.net/talks/untethered-productivity/index-v2.html',
+    slidevUrl: 'https://zackproser.b-cdn.net/talks/untethered-productivity/index-v3.html',
     links: []
   },
   {

--- a/src/app/speaking/speaking-data.js
+++ b/src/app/speaking/speaking-data.js
@@ -37,7 +37,7 @@ export const speakingEngagements = [
     image: 'https://zackproser.b-cdn.net/images/aie-london-untethered-bottleneck.webp',
     audience: 'AI engineers and developers',
     topics: ['AI Coding Agents', 'Developer Wellness', 'Claude Code', 'Productivity', 'Signal Management'],
-    slidevUrl: 'https://zackproser.b-cdn.net/talks/untethered-productivity/index.html',
+    slidevUrl: 'https://zackproser.b-cdn.net/talks/untethered-productivity/index-v2.html',
     links: []
   },
   {

--- a/src/components/SlidevEmbed.jsx
+++ b/src/components/SlidevEmbed.jsx
@@ -19,15 +19,15 @@ export function SlidevEmbed({ src, title }) {
           loading="lazy"
         ></iframe>
       </div>
-      <div className="flex items-center justify-between mt-2">
+      <div className="flex items-start justify-between gap-4 mt-2">
         <p className="text-sm text-zinc-400 dark:text-zinc-500">
-          Tap the slide then use arrow keys to navigate, or open full screen for touch.
+          Click the deck, then use <kbd className="px-1.5 py-0.5 text-xs rounded border border-zinc-300 dark:border-zinc-600 bg-zinc-50 dark:bg-zinc-800">←</kbd> and <kbd className="px-1.5 py-0.5 text-xs rounded border border-zinc-300 dark:border-zinc-600 bg-zinc-50 dark:bg-zinc-800">→</kbd> to navigate. On tablet or mobile, open full screen and use the nav controls that appear at the bottom-left on tap.
         </p>
         <a
           href={src}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 text-sm font-medium text-burnt-400 dark:text-amber-400 hover:text-burnt-500 dark:hover:text-amber-300 transition-colors shrink-0 ml-4"
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-burnt-400 dark:text-amber-400 hover:text-burnt-500 dark:hover:text-amber-300 transition-colors shrink-0"
         >
           Full screen
           <ExternalLink className="h-3.5 w-3.5" />

--- a/src/content/blog/aie-london-untethered-productivity/page.mdx
+++ b/src/content/blog/aie-london-untethered-productivity/page.mdx
@@ -12,7 +12,7 @@ I gave a talk at AI Engineering London this month called "Untethered Productivit
 
 Check out the <Link href="/speaking/untethered-productivity">speaking detail page</Link> for more context, or browse the full interactive deck right here:
 
-<SlidevEmbed src="https://zackproser.b-cdn.net/talks/untethered-productivity/index.html" title="Untethered Productivity - Interactive Slides" />
+<SlidevEmbed src="https://zackproser.b-cdn.net/talks/untethered-productivity/index-v2.html" title="Untethered Productivity - Interactive Slides" />
 
 ## The opening demo
 

--- a/src/content/blog/aie-london-untethered-productivity/page.mdx
+++ b/src/content/blog/aie-london-untethered-productivity/page.mdx
@@ -12,7 +12,7 @@ I gave a talk at AI Engineering London this month called "Untethered Productivit
 
 Check out the <Link href="/speaking/untethered-productivity">speaking detail page</Link> for more context, or browse the full interactive deck right here:
 
-<SlidevEmbed src="https://zackproser.b-cdn.net/talks/untethered-productivity/index-v2.html" title="Untethered Productivity - Interactive Slides" />
+<SlidevEmbed src="https://zackproser.b-cdn.net/talks/untethered-productivity/index-v3.html" title="Untethered Productivity - Interactive Slides" />
 
 ## The opening demo
 


### PR DESCRIPTION
## Summary

Slidev's built-in click-to-advance only fires when `event.target.id === "slide-container"`. When slides have Vue components (ContextChaos, SlackBotLoop, VoiceRace, etc.) filling the area, clicks land on those child elements and do nothing. This broke touch navigation on tablet and the Tesla browser, where arrow keys aren't available.

## Fix

Added `setup/main.ts` to the Slidev deck source that registers a `pointerup` listener on `document`. When the user taps slide content (skipping interactive elements, drawing mode, and text selections), it dispatches an arrow key event that Slidev's native keyboard handler catches. Left third of the screen = prev, right two-thirds = next.

Deck rebuilt and uploaded to Bunny CDN. Since Bunny edge was caching the old `index.html` and query-string busting didn't work, the new build is served from `index-v2.html`. Portfolio references (speaking data + blog post) updated to point to the new URL.

## Test plan
- [ ] Visit `/speaking/untethered-productivity` on a tablet or Tesla browser — tapping left/right advances slides
- [ ] Visit `/blog/aie-london-untethered-productivity` — same behavior
- [ ] On desktop, arrow keys still work
- [ ] Drawing tool still works when enabled
- [ ] Clicking on links/buttons inside slides still works without advancing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content/UI tweaks: updates embedded Slidev deck URLs and adjusts helper text/layout, with no backend or data-model changes.
> 
> **Overview**
> Updates references to the “Untethered Productivity” Slidev deck to point at `index-v3.html` (in `speaking-data.js` and the related blog post MDX).
> 
> Tweaks `SlidevEmbed` helper copy and layout to better explain keyboard navigation and full-screen touch controls, and adjusts spacing/alignment for the caption/link row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458b9a98b890d0887ebc09629e100c4d90234fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->