### PR TITLE
affiliate: Add CTAs to top 5 high-traffic pages (2,258 visitors/mo)

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/content/blog/claude-external-brain-adhd-autistic/metadata.json
+++ b/src/content/blog/claude-external-brain-adhd-autistic/metadata.json
@@ -3,5 +3,6 @@
   "date": "2025-10-27",
   "title": "Claude as My External Brain: Autistic, ADHD, and Finally Supported",
   "description": "How I use Claude as an external brain and assistant—combining voice, agents, and a hardened CI/CD lane—to support an autistic mind with severe ADHD.",
-  "image": "https://zackproser.b-cdn.net/images/claude.webp"
+  "image": "https://zackproser.b-cdn.net/images/claude.webp",
+  "hiddenFromIndex": true
 }

--- a/src/content/blog/claude-external-brain-adhd-autistic/metadata.json
+++ b/src/content/blog/claude-external-brain-adhd-autistic/metadata.json
@@ -3,6 +3,5 @@
   "date": "2025-10-27",
   "title": "Claude as My External Brain: Autistic, ADHD, and Finally Supported",
   "description": "How I use Claude as an external brain and assistant—combining voice, agents, and a hardened CI/CD lane—to support an autistic mind with severe ADHD.",
-  "image": "https://zackproser.b-cdn.net/images/claude.webp",
-  "hiddenFromIndex": true
+  "image": "https://zackproser.b-cdn.net/images/claude.webp"
 }

--- a/src/content/blog/claude-external-brain-adhd-autistic/page.mdx
+++ b/src/content/blog/claude-external-brain-adhd-autistic/page.mdx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
 import Link from 'next/link'
 import { createMetadata } from '@/utils/createMetadata'
 import rawMetadata from './metadata.json'
@@ -20,6 +21,8 @@ export const metadata = createMetadata(rawMetadata)
 </iframe>
 
 ## Table of contents
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## The thesis: Speed requires safety
 
@@ -50,6 +53,8 @@ I program Claude to push back on perfectionism and analysis paralysis. It nudges
 ### Unlimited patience
 When anxious loops spike, I can ask the same question at 3am without burdening my people. The dialogue remains steady, kind, and structured—exactly the support my brain needs.
 
+<InlineAffiliateCTA product=granola />
+
 ## The daily loop
 
 <Image src="https://zackproser.b-cdn.net/images/walking-talking-ai.webp" alt="Walking and talking with AI in the woods" width={800} height={600} />
@@ -78,6 +83,8 @@ Localized CSS/layout changes and feature branches reduce blast radius and make i
 <Image src="https://zackproser.b-cdn.net/images/cursor-agents-hero.webp" alt="Cursor Agents orchestrating bounded coding tasks" width={1200} height={800} />
 <figcaption>Agents thrive on narrow, testable changes with crisp acceptance criteria.</figcaption>
 
+<InlineAffiliateCTA product=wisprflow />
+
 ## Concrete workflows I run with Claude
 
 ### Voice to structure
@@ -101,6 +108,8 @@ Every change passes pre‑commit secret scanning, CI secret scanning, dependency
 ## Example acceptance criteria I reuse
 
 My acceptance language is deterministic: the build passes on the target Node version and key unit tests are green; secret scanners report zero findings and dependency scanning shows no high/critical vulnerabilities; a preview demonstrates the before→after behavior with CSS confined to the intended surface; and the PR description lists changed files, testing notes, and a short risk assessment.
+
+<InlineAffiliateCTA product=granola />
 
 ## Human factors: why this works for my brain
 

--- a/src/content/blog/claude-external-brain-adhd-autistic/page.mdx
+++ b/src/content/blog/claude-external-brain-adhd-autistic/page.mdx
@@ -5,6 +5,7 @@ import { createMetadata } from '@/utils/createMetadata'
 import rawMetadata from './metadata.json'
 
 export const metadata = createMetadata(rawMetadata)
+export const campaign = "claude-external-brain-adhd-autistic"
 
 <Image src={rawMetadata.image} alt="Claude Desktop interface" width={1200} height={630} />
 <figcaption>Claude as external brain: a compassionate, programmable executive function.</figcaption>
@@ -22,7 +23,7 @@ export const metadata = createMetadata(rawMetadata)
 
 ## Table of contents
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## The thesis: Speed requires safety
 
@@ -53,7 +54,7 @@ I program Claude to push back on perfectionism and analysis paralysis. It nudges
 ### Unlimited patience
 When anxious loops spike, I can ask the same question at 3am without burdening my people. The dialogue remains steady, kind, and structured—exactly the support my brain needs.
 
-<InlineAffiliateCTA product=granola />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## The daily loop
 
@@ -83,7 +84,7 @@ Localized CSS/layout changes and feature branches reduce blast radius and make i
 <Image src="https://zackproser.b-cdn.net/images/cursor-agents-hero.webp" alt="Cursor Agents orchestrating bounded coding tasks" width={1200} height={800} />
 <figcaption>Agents thrive on narrow, testable changes with crisp acceptance criteria.</figcaption>
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Concrete workflows I run with Claude
 
@@ -109,7 +110,7 @@ Every change passes pre‑commit secret scanning, CI secret scanning, dependency
 
 My acceptance language is deterministic: the build passes on the target Node version and key unit tests are green; secret scanners report zero findings and dependency scanning shows no high/critical vulnerabilities; a preview demonstrates the before→after behavior with CSS confined to the intended surface; and the PR description lists changed files, testing notes, and a short risk assessment.
 
-<InlineAffiliateCTA product=granola />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## Human factors: why this works for my brain
 

--- a/src/content/blog/claude-skills-internal-training/metadata.json
+++ b/src/content/blog/claude-skills-internal-training/metadata.json
@@ -4,5 +4,14 @@
   "title": "Claude Skills as Self-Documenting Runbooks/Processes You Share With Your Team",
   "description": "This may indeed be a bigger deal than MCP",
   "image": "https://zackproser.b-cdn.net/images/claude-skills.webp",
-  "tags": ["claude", "skills", "workflows", "mcp", "ai", "images", "google"]
+  "tags": [
+    "claude",
+    "skills",
+    "workflows",
+    "mcp",
+    "ai",
+    "images",
+    "google"
+  ],
+  "hiddenFromIndex": true
 }

--- a/src/content/blog/claude-skills-internal-training/metadata.json
+++ b/src/content/blog/claude-skills-internal-training/metadata.json
@@ -12,6 +12,5 @@
     "ai",
     "images",
     "google"
-  ],
-  "hiddenFromIndex": true
+  ]
 }

--- a/src/content/blog/claude-skills-internal-training/page.mdx
+++ b/src/content/blog/claude-skills-internal-training/page.mdx
@@ -1,6 +1,7 @@
 import rawMetadata from './metadata.json'
 import { createMetadata } from '@/utils/createMetadata'
 import Image from 'next/image'
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
 import GitHubRepoCard from '@/components/GitHubRepoCard'
 
 export const metadata = createMetadata(rawMetadata)
@@ -49,6 +50,8 @@ Most teams are quietly rediscovering the same AI workflows in parallel. A few pe
 Even when we try to document these flows, the “how” is scattered across docs, screenshots, and CLI snippets that drift away from the real implementation. Prompts evolve. API sequences change. Small but critical steps like image encoding, content types, or retry logic are easy to miss and hard to standardize.
 
 Claude skills fix this by making the runbook executable and version‑controlled. The same artifact that a human can read (SKILL.md) is the one Claude executes—reviewable in PRs, testable in CI, and distributable to the whole team. That stops knowledge from leaking, and it turns fragile, ad‑hoc workflows into shareable, repeatable capabilities.
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## The Use Case: From Static to Animated
 
@@ -117,6 +120,8 @@ Lock camera; keep motion subtle; preserve original palette and style; no new obj
 Target duration: ~3–4 seconds.
 ```
 
+<InlineAffiliateCTA product=wisprflow />
+
 ## Following the 12 Factor App Pattern
 
 One of the reasons this approach works so well for team distribution is that it follows the twelve-factor app methodology, particularly around configuration management. Rather than hardcoding API keys or embedding credentials in the skill itself, the workflow expects each user to export their own `GOOGLE_API_KEY` in their shell environment.
@@ -149,6 +154,8 @@ Then each person edits their `.env` file to add their Google API key, and restar
   width={1200}
   height={800}
 />
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## Skill Directory Structure
 

--- a/src/content/blog/claude-skills-internal-training/page.mdx
+++ b/src/content/blog/claude-skills-internal-training/page.mdx
@@ -5,6 +5,7 @@ import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
 import GitHubRepoCard from '@/components/GitHubRepoCard'
 
 export const metadata = createMetadata(rawMetadata)
+export const campaign = "claude-skills-internal-training"
 
 I recently had the opportunity to run an internal training at WorkOS on Claude skills, and I wanted to share what I learned about how they can transform the way teams codify and distribute custom AI workflows.
 
@@ -51,7 +52,7 @@ Even when we try to document these flows, the “how” is scattered across docs
 
 Claude skills fix this by making the runbook executable and version‑controlled. The same artifact that a human can read (SKILL.md) is the one Claude executes—reviewable in PRs, testable in CI, and distributable to the whole team. That stops knowledge from leaking, and it turns fragile, ad‑hoc workflows into shareable, repeatable capabilities.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## The Use Case: From Static to Animated
 
@@ -120,7 +121,7 @@ Lock camera; keep motion subtle; preserve original palette and style; no new obj
 Target duration: ~3–4 seconds.
 ```
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Following the 12 Factor App Pattern
 
@@ -155,7 +156,7 @@ Then each person edits their `.env` file to add their Google API key, and restar
   height={800}
 />
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Skill Directory Structure
 

--- a/src/content/blog/cursor-agents-review/metadata.json
+++ b/src/content/blog/cursor-agents-review/metadata.json
@@ -3,5 +3,6 @@
   "date": "2025-07-22",
   "title": "Cursor Agents Hands-on Review",
   "description": "I got hands-on with Cursor's new Agents feature. Here's what I thought...",
-  "image": "https://zackproser.b-cdn.net/images/cursor-agents-hero.webp"
-} 
+  "image": "https://zackproser.b-cdn.net/images/cursor-agents-hero.webp",
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/cursor-agents-review/metadata.json
+++ b/src/content/blog/cursor-agents-review/metadata.json
@@ -3,6 +3,5 @@
   "date": "2025-07-22",
   "title": "Cursor Agents Hands-on Review",
   "description": "I got hands-on with Cursor's new Agents feature. Here's what I thought...",
-  "image": "https://zackproser.b-cdn.net/images/cursor-agents-hero.webp",
-  "hiddenFromIndex": true
+  "image": "https://zackproser.b-cdn.net/images/cursor-agents-hero.webp"
 }

--- a/src/content/blog/cursor-agents-review/page.mdx
+++ b/src/content/blog/cursor-agents-review/page.mdx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/Button'
 import Image from 'next/image'
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
 import Link from 'next/link'
 import ConsultingCTA from '@/components/ConsultingCTA'
 import { createMetadata } from '@/utils/createMetadata'
@@ -27,6 +28,8 @@ The setup process mirrors <Link href="/blog/openai-codex-review">Codex</Link> al
 Where Cursor diverges from OpenAI's approach is in execution quality. While both platforms offer identical workflows—GitHub integration, containerized workers, parallel task execution—Cursor feels more polished out of the box.
 
 This makes sense: Cursor had the advantage of watching OpenAI's viral (and chaotic) <Link href="/blog/openai-codex-review">Codex</Link> launch, learning from the infrastructure mistakes and user experience pain points before shipping their own version.
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## Things I like about Cursor Agents
 
@@ -78,6 +81,8 @@ The code quality is consistently good, with fewer hallucinations and better unde
 
 If you're already using Cursor as your daily editor, Agents feels like a natural extension of the existing workflow. The integration is seamless, and you get the benefits of Cursor's existing codebase understanding and context.
 
+<InlineAffiliateCTA product=wisprflow />
+
 ## Things I'm waiting on to improve
 
 ### Documentation and best practices are sparse
@@ -95,6 +100,8 @@ While the follow-up chat system works well, there's still room for improvement i
 While more reliable than <Link href="/blog/openai-codex-review">Codex's</Link> branch handling, Cursor Agents still has room for improvement in multi-turn development workflows. I did encounter an error when attempting to have Cursor Agents create a new branch for my change when the branch didn't already exist. Updating existing branches and coordinating complex refactors across multiple files remains clunky.
 
 That said, it was smoother than my initial <Link href="/blog/openai-codex-review">Codex</Link> experience, and freer than my initial <Link href="/blog/google-jules-review">Jules</Link> experience, given that Jules is very stingy about the daily tasks you can run.
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## Cursor Agents vs. OpenAI Codex
 

--- a/src/content/blog/cursor-agents-review/page.mdx
+++ b/src/content/blog/cursor-agents-review/page.mdx
@@ -7,6 +7,7 @@ import { createMetadata } from '@/utils/createMetadata'
 import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
+export const campaign = "cursor-agents-review";
 
 <Image src="https://zackproser.b-cdn.net/images/cursor-agents-hero.webp" alt="I got hands-on with Cursor's new Agents feature. Here's what I thought..." width={1200} height={630} />
 
@@ -29,7 +30,7 @@ Where Cursor diverges from OpenAI's approach is in execution quality. While both
 
 This makes sense: Cursor had the advantage of watching OpenAI's viral (and chaotic) <Link href="/blog/openai-codex-review">Codex</Link> launch, learning from the infrastructure mistakes and user experience pain points before shipping their own version.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Things I like about Cursor Agents
 
@@ -81,7 +82,7 @@ The code quality is consistently good, with fewer hallucinations and better unde
 
 If you're already using Cursor as your daily editor, Agents feels like a natural extension of the existing workflow. The integration is seamless, and you get the benefits of Cursor's existing codebase understanding and context.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Things I'm waiting on to improve
 
@@ -101,7 +102,7 @@ While more reliable than <Link href="/blog/openai-codex-review">Codex's</Link> b
 
 That said, it was smoother than my initial <Link href="/blog/openai-codex-review">Codex</Link> experience, and freer than my initial <Link href="/blog/google-jules-review">Jules</Link> experience, given that Jules is very stingy about the daily tasks you can run.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Cursor Agents vs. OpenAI Codex
 

--- a/src/content/blog/openai-codex-review-2026/page.mdx
+++ b/src/content/blog/openai-codex-review-2026/page.mdx
@@ -6,6 +6,7 @@ import { createMetadata } from '@/utils/createMetadata'
 import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
+export const campaign = "openai-codex-review-2026";
 
 <Image src="https://zackproser.b-cdn.net/images/codex-hero.webp" alt="Codex in 2026 - significantly improved after nearly a year of daily use"  width={968} height={545}/>
 
@@ -17,7 +18,7 @@ It's been nearly a year since I wrote my <Link href="/blog/openai-codex-review">
 
 The landscape has changed dramatically. Here's what actually improved and what still needs work.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## The real test: Daily production use
 
@@ -54,7 +55,7 @@ For my portfolio site, I can now ask Codex to:
 
 It understands the existing Next.js structure, follows my component patterns, respects the Tailwind classes I'm already using, and even maintains my preference for named exports over default exports.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## What's actually improved
 
@@ -101,7 +102,7 @@ This has been genuinely useful. For a recent API endpoint, the variations includ
 
 It feels like having multiple senior developers propose solutions, then picking the best approach for your specific context.
 
-<InlineAffiliateCTA product=granola />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## What still frustrates me
 
@@ -123,7 +124,7 @@ This was a major pain point in my original review, but OpenAI has largely fixed 
 
 This is a huge improvement. Installing dependencies, running integration tests, fetching external APIs during development — all possible now depending on your security preferences.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## The meta-improvement: Codex training on Codex usage
 

--- a/src/content/blog/openai-codex-review-2026/page.mdx
+++ b/src/content/blog/openai-codex-review-2026/page.mdx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
 import Link from 'next/link'
 import VoiceAIDemoCard from '@/components/VoiceAIDemoCard'
 import { createMetadata } from '@/utils/createMetadata'
@@ -15,6 +16,8 @@ export const metadata = createMetadata(rawMetadata);
 It's been nearly a year since I wrote my <Link href="/blog/openai-codex-review">original Codex review</Link> after getting access to the research preview. Since then, I've been using Codex daily across multiple contexts: my personal projects, WorkOS infrastructure, and various side builds. 
 
 The landscape has changed dramatically. Here's what actually improved and what still needs work.
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## The real test: Daily production use
 
@@ -50,6 +53,8 @@ For my portfolio site, I can now ask Codex to:
 - "Implement tag-based filtering for the blog index page"
 
 It understands the existing Next.js structure, follows my component patterns, respects the Tailwind classes I'm already using, and even maintains my preference for named exports over default exports.
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## What's actually improved
 
@@ -96,6 +101,8 @@ This has been genuinely useful. For a recent API endpoint, the variations includ
 
 It feels like having multiple senior developers propose solutions, then picking the best approach for your specific context.
 
+<InlineAffiliateCTA product=granola />
+
 ## What still frustrates me
 
 ### Model selection opacity
@@ -115,6 +122,8 @@ This was a major pain point in my original review, but OpenAI has largely fixed 
 - **No access** — fully sandboxed like before
 
 This is a huge improvement. Installing dependencies, running integration tests, fetching external APIs during development — all possible now depending on your security preferences.
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## The meta-improvement: Codex training on Codex usage
 

--- a/src/content/blog/openai-codex-review/metadata.json
+++ b/src/content/blog/openai-codex-review/metadata.json
@@ -3,6 +3,5 @@
   "date": "2025-05-18",
   "title": "OpenAI Codex Hands-on Review",
   "description": "On May 16th, 2025, I gained access to OpenAI's Codex research preview. Here is what I think",
-  "image": "https://zackproser.b-cdn.net/images/codex-hero.webp",
-  "hiddenFromIndex": true
+  "image": "https://zackproser.b-cdn.net/images/codex-hero.webp"
 }

--- a/src/content/blog/openai-codex-review/metadata.json
+++ b/src/content/blog/openai-codex-review/metadata.json
@@ -3,5 +3,6 @@
   "date": "2025-05-18",
   "title": "OpenAI Codex Hands-on Review",
   "description": "On May 16th, 2025, I gained access to OpenAI's Codex research preview. Here is what I think",
-  "image": "https://zackproser.b-cdn.net/images/codex-hero.webp"
+  "image": "https://zackproser.b-cdn.net/images/codex-hero.webp",
+  "hiddenFromIndex": true
 }

--- a/src/content/blog/openai-codex-review/page.mdx
+++ b/src/content/blog/openai-codex-review/page.mdx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/Button'
 import Image from 'next/image'
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
 import Link from 'next/link'
 import ConsultingCTA from '@/components/ConsultingCTA'
 import UpdatedReviewBanner from '@/components/UpdatedReviewBanner'
@@ -21,6 +22,8 @@ the next few days using it to ship improvements and bug fixes to my site and som
 
 Here are my current thoughts...
 
+<InlineAffiliateCTA product=wisprflow />
+
 ## Codex: How it works 
 
 Codex is currently a chat-first experience. You gain access by being invited or by paying for the Pro ($200/per month) subscription.
@@ -34,6 +37,8 @@ Codex then clones your repositories into its own sandboxes so it can run command
 If you maintain dozens of public and private repositories, this setup is fantastic because you can jump between projects and queue up tasks for each of them without leaving the interface. 
 
 If you only keep a single repo or two, the overhead may feel heavier than just asking an LLM for help or working in an AI-powered editor like Cursor.
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## Things I like about Codex 
 
@@ -101,6 +106,8 @@ in order to make changes.
 
 <Image src="https://zackproser.b-cdn.net/images/codex-launch-new-environment.webp" alt="Launching a new environment via Codex"  width={800} height={600}/>
 
+<InlineAffiliateCTA product=granola />
+
 ## Things I'm waiting on to improve 
 
 ### Poor error handling
@@ -140,6 +147,8 @@ Codex can't reach the internet right now, but it does have your repo freshly clo
 
 This means it can't `pnpm add @tar-fs@latest` even if you ask it to. So, for now, I'll still be pulling down these branches and fixing them locally or 
 commenting `@dependabot rebase` on PRs that support it.
+
+<InlineAffiliateCTA product=wisprflow />
 
 ## Did it unlock insane productivity gains for me? 
 

--- a/src/content/blog/openai-codex-review/page.mdx
+++ b/src/content/blog/openai-codex-review/page.mdx
@@ -8,6 +8,7 @@ import { createMetadata } from '@/utils/createMetadata'
 import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
+export const campaign = "openai-codex-review";
 
 <UpdatedReviewBanner href="/blog/openai-codex-review-2026" text="Read the 2026 Codex review — updated from daily use" />
 
@@ -22,7 +23,7 @@ the next few days using it to ship improvements and bug fixes to my site and som
 
 Here are my current thoughts...
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Codex: How it works 
 
@@ -38,7 +39,7 @@ If you maintain dozens of public and private repositories, this setup is fantast
 
 If you only keep a single repo or two, the overhead may feel heavier than just asking an LLM for help or working in an AI-powered editor like Cursor.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Things I like about Codex 
 
@@ -106,7 +107,7 @@ in order to make changes.
 
 <Image src="https://zackproser.b-cdn.net/images/codex-launch-new-environment.webp" alt="Launching a new environment via Codex"  width={800} height={600}/>
 
-<InlineAffiliateCTA product=granola />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## Things I'm waiting on to improve 
 
@@ -148,7 +149,7 @@ Codex can't reach the internet right now, but it does have your repo freshly clo
 This means it can't `pnpm add @tar-fs@latest` even if you ask it to. So, for now, I'll still be pulling down these branches and fixing them locally or 
 commenting `@dependabot rebase` on PRs that support it.
 
-<InlineAffiliateCTA product=wisprflow />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Did it unlock insane productivity gains for me? 
 


### PR DESCRIPTION
Adds WisprFlow and Granola InlineAffiliateCTA components to the 5 highest-traffic pages that currently have zero monetization:

- openai-codex-review (638 visitors/mo)
- claude-external-brain-adhd-autistic (562 visitors/mo)
- openai-codex-review-2026 (459 visitors/mo)
- claude-skills-internal-training (458 visitors/mo)
- cursor-agents-review (141 visitors/mo)

Total: 2,258 monthly visitors now seeing affiliate CTAs. At 0.5% conversion = ~11 new signups/month.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only MDX edits plus a TypeScript reference update; main risk is minor rendering/layout or tracking-link issues on affected pages.
> 
> **Overview**
> Adds inline monetization blocks to five high-traffic blog posts by importing `InlineAffiliateCTA`, defining a per-page `campaign` slug, and inserting WisprFlow/Granola CTAs at key points in each article.
> 
> Also updates TypeScript env typing to include Next.js route types (`.next/types/routes.d.ts`) and normalizes a few blog `metadata.json` files (formatting/newline fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8dd06d11f63a00ae6dd6e41269586cff3052bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->