### PR TITLE
fix: reorder title to 'One Phone, Two Agents'

### DIFF
--- a/src/content/blog/two-agents-one-phone/metadata.json
+++ b/src/content/blog/two-agents-one-phone/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Two Agents, One Phone",
+  "title": "One Phone, Two Agents",
   "author": "Zachary Proser",
   "date": "2026-04-16",
   "description": "I run two AI agents — Claude Code for infrastructure, Hermes for content — both controlled from my phone. Here's the split-brain architecture and why separation of concerns matters for AI agents too.",

--- a/src/content/blog/two-agents-one-phone/page.mdx
+++ b/src/content/blog/two-agents-one-phone/page.mdx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 
 export const metadata = createMetadata(rawMetadata)
 
-# Two Agents, One Phone
+# One Phone, Two Agents
 
 I run two AI agents. One handles infrastructure. The other handles content. I control both from my phone.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Text-only content change to a blog post title; no code paths, data handling, or security-sensitive behavior is affected.
> 
> **Overview**
> Updates the `two-agents-one-phone` blog post title to **"One Phone, Two Agents"** in both `metadata.json` (used for generated metadata) and the MDX page heading, keeping the displayed title consistent across the site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc1f356c07a8ca155d96a1f02276353547eb4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->