### PR TITLE
blog: add persistent Claude Code session pattern to hermes post

### DIFF
--- a/src/content/blog/building-always-on-ai-assistant/page.mdx
+++ b/src/content/blog/building-always-on-ai-assistant/page.mdx
@@ -56,6 +56,20 @@ I read through the docs, looked at what was on the menu, and then tailored it to
 
 The key insight at every decision point was that OpenClaw had already solved most of these problems. Personality contract? Port `SOUL.md` wholesale. User profile? Port `USER.md` — months of accumulated context in one `scp`. Teller bank integration? Port the mTLS certs and access tokens. Skills? Copy the directory. Every integration I'd refined over the past few months came along for the ride, and I got the compounding value of all that iteration without rebuilding any of it.
 
+## The persistent session
+
+<Image src="https://zackproser.b-cdn.net/images/hermes-persistent-session.png" alt="Pixel art scene showing a developer workspace at night: MacBook with Claude Code terminal, smartphone with remote session view, and AWS cloud server connected by glowing data lines" width={2048} height={1024} />
+
+The entire build ran out of a single Claude Code terminal session on my MacBook that stayed open for the full day. One session, accumulating every scrap of context as it went: architecture decisions, OpenTofu state, debugging history, SSM parameter names, cloud-init iterations, the lot. Nothing got re-explained between turns. By hour six, Claude had internalized the entire deployment topology and could reason about interactions between cloud-init, Tailscale, and the hermes installer without me spelling out the dependencies.
+
+Claude Code has remote control — I can monitor and interact with the session from my phone via the Claude Code mobile interface. Between meetings, at a red light, on a walk with the dog, I'd pull up the session, see where things stood, send "approved" or "try the xlarge instead", and go back to whatever I was doing. The AI operator kept working. This is the actual workflow pattern that makes "built in a day while doing other things" honest rather than hyperbolic. The session was running `tofu apply`, polling cloud-init status via SSM, diagnosing failures, committing fixes — all autonomously. I checked in periodically to provide credentials, make judgment calls ("just upsize the instance"), and approve destructive operations. The rest was handled.
+
+By the end of the day, the session had produced six Claude Code skills that encode the operational playbook for future sessions: `/tell-hermes` (pipe context to hermes via webhook), `/hermes-status` (health dashboard), `/hermes-deploy` (safer tofu apply), `/hermes-skill-port` (port OpenClaw skills), `/hermes-debug` (triage bundle), `/hermes-memory-query` (search hermes's memories). Any future Claude Code session opened in the repo picks these up immediately — the operational knowledge persists even if I never touch the project again for months.
+
+The mental model that emerged is a three-actor system. Claude Code is the infrastructure brain: AWS, IaC, debugging, git, skill authoring. Hermes is the user-facing agent: Discord, bank APIs, content management, persistent memory. I'm the director, often mobile, steering both from my phone. Each actor operates in its domain without needing to understand the internals of the others. Claude Code has never spoken to a Discord user. Hermes has never run `tofu plan`. I don't have to hold the full cloud-init template in my head. The separation of concerns is what makes the pattern reproducible — swap any actor for something better and the others don't notice.
+
+<Image src="https://zackproser.b-cdn.net/images/hermes-operator-triangle-v2.png" alt="Pixel art operator triangle: Claude Code MacBook, Hermes Discord window, and Zack with phone as director, connected by labeled data beams showing IaC, webhooks, and review flows" width={2048} height={1024} />
+
 ## The architecture
 
 <Image src="https://zackproser.b-cdn.net/images/hermes-architecture-v2.webp" alt="Hermes Agent architecture diagram showing AWS EC2, EBS data volume, Tailscale mesh, Discord, and external services" width={1200} height={800} />

--- a/src/content/blog/building-always-on-ai-assistant/page.mdx
+++ b/src/content/blog/building-always-on-ai-assistant/page.mdx
@@ -7,13 +7,11 @@ export const metadata = createMetadata(rawMetadata);
 
 # I Built an Always-On Hermes Agent on AWS in a Day, Mostly Async
 
-Since early February I've run a personal AI assistant — OpenClaw — on a System76 Meerkat sitting in my home office. Cheap hardware, fast NVMe, [Tailscale](https://tailscale.com/) overlay so I can reach it from anywhere. Most of the time it works great.
+Since early February I've run a personal AI assistant on a small Linux box in my home office — [Tailscale](https://tailscale.com/) overlay so I can reach it from anywhere. Most of the time it works great.
 
-<Image src="https://zackproser.b-cdn.net/images/hermes-pixel-meerkat.webp" alt="Pixel art of a System76 Meerkat NUC on a desk with a glowing terminal, cozy home office vibes" width={1200} height={800} />
+<Image src="https://zackproser.b-cdn.net/images/hermes-pixel-meerkat.webp" alt="Pixel art of a small Linux server on a desk with a glowing terminal, cozy home office vibes" width={1200} height={800} />
 
-Twice in the past few months it didn't, and both times I was out of the country. I'd open my laptop in a hotel, reach for the assistant I'd quietly started depending on, and get silence. First time was a power blip. Second time I'd recently installed a [HackRF One](https://greatscottgadgets.com/hackrf/one/) (software-defined radio for RF research) in the same room and my best guess is a transient power fault that took the NUC down with it.
-
-The cognitive infrastructure I'd come to rely on was tied to a single box I couldn't power-cycle from 5,000 miles away. Time to fix that.
+Twice in the past few months it went offline while I was out of the country. I haven't fully debugged why — could be power, could be a hardware fault, doesn't matter. What matters is that those outages proved two things: first, that I'd come to genuinely depend on having an always-on AI assistant. And second, that I needed it running on infrastructure that could survive a destroyed instance, a power failure, or me being 5,000 miles away with no physical access. Time to fix that.
 
 ## The constraints
 


### PR DESCRIPTION
## Summary
- New section 'The persistent session' placed early in the post (after agent selection, before architecture)
- Covers: persistent Claude Code terminal as the infrastructure brain, remote phone monitoring, three-actor model, the 6 built skills
- Adds operator triangle pixel art (hermes-operator-triangle-v2.png) at the end of the new section
- Two new CDN images: hermes-persistent-session.png, hermes-operator-triangle-v2.png

## Test plan
- [ ] Verify Vercel preview renders both new images
- [ ] Check section flows naturally between existing sections
- [ ] No banned voice patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only MDX edits (text and image references) with no impact on application logic; main risk is broken image links or rendering issues in the post.
> 
> **Overview**
> Updates the `building-always-on-ai-assistant` post’s intro to generalize the hardware description and rewrite the outage motivation paragraph, including a small tweak to the hero image `alt` text.
> 
> Adds a new **“The persistent session”** section (with two new CDN-hosted images) describing the day-long Claude Code workflow, remote phone supervision, the three-actor model, and the set of operational Claude Code skills used to run/deploy Hermes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db202e3d8453ce6a2eb3bcd4408200729bac8fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->