### PR TITLE
homepage: editorial glow-up

### DIFF
--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -1,34 +1,411 @@
 'use client'
 
-import Link from "next/link"
-import { useState } from "react"
-import { track } from "@vercel/analytics"
-import { ContentCard } from "@/components/ContentCard"
-import ConsultationForm from "@/components/ConsultationForm"
-import YoutubeEmbed from "@/components/YoutubeEmbed"
-import AuthorityHero from "@/components/AuthorityHero"
-import EngagementGrid from "@/components/EngagementGrid"
+import Link from 'next/link'
+import { useState, FormEvent } from 'react'
+import type { Route } from 'next'
+import { track } from '@vercel/analytics'
+import { sendGTMEvent } from '@next/third-parties/google'
+import { ContentCard } from '@/components/ContentCard'
+import ConsultationForm from '@/components/ConsultationForm'
+import type { Content } from '@/types/content'
 
-// Import demo hero images
-const embeddingsDemoHero = 'https://zackproser.b-cdn.net/images/embeddings-demo-hero.webp'
-const tokenizationDemoHero = 'https://zackproser.b-cdn.net/images/tokenization-demo-hero.webp'
-const chatbotDemoHero = 'https://zackproser.b-cdn.net/images/chatbot-demo-hero.webp'
+/* ------------------------------------------------------------------
+ * Editorial homepage — restrained, engineering-paper aesthetic.
+ * See src/styles/editorial-home.css for the primitive styles.
+ * ------------------------------------------------------------------ */
 
-// Add type definitions for the props
-interface Article {
-  slug: string;
-  // Add other properties of the article object as needed
+type Article = Content
+
+interface Props {
+  deepMLTutorials: Article[]
+  mlProjects: Article[]
+  aiDev: Article[]
+  refArchitectures: Article[]
+  careerAdvice: Article[]
+  videos: Article[]
+  isMobile: boolean
 }
 
-interface HomepageClientComponentProps {
-  deepMLTutorials: Article[];
-  mlProjects: Article[];
-  aiDev: Article[];
-  refArchitectures: Article[];
-  careerAdvice: Article[];
-  videos: Article[];
-  isMobile: boolean;
+// ----- Hero ---------------------------------------------------------
+
+function EditorialHero({ onConsult }: { onConsult: () => void }) {
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState<string>('')
+
+  async function handleSubscribe(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = event.currentTarget
+    const email = (form.elements.namedItem('email') as HTMLInputElement)?.value?.trim()
+    if (!email) return
+
+    setStatus('submitting')
+    setErrorMessage('')
+
+    track('newsletter_subscribe_submit', { location: 'hero' })
+    sendGTMEvent({
+      event: 'newsletter-signup-conversion',
+      method: 'newsletter',
+      source: '/',
+      position: 'hero',
+      tags: '',
+      slug: 'homepage',
+    })
+
+    try {
+      const response = await fetch('/api/form', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, referrer: '/', tags: [] }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        throw new Error(data?.data || 'Failed to subscribe')
+      }
+      setStatus('success')
+      form.reset()
+    } catch (err) {
+      setStatus('error')
+      setErrorMessage(err instanceof Error ? err.message : 'Something went wrong')
+    }
+  }
+
+  return (
+    <section className="pt-16 pb-12 md:pt-24 md:pb-16">
+      <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-14 lg:grid-cols-[1.6fr_1fr] lg:items-start">
+        <div>
+          <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
+            Applied AI · WorkOS
+          </div>
+          <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
+            AI engineering for teams that actually ship.
+          </h1>
+          <p className="editorial-lede text-parchment-600 dark:text-slate-300">
+            I build retrieval pipelines, agent harnesses, and ship-ready
+            developer tools at WorkOS. Fourteen years in production. Writing,
+            workshops, and consulting for teams that got handed an LLM and a
+            deadline.
+          </p>
+
+          {/* Newsletter — the primary CTA. Inline under the lede. */}
+          <form className="editorial-capture" onSubmit={handleSubscribe} noValidate>
+            <div className="editorial-capture-label text-parchment-600 dark:text-slate-400">
+              <span className="text-burnt-400 dark:text-amber-400">✱</span>
+              <span>The Modern Coding letter</span>
+            </div>
+            <div className="editorial-capture-title text-burnt-400 dark:text-amber-400">
+              Applied AI dispatches read by 5,000+ engineers
+            </div>
+            {status === 'success' ? (
+              <div className="editorial-capture-fine text-burnt-400 dark:text-amber-400" role="status">
+                ✓ Subscribed. Check your inbox to confirm.
+              </div>
+            ) : (
+              <>
+                <div className="editorial-capture-row">
+                  <input
+                    type="email"
+                    name="email"
+                    required
+                    placeholder="you@company.com"
+                    aria-label="Email"
+                    disabled={status === 'submitting'}
+                  />
+                  <button
+                    type="submit"
+                    disabled={status === 'submitting'}
+                    className="inline-flex items-center justify-center px-5 py-[13px] text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors disabled:opacity-60"
+                  >
+                    {status === 'submitting' ? 'Subscribing…' : 'Subscribe →'}
+                  </button>
+                </div>
+                <div className="editorial-capture-fine text-parchment-500 dark:text-slate-500">
+                  {status === 'error' && errorMessage
+                    ? errorMessage
+                    : 'No spam. Unsubscribe in one click.'}
+                </div>
+              </>
+            )}
+          </form>
+
+          <div className="editorial-secondary text-parchment-600 dark:text-slate-400">
+            <button
+              type="button"
+              onClick={() => {
+                onConsult()
+                track('main_cta_click', { destination: 'consultation' })
+              }}
+              className="bg-transparent border-0 p-0 cursor-pointer font-inherit text-inherit"
+              style={{ borderBottom: '1px solid currentColor', paddingBottom: 1 }}
+            >
+              Book a consult →
+            </button>
+            <span>·</span>
+            <Link href="/blog">Read the essays →</Link>
+            <span>·</span>
+            <Link href="/services">Workshops →</Link>
+          </div>
+
+          <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
+            <dt>Current</dt>
+            <dd>Applied AI · WorkOS</dd>
+            <dt>Recent</dt>
+            <dd>Pinecone · Cloudflare · Gruntwork</dd>
+          </dl>
+        </div>
+
+        <div className="lg:justify-self-end">
+          <div className="editorial-portrait" role="img" aria-label="Portrait of Zachary Proser" />
+          <div className="editorial-portrait-caption text-parchment-600 dark:text-slate-400">
+            Plate I · Applied AI · MMXXVI
+          </div>
+        </div>
+      </div>
+    </section>
+  )
 }
+
+// ----- Stat row -----------------------------------------------------
+
+function StatRow() {
+  const stats = [
+    { num: '14', unit: 'yrs', label: 'Shipping software' },
+    { num: '5,000', unit: '+', label: 'Newsletter readers' },
+    { num: '184', unit: 'wpm', label: 'Voice-coding velocity' },
+    { num: '30', unit: 'yrs', label: 'Writing online since' },
+  ]
+  return (
+    <section className="pb-12">
+      <div className="container mx-auto max-w-6xl px-4 md:px-6">
+        <div className="editorial-stats text-charcoal-50 dark:text-parchment-100">
+          {stats.map((s, i) => (
+            <div key={i} className="editorial-stat">
+              <div className="editorial-stat-num">
+                {s.num}
+                <span className="unit">{s.unit}</span>
+              </div>
+              <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                {s.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ----- Featured Project ---------------------------------------------
+
+function FeaturedProject() {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto max-w-6xl px-4 md:px-6">
+        <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+          Featured project
+        </div>
+        <article className="grid gap-10 lg:grid-cols-[1.3fr_1fr] lg:gap-16 items-start">
+          <div>
+            <div className="flex flex-wrap gap-2 mb-5">
+              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-[11px] font-bold font-mono uppercase tracking-wider text-amber-700 dark:text-amber-300 border border-amber-300 dark:border-amber-400/50">
+                Premium · $149
+              </span>
+              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-[11px] font-semibold font-mono uppercase tracking-wider text-green-700 dark:text-green-300 border border-green-600/40">
+                <span className="w-1.5 h-1.5 rounded-full bg-green-600 dark:bg-green-400" />
+                Shipping
+              </span>
+            </div>
+            <h2 className="font-serif text-3xl md:text-4xl font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100">
+              Build a chatbot that actually knows your shit.
+            </h2>
+            <p className="mt-5 text-[17px] leading-relaxed text-parchment-600 dark:text-slate-300 max-w-[52ch]">
+              End-to-end RAG with Pinecone, the Vercel AI SDK, and Next.js 15.
+              No hallucinations. No magic. A production harness you can hand to
+              your team and they&apos;ll still understand it in six months.
+            </p>
+            <div className="mt-7 grid grid-cols-3 gap-4 max-w-md">
+              {[
+                ['Runtime', 'Node 20'],
+                ['Vector DB', 'Pinecone'],
+                ['Eval', 'Ragas++'],
+              ].map(([label, val]) => (
+                <div key={label}>
+                  <div className="font-mono text-[10px] uppercase tracking-wider text-parchment-500 dark:text-slate-500">
+                    {label}
+                  </div>
+                  <div className="font-mono text-sm font-semibold text-charcoal-50 dark:text-parchment-100 mt-1">
+                    {val}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                href="/checkout?product=rag-pipeline-tutorial&type=blog"
+                className="inline-flex items-center justify-center px-5 py-3 text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors"
+                onClick={() =>
+                  track('featured_product_click', {
+                    location: 'hero_section',
+                    product: 'rag_tutorial',
+                    action: 'buy',
+                  })
+                }
+              >
+                Buy tutorial — $149
+              </Link>
+              <Link
+                href="/chat"
+                className="inline-flex items-center justify-center px-5 py-3 text-sm font-semibold rounded-md border border-parchment-400 dark:border-slate-600 text-charcoal-50 dark:text-parchment-100 hover:border-burnt-400 dark:hover:border-amber-400 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors"
+                onClick={() =>
+                  track('featured_product_click', {
+                    location: 'hero_section',
+                    product: 'rag_tutorial',
+                    action: 'demo',
+                  })
+                }
+              >
+                Try the live demo →
+              </Link>
+            </div>
+          </div>
+
+          {/* Terminal readout — static, editorial flavor */}
+          <div className="rounded-md overflow-hidden border border-charcoal-100/30 dark:border-slate-700 bg-[#141428] text-sm font-mono shadow-lg">
+            <div className="flex items-center gap-1.5 px-3 py-2 border-b border-white/10 bg-black/20">
+              <span className="w-2.5 h-2.5 rounded-full bg-red-400/60" />
+              <span className="w-2.5 h-2.5 rounded-full bg-yellow-400/60" />
+              <span className="w-2.5 h-2.5 rounded-full bg-green-400/60" />
+              <span className="ml-3 text-[11px] text-slate-400">pnpm ingest</span>
+            </div>
+            <div className="p-4 text-[12px] leading-relaxed text-slate-200 whitespace-nowrap overflow-x-auto">
+              <div><span className="text-amber-400">➜</span> <span className="text-slate-500">rag-pipeline-tutorial</span> pnpm ingest</div>
+              <div><span className="text-slate-500">  scanning ./content ...........</span> <span className="text-green-400">218 files</span></div>
+              <div><span className="text-slate-500">  chunking (1024/128) ..........</span> <span className="text-green-400">3,740 chunks</span></div>
+              <div><span className="text-slate-500">  embed (text-3-large) .........</span> <span className="text-green-400">$0.14</span></div>
+              <div><span className="text-slate-500">  upsert → pinecone ............</span> <span className="text-green-400">ok</span></div>
+              <div><span className="text-amber-400">➜</span> pnpm eval</div>
+              <div><span className="text-slate-500">  faithfulness ..</span> <span className="text-green-400">0.94</span> <span className="text-slate-500">p@5 ..</span> <span className="text-green-400">0.87</span></div>
+              <div><span className="text-slate-500">  recall@10 .....</span> <span className="text-green-400">0.91</span> <span className="text-slate-500">p95 ..</span> <span className="text-yellow-400">340ms</span></div>
+              <div><span className="text-amber-400">➜</span> <span className="inline-block w-2 h-3.5 bg-amber-400 align-middle animate-pulse ml-1" /></div>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  )
+}
+
+// ----- Section head + Content rail ----------------------------------
+
+function SectionHead({
+  num,
+  title,
+  moreHref,
+  moreLabel = 'Archive →',
+}: {
+  num: string
+  title: string
+  moreHref: string
+  moreLabel?: string
+}) {
+  return (
+    <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
+      <div className="editorial-section-num">§ {num}</div>
+      <h2 className="editorial-section-title">{title}</h2>
+      <Link
+        href={moreHref as Route}
+        className="editorial-section-more text-burnt-400 dark:text-amber-400 hover:underline"
+      >
+        {moreLabel}
+      </Link>
+    </header>
+  )
+}
+
+function ContentRail({
+  num,
+  title,
+  moreHref,
+  moreLabel,
+  articles,
+  alt,
+  keyPrefix,
+}: {
+  num: string
+  title: string
+  moreHref: string
+  moreLabel?: string
+  articles: Article[]
+  alt?: boolean
+  keyPrefix: string
+}) {
+  return (
+    <section className={`py-14 ${alt ? 'editorial-section-alt' : ''}`}>
+      <div className="container mx-auto max-w-6xl px-4 md:px-6">
+        <SectionHead num={num} title={title} moreHref={moreHref} moreLabel={moreLabel} />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {articles.slice(0, 3).map((a, i) => (
+            <ContentCard key={`${keyPrefix}-${i}`} article={a as never} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ----- Colophon footer ----------------------------------------------
+
+function ColophonFooter() {
+  return (
+    <footer className="mt-16">
+      <div className="container mx-auto max-w-6xl px-4 md:px-6 editorial-colophon text-charcoal-50 dark:text-parchment-100">
+        <div className="grid gap-10 md:grid-cols-[2fr_1fr_1fr_1fr]">
+          <div>
+            <p className="font-serif text-lg leading-snug mb-2">
+              Zachary Proser writes, ships, and teaches applied AI.
+            </p>
+            <p className="text-parchment-600 dark:text-slate-400 leading-relaxed text-[13px] max-w-[52ch]">
+              Currently Applied AI at WorkOS. Formerly Pinecone, Cloudflare,
+              Gruntwork. Before that, a very long stretch of infrastructure.
+            </p>
+          </div>
+          <div>
+            <h4 className="text-parchment-600 dark:text-slate-400">Writing</h4>
+            <ul>
+              <li><Link href="/blog">All essays</Link></li>
+              <li><Link href="/blog">Archive</Link></li>
+              <li><Link href="/rss/feed.xml">RSS feed</Link></li>
+              <li><Link href="/newsletter">Newsletter</Link></li>
+            </ul>
+          </div>
+          <div>
+            <h4 className="text-parchment-600 dark:text-slate-400">Work with me</h4>
+            <ul>
+              <li><Link href="/services">Consulting</Link></li>
+              <li><Link href="/services">Workshops</Link></li>
+              <li><Link href="/speaking">Speaking</Link></li>
+              <li><Link href="/contact">Contact</Link></li>
+            </ul>
+          </div>
+          <div>
+            <h4 className="text-parchment-600 dark:text-slate-400">Elsewhere</h4>
+            <ul>
+              <li><a href="https://github.com/zackproser" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+              <li><a href="https://youtube.com/@zackproser" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+              <li><a href="https://linkedin.com/in/zackproser" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+              <li><a href="https://x.com/zackproser" target="_blank" rel="noopener noreferrer">Twitter / X</a></li>
+            </ul>
+          </div>
+        </div>
+        <div className="editorial-colophon-rule text-parchment-600 dark:text-slate-500">
+          <div>© MMXXVI Zachary Proser · Set in Source Serif 4 &amp; JetBrains Mono</div>
+          <div>Built with Next.js · Hosted on Vercel</div>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+// ----- Main component -----------------------------------------------
 
 export default function HomepageClientComponent({
   deepMLTutorials,
@@ -37,380 +414,77 @@ export default function HomepageClientComponent({
   refArchitectures,
   careerAdvice,
   videos,
-}: HomepageClientComponentProps) {
-  const [isConsultationOpen, setIsConsultationOpen] = useState(false)
+}: Props) {
+  const [isConsultOpen, setIsConsultOpen] = useState(false)
 
   return (
-    <div className="flex flex-col min-h-screen bg-parchment-100 dark:bg-charcoal-400 theme-transition">
+    <div className="editorial-home flex flex-col min-h-screen text-charcoal-50 dark:text-parchment-100 theme-transition">
       <main className="flex-1">
-        {/* New Authority Hero */}
-        <AuthorityHero />
+        <EditorialHero onConsult={() => setIsConsultOpen(true)} />
+        <StatRow />
+        <FeaturedProject />
 
-        {/* How I Engage Grid - replaces the blueprint */}
-        <EngagementGrid />
+        <ContentRail
+          num="01"
+          title="Deep &amp; machine learning, by hand"
+          moreHref="/blog"
+          articles={deepMLTutorials}
+          alt
+          keyPrefix="ml-tutorial"
+        />
 
-        {/* Premium Featured Project Title Section */}
-        <section className="py-8 bg-parchment-100 dark:bg-charcoal-400 border-t border-parchment-300 dark:border-charcoal-100/20">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="text-center">
-              <div className="inline-block bg-burnt-400 dark:bg-amber-400/90 px-6 py-2 border border-burnt-500/20 dark:border-amber-500/20 rounded-lg shadow-lg">
-                <h2 className="font-serif text-2xl font-bold tracking-tighter sm:text-3xl md:text-4xl text-white dark:text-charcoal-500">
-                  Featured Premium Project
-                </h2>
-              </div>
-            </div>
-          </div>
-        </section>
+        <ContentRail
+          num="02"
+          title="Open-source projects"
+          moreHref="/projects"
+          moreLabel="All projects →"
+          articles={mlProjects}
+          keyPrefix="ml-project"
+        />
 
-        {/* Featured Product Content */}
-        <section className="overflow-hidden bg-parchment-100 dark:bg-charcoal-400 border-t border-parchment-300 dark:border-charcoal-100/20 px-5 isolate">
-          <div className="mx-auto grid max-w-6xl grid-cols-1 grid-rows-[auto_1fr] gap-y-16 pt-16 md:pt-20 lg:grid-cols-12 lg:gap-y-20 lg:px-3 lg:pt-20 lg:pb-36 xl:py-32">
-            <div className="relative flex items-end lg:col-span-6 lg:row-span-2">
-              <div className="relative z-10 mx-auto flex w-[90%] max-w-xl rounded-xl shadow-xl md:w-auto lg:w-auto">
-                <Link 
-                  href="/chat"
-                  className="block w-full group"
-                  onClick={() => {
-                    track("featured_product_click", {
-                      location: "featured_banner",
-                      product: "rag_tutorial",
-                      action: "demo"
-                    })
-                  }}
-                >
-                <div className="relative aspect-[3.5/3] sm:aspect-[4/3] w-full max-w-[650px] rounded-2xl bg-gradient-to-br from-blue-700 to-blue-900 p-6 sm:p-8 shadow-2xl border-t-8 border-blue-500/20 transition-transform duration-200 group-hover:scale-[1.01]">
-                  {/* Badge and price in separate container with flexbox */}
-                  <div className="w-full flex flex-col gap-2 sm:block">
-                    <div className="inline-flex items-center px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-blue-500/20 text-blue-200 text-xs sm:text-sm font-medium">
-                      <span className="mr-1">💎</span> Premium Project
-                    </div>
-                    
-                    <div className="hidden sm:block sm:absolute sm:top-8 sm:right-8">
-                      <div className="px-3 py-1.5 sm:px-4 sm:py-2 bg-gradient-to-r from-amber-600 to-yellow-400 rounded-full">
-                        <span className="text-xl sm:text-2xl font-bold text-white">$149</span>
-                      </div>
-                    </div>
-                    
-                    <div className="sm:hidden absolute top-5 right-5">
-                      <div className="px-3 py-1.5 bg-gradient-to-r from-amber-600 to-yellow-400 rounded-full">
-                        <span className="text-xl font-bold text-white">$149</span>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  {/* Title and subtitle */}
-                  <div className="mt-5 sm:mt-6">
-                    <h2 className="font-display text-2xl sm:text-4xl font-bold text-white leading-tight">
-                      Build a Chatbot That <span className="italic">Actually Knows Your Shit</span>
-                    </h2>
-                    <p className="mt-3 sm:mt-6 text-base sm:text-lg text-zinc-100 leading-relaxed">
-                     Learn to create a chatbot that answers questions about your content.
-                    </p>
-                  </div>
+        <ContentRail
+          num="03"
+          title="AI-assisted development"
+          moreHref="/blog"
+          moreLabel="More essays →"
+          articles={aiDev}
+          alt
+          keyPrefix="ai-dev"
+        />
 
-                  {/* Feature list */}
-                  <div className="mt-4 sm:mt-8 grid grid-cols-1 gap-3 sm:gap-4">
-                    <div className="flex items-center space-x-2">
-                      <svg className="w-4 h-4 sm:w-5 sm:h-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                      <span className="text-sm sm:text-base text-zinc-100"><strong>No hallucinations</strong> – Answers grounded in your docs</span>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <svg className="w-4 h-4 sm:w-5 sm:h-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                      <span className="text-sm sm:text-base text-zinc-100"><strong>State of the art tech</strong> – Vercel AI SDK, embeddings, vector retrieval</span>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <svg className="w-4 h-4 sm:w-5 sm:h-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                      <span className="text-sm sm:text-base text-zinc-100"><strong>Battle-tested</strong> – I&apos;ve built production RAG pipelines for years</span>
-                    </div>
-                  </div>
-                </div>
-                </Link>
-              </div>
-            </div>
-            <div className="relative px-4 sm:px-6 lg:col-span-6 lg:pr-0 lg:pb-14 lg:pl-16 xl:pl-20">
-              <div className="hidden lg:absolute lg:-top-32 lg:bottom-0 lg:left-[-100vw] lg:right-[-100vw] lg:block lg:bg-parchment-200 dark:bg-charcoal-300" />
-              <div className="relative">
-                <div className="flex justify-start">
-                  <div className="flex items-center text-burnt-400 dark:text-amber-400">
-                    <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-                      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                    </svg>
-                    <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-                      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                    </svg>
-                    <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-                      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                    </svg>
-                  <span className="ml-2 text-sm text-parchment-600 dark:text-parchment-400">5.0 rating</span>
-                  </div>
-                </div>
-                <blockquote className="mt-8">
-                  <p className="font-serif text-xl font-medium text-charcoal-50 dark:text-parchment-100">
-                    &ldquo;Thanks for publishing the tutorial, very helpful.&rdquo;
-                  </p>
-                </blockquote>
-                <p className="mt-4 text-base text-parchment-600 dark:text-parchment-400">
-                  <strong className="font-semibold text-burnt-400 dark:text-amber-400">Scott McCallum</strong> &bull; Full Stack Developer at Intermine
-                </p>
-              </div>
-            </div>
-            <div className="bg-parchment-50 dark:bg-charcoal-300 pt-16 lg:col-span-6 lg:pt-0 lg:pl-16 xl:pl-20 rounded-xl">
-              <div className="mx-auto px-4 sm:px-6 md:max-w-2xl md:px-4 lg:px-0">
-                <div className="flex flex-col sm:flex-row gap-4">
-                  <Link 
-                    href="/checkout?product=rag-pipeline-tutorial&type=blog"
-                    className="inline-flex items-center justify-center px-6 py-3 text-base font-medium rounded-md text-white bg-gradient-to-r from-amber-500 to-yellow-500 hover:from-amber-600 hover:to-yellow-600 shadow-md hover:shadow-lg transition-all duration-200"
-                    onClick={() => {
-                      track("featured_product_click", {
-                        location: "hero_section",
-                        product: "rag_tutorial",
-                        action: "buy"
-                      })
-                    }}
-                  >
-                    Get the $149 Tutorial →
-                  </Link>
-                  <Link 
-                    href="/chat"
-                    className="inline-flex items-center justify-center px-6 py-3 text-base font-medium rounded-md text-white bg-blue-500 hover:bg-blue-400 transition-colors"
-                    onClick={() => {
-                      track("featured_product_click", {
-                        location: "hero_section",
-                        product: "rag_tutorial",
-                        action: "demo"
-                      })
-                    }}
-                  >
-                    Try the live demo →
-                  </Link>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
+        <ContentRail
+          num="04"
+          title="Reference architectures"
+          moreHref="/blog"
+          articles={refArchitectures}
+          keyPrefix="ref-arch"
+        />
 
-        {/* Interactive Demos Section */}
-        <section className="w-full py-12 md:py-16 lg:py-20 bg-parchment-200 dark:bg-charcoal-500">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="mb-10 text-center">
-              <h2 className="font-serif text-3xl font-bold tracking-tight sm:text-4xl md:text-5xl text-charcoal-50 dark:text-parchment-100 mb-4">
-                Interactive AI Laboratory
-              </h2>
-              <p className="text-lg text-parchment-600 dark:text-parchment-400 max-w-3xl mx-auto">
-                Learn by doing! Explore how AI systems work under the hood through hands-on interactive experiences.
-              </p>
-            </div>
+        <ContentRail
+          num="05"
+          title="Career notes — from the field"
+          moreHref="/blog"
+          moreLabel="All advice →"
+          articles={careerAdvice}
+          alt
+          keyPrefix="career"
+        />
 
-            <div className="relative">
-               <div className="mx-auto mt-8 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-                 <ContentCard 
-                   key="chatbot-demo"
-                   article={{
-                     slug: '/chat',
-                     title: 'How do you give an AI system your specific knowledge?',
-                     description: 'Try a live AI chatbot powered by RAG (Retrieval Augmented Generation) that knows my content. See how AI systems can be grounded with specific data to avoid hallucinations.',
-                     author: 'Zachary Proser',
-                     date: '2024-01-01',
-                     type: 'demo',
-                     image: chatbotDemoHero
-                   }} 
-                 />
-                 <ContentCard 
-                   key="embeddings-demo"
-                   article={{
-                     slug: '/demos/embeddings',
-                     title: 'How do LLMs understand meaning in text?',
-                     description: 'Visualize how text transforms into vectors that capture semantic meaning. See why similar concepts cluster together and understand the foundation of RAG systems.',
-                     author: 'Zachary Proser',
-                     date: '2024-01-01',
-                     type: 'demo',
-                     image: embeddingsDemoHero
-                   }} 
-                 />
-                 <ContentCard
-                   key="tokenization-demo"
-                   article={{
-                     slug: '/demos/tokenize',
-                     title: 'Why do LLMs have context limits and token costs?',
-                     description: 'See how language models break text into tokens. Understand why context windows exist, how pricing works, and optimize your prompts for better performance.',
-                     author: 'Zachary Proser',
-                     date: '2024-01-01',
-                     type: 'demo',
-                     image: tokenizationDemoHero
-                   }}
-                 />
-               </div>
+        <ContentRail
+          num="06"
+          title="Video &amp; screencasts"
+          moreHref="/videos"
+          moreLabel="All videos →"
+          articles={videos}
+          keyPrefix="video"
+        />
 
-              <div className="text-center mt-8">
-                <Link
-                  href="/demos"
-                  className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-lg bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 text-white dark:text-charcoal-500 shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-0.5"
-                  onClick={() => {
-                    track("main_cta_click", {
-                      destination: "all_demos"
-                    })
-                  }}
-                >
-                  View All Interactive Demos &rarr;
-                </Link>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Content Collections Section Header */}
-        <section className="py-12 bg-parchment-200 dark:bg-charcoal-500 border-t border-parchment-300 dark:border-charcoal-100/20">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="text-center mb-10">
-              <h2 className="font-serif text-3xl font-bold tracking-tight sm:text-4xl text-charcoal-50 dark:text-parchment-100 mb-4">
-                Knowledge Collections
-              </h2>
-              <p className="text-lg text-parchment-600 dark:text-parchment-400 max-w-3xl mx-auto">
-                Explore my comprehensive library of AI engineering resources and implementation guides.
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-4 justify-center mt-8">
-              <Link
-                href="/projects"
-                className="inline-flex items-center justify-center px-6 py-3 text-base font-medium rounded-lg text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors shadow-md"
-                onClick={() => {
-                  track("main_cta_click", {
-                    destination: "projects"
-                  })
-                }}
-              >
-                All Projects &rarr;
-              </Link>
-              <Link
-                href="/publications"
-                className="inline-flex items-center justify-center px-6 py-3 text-base font-medium rounded-lg text-burnt-400 dark:text-amber-400 bg-burnt-400/10 dark:bg-amber-400/10 hover:bg-burnt-400/20 dark:hover:bg-amber-400/20 border border-burnt-400/30 dark:border-amber-400/30 transition-colors shadow-md"
-                onClick={() => {
-                  track("main_cta_click", {
-                    destination: "publications"
-                  })
-                }}
-              >
-                All Publications &rarr;
-              </Link>
-              <Link
-                href="/testimonials"
-                className="inline-flex items-center justify-center px-6 py-3 text-base font-medium rounded-lg text-burnt-400 dark:text-amber-400 bg-burnt-400/10 dark:bg-amber-400/10 hover:bg-burnt-400/20 dark:hover:bg-amber-400/20 border border-burnt-400/30 dark:border-amber-400/30 transition-colors shadow-md"
-                onClick={() => {
-                  track("main_cta_click", {
-                    destination: "testimonials"
-                  })
-                }}
-              >
-                Client Success Stories &rarr;
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-parchment-50 dark:bg-charcoal-300 py-12">
-          <div className="container px-4 md:px-6 mx-auto">
-            <h2 className="font-serif text-2xl font-bold mb-6 flex items-center text-charcoal-50 dark:text-parchment-100">
-              Deep and Machine Learning Tutorials
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {deepMLTutorials.slice(0, 3).map((article, index) => (
-                <ContentCard key={`ml-tutorial-${index}`} article={article} />
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-parchment-200 dark:bg-charcoal-500 py-12">
-          <div className="container px-4 md:px-6 mx-auto">
-            <h2 className="font-serif text-2xl font-bold mb-6 flex items-center text-charcoal-50 dark:text-parchment-100">
-              Open-source AI / ML / Pipelines Projects
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {mlProjects.slice(0, 3).map((article, index) => (
-                <ContentCard key={`ml-project-${index}`} article={article} />
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-parchment-50 dark:bg-charcoal-300 py-12">
-          <div className="container px-4 md:px-6 mx-auto">
-            <h2 className="font-serif text-2xl font-bold mb-6 flex items-center text-charcoal-50 dark:text-parchment-100">
-              AI-assisted Development
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {aiDev.slice(0, 3).map((article, index) => (
-                <ContentCard key={`ai-dev-${index}`} article={article} />
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-parchment-200 dark:bg-charcoal-500 py-12">
-          <div className="container px-4 md:px-6 mx-auto">
-            <h2 className="font-serif text-2xl font-bold mb-6 flex items-center text-charcoal-50 dark:text-parchment-100">
-              Career Advice
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {careerAdvice.slice(0, 3).map((article, index) => (
-                <ContentCard key={`career-${index}`} article={article} />
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-parchment-50 dark:bg-charcoal-300 py-12">
-          <div className="container px-4 md:px-6 mx-auto">
-            <h2 className="font-serif text-2xl font-bold mb-6 flex items-center text-charcoal-50 dark:text-parchment-100">
-              Videos
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {videos.slice(0, 3).map((article, index) => (
-                <ContentCard key={`video-${index}`} article={article} />
-              ))}
-            </div>
-            <div className="text-center mt-6">
-              <Link
-                href="/videos"
-                className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-lg text-burnt-400 dark:text-amber-400 bg-burnt-400/10 dark:bg-amber-400/10 hover:bg-burnt-400/20 dark:hover:bg-amber-400/20 border border-burnt-400/30 dark:border-amber-400/30 transition-colors"
-                onClick={() => {
-                  track("see_all_click", {
-                    contentType: "videos"
-                  })
-                }}
-              >
-                See all videos &rarr;
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-parchment-200 dark:bg-charcoal-500 py-12">
-          <div className="container px-4 md:px-6 mx-auto">
-            <h2 className="font-serif text-2xl font-bold mb-6 flex items-center text-charcoal-50 dark:text-parchment-100">
-              Reference Architectures and Demos
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {refArchitectures.slice(0, 3).map((article, index) => (
-                <ContentCard key={`ref-arch-${index}`} article={article} />
-              ))}
-            </div>
-          </div>
-        </section>
-
+        <ColophonFooter />
       </main>
-      <footer className="w-full py-6 bg-charcoal-400 dark:bg-charcoal-600 text-parchment-100">
-      </footer>
-      <ConsultationForm 
-        isOpen={isConsultationOpen} 
-        onClose={() => setIsConsultationOpen(false)} 
+
+      <ConsultationForm
+        isOpen={isConsultOpen}
+        onClose={() => setIsConsultOpen(false)}
       />
     </div>
   )

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -419,7 +419,7 @@ export default function HomepageClientComponent({
 
         <ContentRail
           num="01"
-          title="Deep &amp; machine learning, by hand"
+          title="Deep & machine learning, by hand"
           moreHref="/blog"
           articles={deepMLTutorials}
           alt
@@ -470,7 +470,7 @@ export default function HomepageClientComponent({
 
         <ContentRail
           num="06"
-          title="Video &amp; screencasts"
+          title="Video & screencasts"
           moreHref="/videos"
           moreLabel="All videos →"
           articles={videos}

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -6,7 +6,7 @@ import { useState, FormEvent } from 'react'
 import type { Route } from 'next'
 import { track } from '@vercel/analytics'
 import { sendGTMEvent } from '@next/third-parties/google'
-import { ContentCard } from '@/components/ContentCard'
+import { EditorialCard } from '@/components/EditorialCard'
 import ConsultationForm from '@/components/ConsultationForm'
 import type { Content } from '@/types/content'
 
@@ -279,24 +279,23 @@ function FeaturedProject() {
             </div>
           </div>
 
-          {/* Terminal readout — static, editorial flavor */}
+          {/* Terminal readout — site index */}
           <div className="rounded-md overflow-hidden border border-charcoal-100/30 dark:border-slate-700 bg-[#141428] text-sm font-mono shadow-lg">
             <div className="flex items-center gap-1.5 px-3 py-2 border-b border-white/10 bg-black/20">
               <span className="w-2.5 h-2.5 rounded-full bg-red-400/60" />
               <span className="w-2.5 h-2.5 rounded-full bg-yellow-400/60" />
               <span className="w-2.5 h-2.5 rounded-full bg-green-400/60" />
-              <span className="ml-3 text-[11px] text-slate-400">pnpm ingest</span>
+              <span className="ml-3 text-[11px] tracking-wider uppercase text-slate-400">~/zackproser.com — index</span>
             </div>
             <div className="p-4 text-[12px] leading-relaxed text-slate-200 whitespace-nowrap overflow-x-auto">
-              <div><span className="text-amber-400">➜</span> <span className="text-slate-500">rag-pipeline-tutorial</span> pnpm ingest</div>
-              <div><span className="text-slate-500">  scanning ./content ...........</span> <span className="text-green-400">218 files</span></div>
-              <div><span className="text-slate-500">  chunking (1024/128) ..........</span> <span className="text-green-400">3,740 chunks</span></div>
-              <div><span className="text-slate-500">  embed (text-3-large) .........</span> <span className="text-green-400">$0.14</span></div>
-              <div><span className="text-slate-500">  upsert → pinecone ............</span> <span className="text-green-400">ok</span></div>
-              <div><span className="text-amber-400">➜</span> pnpm eval</div>
-              <div><span className="text-slate-500">  faithfulness ..</span> <span className="text-green-400">0.94</span> <span className="text-slate-500">p@5 ..</span> <span className="text-green-400">0.87</span></div>
-              <div><span className="text-slate-500">  recall@10 .....</span> <span className="text-green-400">0.91</span> <span className="text-slate-500">p95 ..</span> <span className="text-yellow-400">340ms</span></div>
-              <div><span className="text-amber-400">➜</span> <span className="inline-block w-2 h-3.5 bg-amber-400 align-middle animate-pulse ml-1" /></div>
+              <div><span className="text-slate-500">zp@work ~ $</span> ls -lh ./content</div>
+              <div><span className="text-slate-500">drwx  </span>writing/<span className="text-slate-500">        218 essays       </span><span className="text-amber-400">&quot;modern-coding&quot;</span></div>
+              <div><span className="text-slate-500">drwx  </span>builds/<span className="text-slate-500">          37 projects     </span><span className="text-amber-400">&quot;rag, tools, tuis&quot;</span></div>
+              <div><span className="text-slate-500">drwx  </span>videos/<span className="text-slate-500">          24 screencasts  </span><span className="text-amber-400">&quot;long-form&quot;</span></div>
+              <div><span className="text-slate-500">drwx  </span>workshops/<span className="text-slate-500">        6 decks        </span><span className="text-amber-400">&quot;cowork, claude&quot;</span></div>
+              <div><span className="text-slate-500">zp@work ~ $</span> cat ./status.json</div>
+              <div>{'{ '}<span className="text-amber-400">&quot;current&quot;</span>: <span className="text-green-400">&quot;applied-ai @ workos&quot;</span>, <span className="text-amber-400">&quot;open_to&quot;</span>: [<span className="text-green-400">&quot;workshops&quot;</span>, <span className="text-green-400">&quot;retainers&quot;</span>], <span className="text-amber-400">&quot;wpm&quot;</span>: <span className="text-green-400">184</span> {'}'}</div>
+              <div><span className="text-slate-500">zp@work ~ $</span> <span className="inline-block w-2 h-3.5 bg-amber-400 align-middle animate-pulse ml-1" /></div>
             </div>
           </div>
         </article>
@@ -340,6 +339,7 @@ function ContentRail({
   articles,
   alt,
   keyPrefix,
+  kind,
 }: {
   num: string
   title: string
@@ -348,6 +348,7 @@ function ContentRail({
   articles: Article[]
   alt?: boolean
   keyPrefix: string
+  kind?: string
 }) {
   return (
     <section className={`py-14 ${alt ? 'editorial-section-alt' : ''}`}>
@@ -355,7 +356,12 @@ function ContentRail({
         <SectionHead num={num} title={title} moreHref={moreHref} moreLabel={moreLabel} />
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {articles.slice(0, 3).map((a, i) => (
-            <ContentCard key={`${keyPrefix}-${i}`} article={a as never} />
+            <EditorialCard
+              key={`${keyPrefix}-${i}`}
+              article={a}
+              index={i + 1}
+              kind={kind}
+            />
           ))}
         </div>
       </div>
@@ -442,6 +448,7 @@ export default function HomepageClientComponent({
           articles={deepMLTutorials}
           alt
           keyPrefix="ml-tutorial"
+          kind="Tutorial"
         />
 
         <ContentRail
@@ -451,6 +458,7 @@ export default function HomepageClientComponent({
           moreLabel="All projects →"
           articles={mlProjects}
           keyPrefix="ml-project"
+          kind="Project"
         />
 
         <ContentRail
@@ -461,6 +469,7 @@ export default function HomepageClientComponent({
           articles={aiDev}
           alt
           keyPrefix="ai-dev"
+          kind="Essay"
         />
 
         <ContentRail
@@ -469,6 +478,7 @@ export default function HomepageClientComponent({
           moreHref="/blog"
           articles={refArchitectures}
           keyPrefix="ref-arch"
+          kind="Ref arch"
         />
 
         <ContentRail
@@ -479,6 +489,7 @@ export default function HomepageClientComponent({
           articles={careerAdvice}
           alt
           keyPrefix="career"
+          kind="Field note"
         />
 
         <ContentRail
@@ -488,6 +499,7 @@ export default function HomepageClientComponent({
           moreLabel="All videos →"
           articles={videos}
           keyPrefix="video"
+          kind="Video"
         />
 
         <ColophonFooter />

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -148,27 +148,45 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
             <Link href="/services">Workshops →</Link>
           </div>
 
-          <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
-            <dt>Current</dt>
-            <dd>Applied AI · WorkOS</dd>
-            <dt>Recent</dt>
-            <dd>Pinecone · Cloudflare · Gruntwork</dd>
-          </dl>
         </div>
 
-        <div className="lg:justify-self-end">
+        <div className="editorial-hero-plate">
           <div className="editorial-portrait">
             <Image
               src="https://zackproser.b-cdn.net/images/zack-sketch.webp"
               alt="Portrait of Zachary Proser"
               fill
-              sizes="(max-width: 1024px) 80vw, 440px"
+              sizes="(max-width: 1024px) 80vw, 500px"
               className="editorial-portrait-image"
               priority
             />
           </div>
           <div className="editorial-portrait-caption text-parchment-600 dark:text-slate-400">
             Plate I · Applied AI · MMXXVI
+          </div>
+          <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
+            <dt>Current</dt>
+            <dd>Applied AI · WorkOS</dd>
+            <dt>Recent</dt>
+            <dd>Pinecone · Cloudflare · Gruntwork</dd>
+            <dt>Open to</dt>
+            <dd>
+              <span className="text-burnt-400 dark:text-amber-400">●</span> Workshops and retainers
+            </dd>
+          </dl>
+          <div className="editorial-hero-plate-quote">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              In the wild
+            </div>
+            <blockquote className="font-serif text-[17px] leading-[1.4] text-charcoal-50 dark:text-parchment-100">
+              “Zack is the rare engineer who ships, writes, and teaches — all at
+              the depth you actually want.”
+            </blockquote>
+            <div className="mt-3 font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+              <Link href="/testimonials" className="hover:text-burnt-400 dark:hover:text-amber-400">
+                Read the testimonials →
+              </Link>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import Image from 'next/image'
 import { useState, FormEvent } from 'react'
 import type { Route } from 'next'
 import { track } from '@vercel/analytics'
@@ -77,7 +78,8 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
             Applied AI · WorkOS
           </div>
           <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
-            AI engineering for teams that actually ship.
+            AI engineering for teams that actually{' '}
+            <span className="text-burnt-400 dark:text-amber-400">ship</span>.
           </h1>
           <p className="editorial-lede text-parchment-600 dark:text-slate-300">
             I build retrieval pipelines, agent harnesses, and ship-ready
@@ -154,7 +156,16 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
         </div>
 
         <div className="lg:justify-self-end">
-          <div className="editorial-portrait" role="img" aria-label="Portrait of Zachary Proser" />
+          <div className="editorial-portrait">
+            <Image
+              src="https://zackproser.b-cdn.net/images/zack-sketch.webp"
+              alt="Portrait of Zachary Proser"
+              fill
+              sizes="(max-width: 1024px) 80vw, 340px"
+              className="editorial-portrait-image"
+              priority
+            />
+          </div>
           <div className="editorial-portrait-caption text-parchment-600 dark:text-slate-400">
             Plate I · Applied AI · MMXXVI
           </div>

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -182,7 +182,7 @@ function StatRow() {
     { num: '14', unit: 'yrs', label: 'Shipping software' },
     { num: '5,000', unit: '+', label: 'Newsletter readers' },
     { num: '184', unit: 'wpm', label: 'Voice-coding velocity' },
-    { num: '30', unit: 'yrs', label: 'Writing online since' },
+    { num: '30', unit: 'yrs', label: 'Writing online' },
   ]
   return (
     <section className="pb-12">
@@ -501,9 +501,9 @@ export default function HomepageClientComponent({
           keyPrefix="video"
           kind="Video"
         />
-
-        <ColophonFooter />
       </main>
+
+      <ColophonFooter />
 
       <ConsultationForm
         isOpen={isConsultOpen}

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -2,13 +2,13 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import { useState, FormEvent } from 'react'
+import { useState } from 'react'
 import type { Route } from 'next'
 import { track } from '@vercel/analytics'
-import { sendGTMEvent } from '@next/third-parties/google'
 import { EditorialCard } from '@/components/EditorialCard'
 import { SectionHead } from '@/components/SectionHead'
 import ConsultationForm from '@/components/ConsultationForm'
+import { EditorialNewsletter } from '@/components/EditorialNewsletter'
 import type { Content } from '@/types/content'
 
 /* ------------------------------------------------------------------
@@ -30,45 +30,6 @@ interface Props {
 // ----- Hero ---------------------------------------------------------
 
 function EditorialHero({ onConsult }: { onConsult: () => void }) {
-  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
-  const [errorMessage, setErrorMessage] = useState<string>('')
-
-  async function handleSubscribe(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const form = event.currentTarget
-    const email = (form.elements.namedItem('email') as HTMLInputElement)?.value?.trim()
-    if (!email) return
-
-    setStatus('submitting')
-    setErrorMessage('')
-
-    try {
-      const response = await fetch('/api/form', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, referrer: '/', tags: [] }),
-      })
-      const data = await response.json().catch(() => ({}))
-      if (!response.ok) {
-        throw new Error(data?.data || 'Failed to subscribe')
-      }
-      track('newsletter-signup', { location: 'hero' })
-      sendGTMEvent({
-        event: 'newsletter-signup-conversion',
-        method: 'newsletter',
-        source: '/',
-        position: 'hero',
-        tags: '',
-        slug: 'homepage',
-      })
-      setStatus('success')
-      form.reset()
-    } catch (err) {
-      setStatus('error')
-      setErrorMessage(err instanceof Error ? err.message : 'Something went wrong')
-    }
-  }
-
   return (
     <section className="pt-16 pb-12 md:pt-24 md:pb-16">
       <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-14 lg:grid-cols-[1.35fr_1fr] lg:items-start">
@@ -88,45 +49,7 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
           </p>
 
           {/* Newsletter — the primary CTA. Inline under the lede. */}
-          <form className="editorial-capture" onSubmit={handleSubscribe} noValidate>
-            <div className="editorial-capture-label text-parchment-600 dark:text-slate-400">
-              <span className="text-burnt-400 dark:text-amber-400">✱</span>
-              <span>The Modern Coding letter</span>
-            </div>
-            <div className="editorial-capture-title text-burnt-400 dark:text-amber-400">
-              Applied AI dispatches read by 5,000+ engineers
-            </div>
-            {status === 'success' ? (
-              <div className="editorial-capture-fine text-burnt-400 dark:text-amber-400" role="status">
-                ✓ Subscribed. Check your inbox to confirm.
-              </div>
-            ) : (
-              <>
-                <div className="editorial-capture-row">
-                  <input
-                    type="email"
-                    name="email"
-                    required
-                    placeholder="you@company.com"
-                    aria-label="Email"
-                    disabled={status === 'submitting'}
-                  />
-                  <button
-                    type="submit"
-                    disabled={status === 'submitting'}
-                    className="inline-flex items-center justify-center px-5 py-[13px] text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors disabled:opacity-60"
-                  >
-                    {status === 'submitting' ? 'Subscribing…' : 'Subscribe →'}
-                  </button>
-                </div>
-                <div className="editorial-capture-fine text-parchment-500 dark:text-slate-500">
-                  {status === 'error' && errorMessage
-                    ? errorMessage
-                    : 'No spam. Unsubscribe in one click.'}
-                </div>
-              </>
-            )}
-          </form>
+          <EditorialNewsletter location="hero" />
 
           <div className="editorial-secondary text-parchment-600 dark:text-slate-400">
             <button

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -162,30 +162,6 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
           <div className="editorial-portrait-caption text-parchment-600 dark:text-slate-400">
             Plate I · Applied AI · MMXXVI
           </div>
-          <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
-            <dt>Current</dt>
-            <dd>Applied AI · WorkOS</dd>
-            <dt>Recent</dt>
-            <dd>Pinecone · Cloudflare · Gruntwork</dd>
-            <dt>Open to</dt>
-            <dd>
-              <span className="text-burnt-400 dark:text-amber-400">●</span> Workshops and retainers
-            </dd>
-          </dl>
-          <div className="editorial-hero-plate-quote">
-            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
-              In the wild
-            </div>
-            <blockquote className="font-serif text-[17px] leading-[1.4] text-charcoal-50 dark:text-parchment-100">
-              “Zack is the rare engineer who ships, writes, and teaches — all at
-              the depth you actually want.”
-            </blockquote>
-            <div className="mt-3 font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
-              <Link href="/testimonials" className="hover:text-burnt-400 dark:hover:text-amber-400">
-                Read the testimonials →
-              </Link>
-            </div>
-          </div>
         </div>
       </div>
     </section>

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -25,7 +25,6 @@ interface Props {
   refArchitectures: Article[]
   careerAdvice: Article[]
   videos: Article[]
-  isMobile: boolean
 }
 
 // ----- Hero ---------------------------------------------------------

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -43,16 +43,6 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
     setStatus('submitting')
     setErrorMessage('')
 
-    track('newsletter_subscribe_submit', { location: 'hero' })
-    sendGTMEvent({
-      event: 'newsletter-signup-conversion',
-      method: 'newsletter',
-      source: '/',
-      position: 'hero',
-      tags: '',
-      slug: 'homepage',
-    })
-
     try {
       const response = await fetch('/api/form', {
         method: 'POST',
@@ -63,6 +53,15 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
       if (!response.ok) {
         throw new Error(data?.data || 'Failed to subscribe')
       }
+      track('newsletter_subscribe_submit', { location: 'hero' })
+      sendGTMEvent({
+        event: 'newsletter-signup-conversion',
+        method: 'newsletter',
+        source: '/',
+        position: 'hero',
+        tags: '',
+        slug: 'homepage',
+      })
       setStatus('success')
       form.reset()
     } catch (err) {

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -72,7 +72,7 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
 
   return (
     <section className="pt-16 pb-12 md:pt-24 md:pb-16">
-      <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-14 lg:grid-cols-[1.6fr_1fr] lg:items-start">
+      <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-14 lg:grid-cols-[1.35fr_1fr] lg:items-start">
         <div>
           <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
             Applied AI · WorkOS
@@ -161,7 +161,7 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
               src="https://zackproser.b-cdn.net/images/zack-sketch.webp"
               alt="Portrait of Zachary Proser"
               fill
-              sizes="(max-width: 1024px) 80vw, 340px"
+              sizes="(max-width: 1024px) 80vw, 440px"
               className="editorial-portrait-image"
               priority
             />
@@ -414,8 +414,16 @@ function ColophonFooter() {
           </div>
         </div>
         <div className="editorial-colophon-rule text-parchment-600 dark:text-slate-500">
-          <div>© MMXXVI Zachary Proser · Set in Source Serif 4 &amp; JetBrains Mono</div>
-          <div>Built with Next.js · Hosted on Vercel</div>
+          <div>
+            <span className="text-burnt-400 dark:text-amber-400">●</span>{' '}
+            Currently: Applied AI @ WorkOS · Open to{' '}
+            <Link href="/speaking" className="underline decoration-dotted underline-offset-4 hover:text-burnt-400 dark:hover:text-amber-400">workshops</Link>
+            {' '}and{' '}
+            <Link href="/contact" className="underline decoration-dotted underline-offset-4 hover:text-burnt-400 dark:hover:text-amber-400">retainers</Link>
+          </div>
+          <div>
+            <Link href="/contact" className="hover:text-burnt-400 dark:hover:text-amber-400">Get in touch →</Link>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -52,7 +52,7 @@ function EditorialHero({ onConsult }: { onConsult: () => void }) {
       if (!response.ok) {
         throw new Error(data?.data || 'Failed to subscribe')
       }
-      track('newsletter_subscribe_submit', { location: 'hero' })
+      track('newsletter-signup', { location: 'hero' })
       sendGTMEvent({
         event: 'newsletter-signup-conversion',
         method: 'newsletter',

--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -7,6 +7,7 @@ import type { Route } from 'next'
 import { track } from '@vercel/analytics'
 import { sendGTMEvent } from '@next/third-parties/google'
 import { EditorialCard } from '@/components/EditorialCard'
+import { SectionHead } from '@/components/SectionHead'
 import ConsultationForm from '@/components/ConsultationForm'
 import type { Content } from '@/types/content'
 
@@ -304,32 +305,7 @@ function FeaturedProject() {
   )
 }
 
-// ----- Section head + Content rail ----------------------------------
-
-function SectionHead({
-  num,
-  title,
-  moreHref,
-  moreLabel = 'Archive →',
-}: {
-  num: string
-  title: string
-  moreHref: string
-  moreLabel?: string
-}) {
-  return (
-    <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
-      <div className="editorial-section-num">§ {num}</div>
-      <h2 className="editorial-section-title">{title}</h2>
-      <Link
-        href={moreHref as Route}
-        className="editorial-section-more text-burnt-400 dark:text-amber-400 hover:underline"
-      >
-        {moreLabel}
-      </Link>
-    </header>
-  )
-}
+// ----- Content rail ----------------------------------
 
 function ContentRail({
   num,

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -135,7 +135,7 @@ export default function About() {
                 software development experience at top startups and established
                 enterprise companies. Currently a Developer Experience Engineer
                 at{' '}
-                <Link href="/blog" className="text-burnt-400 dark:text-amber-400 hover:underline">
+                <Link href="https://workos.com" className="text-burnt-400 dark:text-amber-400 hover:underline">
                   WorkOS
                 </Link>
                 , where we help companies add enterprise features to their apps
@@ -227,7 +227,7 @@ export default function About() {
             <div className="prose-editorial text-[17px] leading-[1.7] text-charcoal-50 dark:text-parchment-100 space-y-5 mt-6">
               <p className="first-letter:float-left first-letter:font-serif first-letter:text-[64px] first-letter:leading-[0.9] first-letter:mr-2 first-letter:mt-1 first-letter:text-burnt-400 dark:first-letter:text-amber-400">
                 I&apos;m a Developer Experience Engineer at{' '}
-                <Link href="/blog" className="underline decoration-burnt-400/40 hover:decoration-burnt-400 dark:decoration-amber-400/40 dark:hover:decoration-amber-400">
+                <Link href="https://workos.com" className="underline decoration-burnt-400/40 hover:decoration-burnt-400 dark:decoration-amber-400/40 dark:hover:decoration-amber-400">
                   WorkOS
                 </Link>
                 . Before that I did developer-education and staff developer-

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -1,144 +1,415 @@
-import Head from "next/head";
-import { Suspense } from "react";
-import Link from "next/link";
-import { Container } from "@/components/Container";
-import Newsletter from "@/components/NewsletterWrapper";
-import CV from "@/components/CV";
+import { Suspense } from "react"
+import Link from "next/link"
+import Image from "next/image"
+import Newsletter from "@/components/NewsletterWrapper"
 import {
-	GitHubIcon,
-	InstagramIcon,
-	LinkedInIcon,
-	TwitterIcon,
-	YouTubeIcon,
-	SocialLink,
-} from "@/components/SocialIcons";
-import { MailIcon } from '@/components/icons'
-import RenderNumYearsExperience from "@/components/NumYearsExperience";
-import RandomPortrait from '@/components/RandomPortrait'
-import { generateOgUrl } from "@/utils/ogUrl";
+  GitHubIcon,
+  InstagramIcon,
+  LinkedInIcon,
+  TwitterIcon,
+  YouTubeIcon,
+  SocialLink,
+} from "@/components/SocialIcons"
+import { MailIcon } from "@/components/icons"
+import RenderNumYearsExperience from "@/components/NumYearsExperience"
+import RandomPortrait from "@/components/RandomPortrait"
+import { generateOgUrl } from "@/utils/ogUrl"
 
 const data = {
-    title: "About Zachary Proser",
-    description:
-        "Full-stack open-source hacker, technical writer, and Developer Experience Engineer.",
-};
+  title: "About Zachary Proser",
+  description:
+    "Full-stack open-source hacker, technical writer, and Developer Experience Engineer at WorkOS.",
+}
 
-const ogUrl = generateOgUrl(data);
+const ogUrl = generateOgUrl(data)
 
 export const metadata = {
   title: data.title,
   description: data.description,
   alternates: { canonical: "https://zackproser.com/about" },
-	openGraph: {
-		title: data.title,
-		description: data.description,
-		url: ogUrl,
-		siteName: "Modern Coding",
-		images: [
-			{
-				url: ogUrl,
-			},
-		],
-		locale: "en_US",
-		type: "website",
-	},
-};
+  openGraph: {
+    title: data.title,
+    description: data.description,
+    url: ogUrl,
+    siteName: "Modern Coding",
+    images: [{ url: ogUrl }],
+    locale: "en_US",
+    type: "website",
+  },
+}
+
+// Career history — single source is CV.jsx. Replicated here so the
+// timeline can render without the CV tile's chrome.
+const resume = [
+  {
+    company: "WorkOS",
+    title: "Developer Experience Engineer",
+    logo: "https://zackproser.b-cdn.net/images/logos/workos.svg",
+    start: "2025",
+    end: "Present",
+    blurb:
+      "Applied AI work on developer-facing products. Retrieval, agent harnesses, and the writing that helps teams adopt them.",
+  },
+  {
+    company: "WorkOS",
+    title: "Developer Education",
+    logo: "https://zackproser.b-cdn.net/images/logos/workos.svg",
+    start: "2024",
+    end: "2025",
+    blurb:
+      "Built and led the developer-education surface at WorkOS — documentation, workshops, and video.",
+  },
+  {
+    company: "Pinecone.io",
+    title: "Staff Developer Advocate",
+    logo: "https://zackproser.b-cdn.net/images/logos/pinecone-logo.png",
+    start: "2023",
+    end: "2024",
+    blurb:
+      "Designed the RAG reference architectures and tutorials that thousands of teams used to go from embeddings to a shipped retrieval system.",
+  },
+  {
+    company: "Gruntwork.io",
+    title: "Tech Lead",
+    logo: "https://zackproser.b-cdn.net/images/logos/grunty.png",
+    start: "2020",
+    end: "2023",
+    blurb:
+      "Wrote, maintained, and open-sourced Terraform modules used by hundreds of companies to run their AWS infrastructure.",
+  },
+  {
+    company: "Cloudflare",
+    title: "Senior Software Engineer",
+    logo: "https://zackproser.b-cdn.net/images/logos/cloudflare.svg",
+    start: "2017",
+    end: "2020",
+    blurb:
+      "Built and shipped developer-tooling features used by hundreds of thousands of developers per month.",
+  },
+  {
+    company: "Cloudmark",
+    title: "Software Engineer",
+    logo: "https://zackproser.b-cdn.net/images/logos/cloudmark.png",
+    start: "2015",
+    end: "2017",
+  },
+  {
+    company: "BrightContext",
+    title: "Software Engineer",
+    logo: "https://zackproser.b-cdn.net/images/logos/brightcontext.png",
+    start: "2012",
+    end: "2014",
+  },
+]
+
+const pressLogos = [
+  "Pinecone",
+  "Cloudflare",
+  "Gruntwork",
+  "WorkOS",
+  "DevSecCon",
+  "AI Engineering",
+]
 
 export default function About() {
-	return (
-		<>
-			<Head>
-				<title>About - Zachary Proser</title>
-                <meta
-                    name="description"
-                    content="I&apos;m Zachary Proser, a Developer Experience Engineer at WorkOS, open-source developer, and technical writer"
-                />
-			</Head>
-			<Container className="mt-16 sm:mt-32">
-				<div className="grid grid-cols-1 gap-y-16 lg:grid-cols-2 lg:grid-rows-[auto_1fr] lg:gap-y-12">
-					<div className="lg:pl-20">
-						<div className="max-w-xs px-2.5 lg:max-w-none">
-							<Suspense>
-								<RandomPortrait width={600} height={600} />
-							</Suspense>
-						</div>
-					</div>
-					<div className="lg:order-first lg:row-span-2">
-						<h1 className="text-4xl font-bold tracking-tight text-charcoal-50 dark:text-slate-100 sm:text-5xl font-serif">
-							Hi, I&apos;m Zachary
-						</h1>
-						<div className="mt-6 space-y-7 text-base text-parchment-600 dark:text-slate-300">
-							<p>
-								I&apos;m a full-stack open source hacker with{" "}
-								<span className="text-burnt-400 dark:text-sky-400 font-bold">
-									{RenderNumYearsExperience()} years
-								</span>{" "}
-								of software development experience at top startups and established enterprise companies.
-							</p>
-							<p>
-								<Link className="text-burnt-400 dark:text-sky-400 hover:text-amber-900 dark:hover:text-sky-300" href="/testimonials">See what my colleagues say</Link> about working with me.
-							</p>
-                            <p>
-                                I&apos;m a Developer Experience Engineer at{" "}
-                                <Link
-                                    className="font-bold text-burnt-400 dark:text-sky-400"
-                                    href="https://workos.com"
-                                >
-                                    WorkOS
-                                </Link>
-                                , where we help companies add enterprise features to their apps in minutes, not months.
-                            </p>
-							<p>
-								I offer <Link className="font-bold text-burnt-400 dark:text-sky-400" href="/services">specialized AI engineering services</Link> focusing on production-ready Next.js applications with vector database integration. Check out my <Link className="font-bold text-burnt-400 dark:text-sky-400" href="/services">services page</Link> to learn how I can help bring your AI project to life.
-							</p>
-							<Newsletter />
-							<p>
-								Looking to level up your business with AI? Check out my guide to the <Link className="font-bold text-burnt-400 dark:text-sky-400" href="/best-ai-tools">best AI tools for small business owners</Link>—the exact stack I use daily.
-							</p>
-							<p>Want to know what it&apos;s like to work with me? Read <Link className="text-burnt-400 dark:text-sky-400 font-bold" href="/testimonials">testimonials from past colleagues and clients</Link> who share their experiences.</p>
-							<div className="mt-8">
-								<CV />
-							</div>
-						</div>
-					</div>
-					<div className="lg:pl-20">
-						<ul role="list" className="space-y-4">
-							<SocialLink href="https://twitter.com/zackproser" icon={TwitterIcon}>
-								Follow on Twitter
-							</SocialLink>
-							<SocialLink href="https://youtube.com/@zackproser" icon={YouTubeIcon}>
-								Subscribe to my YouTube channel
-							</SocialLink>
-							<SocialLink href="https://instagram.com/zackproser" icon={InstagramIcon}>
-								Follow me on Instagram
-							</SocialLink>
-							<SocialLink href="https://github.com/zackproser" icon={GitHubIcon}>
-								Follow on GitHub
-							</SocialLink>
-							<SocialLink href="https://linkedin.com/in/zackproser" icon={LinkedInIcon}>
-								Follow on LinkedIn
-							</SocialLink>
-							<SocialLink
-								href="mailto:zackproser@gmail.com"
-								icon={MailIcon}
-							>
-								zackproser@gmail.com
-							</SocialLink>
-						</ul>
-						<div className="mt-8">
-							<Link
-								href="/services"
-								className="inline-flex items-center px-4 py-2 bg-burnt-400 hover:bg-burnt-500 dark:bg-sky-500 dark:hover:bg-sky-400 text-white font-medium rounded-md transition-colors"
-							>
-								View My Services
-								<svg className="ml-2 -mr-1 w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
-								</svg>
-							</Link>
-						</div>
-					</div>
-				</div>
-			</Container>
-		</>
-	);
+  const years = RenderNumYearsExperience()
+
+  return (
+    <div className="editorial-home flex flex-col min-h-screen text-charcoal-50 dark:text-parchment-100 theme-transition">
+      <main className="flex-1">
+        {/* ----- Hero ----- */}
+        <section className="pt-14 pb-12 md:pt-20 md:pb-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-10 lg:grid-cols-[1.35fr_1fr] lg:items-start">
+            <div>
+              <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
+                <Link href="/" className="hover:text-burnt-400 dark:hover:text-amber-400">Home</Link>
+                <span className="mx-2 opacity-40">/</span>
+                <span>About</span>
+              </div>
+              <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
+                Hi, I&apos;m{' '}
+                <span className="text-burnt-400 dark:text-amber-400">Zachary</span>.
+              </h1>
+              <p className="editorial-lede text-parchment-600 dark:text-slate-300">
+                I&apos;m a full-stack open-source hacker with {years} years of
+                software development experience at top startups and established
+                enterprise companies. Currently a Developer Experience Engineer
+                at{' '}
+                <Link href="/blog" className="text-burnt-400 dark:text-amber-400 hover:underline">
+                  WorkOS
+                </Link>
+                , where we help companies add enterprise features to their apps
+                in minutes, not months.
+              </p>
+              <div className="editorial-secondary text-parchment-600 dark:text-slate-400 mt-6">
+                <a href="#work">Work history →</a>
+                <span>·</span>
+                <Link href="/blog">Writing →</Link>
+                <span>·</span>
+                <Link href="/testimonials">Testimonials →</Link>
+                <span>·</span>
+                <Link href="/contact">Say hello →</Link>
+              </div>
+              <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
+                <dt>Currently</dt>
+                <dd>Developer Experience Engineer · WorkOS</dd>
+                <dt>Formerly</dt>
+                <dd>Pinecone · Cloudflare · Gruntwork</dd>
+                <dt>Writes</dt>
+                <dd>
+                  <Link href="/newsletter" className="hover:text-burnt-400 dark:hover:text-amber-400">
+                    The Modern Coding letter
+                  </Link>
+                  {' '}— read by 5,000+ engineers
+                </dd>
+              </dl>
+            </div>
+
+            <div className="lg:justify-self-end">
+              <div className="editorial-portrait" style={{ maxWidth: 440 }}>
+                <Suspense>
+                  <RandomPortrait width={600} height={600} />
+                </Suspense>
+              </div>
+              <div className="editorial-portrait-caption text-parchment-600 dark:text-slate-400">
+                Plate I · Applied AI · MMXXVI
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ----- Stats ----- */}
+        <section className="pb-10">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <div className="editorial-stats text-charcoal-50 dark:text-parchment-100">
+              <div className="editorial-stat">
+                <div className="editorial-stat-num">
+                  {years}<span className="unit">yrs</span>
+                </div>
+                <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                  Shipping software
+                </div>
+              </div>
+              <div className="editorial-stat">
+                <div className="editorial-stat-num">
+                  5,000<span className="unit">+</span>
+                </div>
+                <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                  Newsletter readers
+                </div>
+              </div>
+              <div className="editorial-stat">
+                <div className="editorial-stat-num">
+                  6<span className="unit">cos</span>
+                </div>
+                <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                  Companies shipped at
+                </div>
+              </div>
+              <div className="editorial-stat">
+                <div className="editorial-stat-num">
+                  1<span className="unit">focus</span>
+                </div>
+                <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                  Making AI survive production
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ----- § 01 Bio ----- */}
+        <section className="py-12">
+          <div className="container mx-auto max-w-3xl px-4 md:px-6">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              § 01 · Biography
+            </div>
+            <div className="prose-editorial text-[17px] leading-[1.7] text-charcoal-50 dark:text-parchment-100 space-y-5 mt-6">
+              <p className="first-letter:float-left first-letter:font-serif first-letter:text-[64px] first-letter:leading-[0.9] first-letter:mr-2 first-letter:mt-1 first-letter:text-burnt-400 dark:first-letter:text-amber-400">
+                I&apos;m a Developer Experience Engineer at{' '}
+                <Link href="/blog" className="underline decoration-burnt-400/40 hover:decoration-burnt-400 dark:decoration-amber-400/40 dark:hover:decoration-amber-400">
+                  WorkOS
+                </Link>
+                . Before that I did developer-education and staff developer-
+                advocacy work at Pinecone, senior engineering at Cloudflare, and
+                tech-lead work at Gruntwork. {years} years in production,
+                mostly building the thing underneath the thing.
+              </p>
+              <p>
+                I offer{' '}
+                <Link href="/services" className="underline decoration-burnt-400/40 hover:decoration-burnt-400 dark:decoration-amber-400/40 dark:hover:decoration-amber-400">
+                  specialized AI engineering services
+                </Link>
+                {' '}focused on production-ready Next.js apps with vector-database
+                integration. If your team was handed an LLM and a deadline, I
+                can help you ship a RAG pipeline, an agent harness, or the evals
+                that tell you whether any of it works.
+              </p>
+              <p>
+                I&apos;ve been writing online since I was fifteen. The form has
+                changed — blogs, newsletters, this site — but the reason
+                hasn&apos;t. Writing is the only way I know to verify that I
+                actually understand something. The{' '}
+                <Link href="/newsletter" className="underline decoration-burnt-400/40 hover:decoration-burnt-400 dark:decoration-amber-400/40 dark:hover:decoration-amber-400">
+                  Modern Coding letter
+                </Link>
+                {' '}is read by 5,000+ engineers and is where most of what I
+                publish ends up first.
+              </p>
+              <p>
+                Want to know what it&apos;s like to work with me? Read{' '}
+                <Link href="/testimonials" className="underline decoration-burnt-400/40 hover:decoration-burnt-400 dark:decoration-amber-400/40 dark:hover:decoration-amber-400">
+                  testimonials from past colleagues and clients
+                </Link>
+                . Or check my guide to the{' '}
+                <Link href="/best-ai-tools" className="underline decoration-burnt-400/40 hover:decoration-burnt-400 dark:decoration-amber-400/40 dark:hover:decoration-amber-400">
+                  best AI tools for small business owners
+                </Link>
+                {' '}— the exact stack I use daily.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ----- § 02 Work history ----- */}
+        <section id="work" className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-4xl px-4 md:px-6">
+            <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
+              <div className="editorial-section-num">§ 02</div>
+              <h2 className="editorial-section-title">Where I&apos;ve worked</h2>
+              <a
+                href="https://linkedin.com/in/zackproser"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="editorial-section-more text-burnt-400 dark:text-amber-400 hover:underline"
+              >
+                LinkedIn →
+              </a>
+            </header>
+
+            <ol className="space-y-6">
+              {resume.map((role) => (
+                <li
+                  key={`${role.company}-${role.start}`}
+                  className="grid grid-cols-[120px_1fr] md:grid-cols-[160px_1fr] gap-6 pb-6 border-b border-parchment-300/40 dark:border-slate-700/40 last:border-b-0"
+                >
+                  <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400 pt-1">
+                    <div>{role.start} — {role.end}</div>
+                    <div className="mt-3 w-8 h-8 relative opacity-80">
+                      <Image
+                        src={role.logo}
+                        alt={role.company}
+                        fill
+                        className="object-contain"
+                        unoptimized
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div className="font-serif text-xl font-bold leading-tight text-charcoal-50 dark:text-parchment-100">
+                      {role.title}{' '}
+                      <span className="text-burnt-400 dark:text-amber-400">
+                        at {role.company}
+                      </span>
+                    </div>
+                    {role.blurb ? (
+                      <p className="mt-2 text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300">
+                        {role.blurb}
+                      </p>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        {/* ----- § 03 Written & spoken at ----- */}
+        <section className="py-12">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              § 03 · Written &amp; spoken at
+            </div>
+            <div className="flex flex-wrap gap-x-8 gap-y-4 font-serif text-xl md:text-2xl text-parchment-600 dark:text-slate-400">
+              {pressLogos.map((name) => (
+                <span key={name} className="opacity-70 hover:opacity-100 transition-opacity">
+                  {name}
+                </span>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ----- § 04 Elsewhere ----- */}
+        <section className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-4xl px-4 md:px-6">
+            <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
+              <div className="editorial-section-num">§ 04</div>
+              <h2 className="editorial-section-title">Elsewhere on the internet</h2>
+              <span />
+            </header>
+
+            <ul role="list" className="grid gap-3 md:grid-cols-2">
+              <SocialLink href="https://twitter.com/zackproser" icon={TwitterIcon}>
+                Follow on Twitter
+              </SocialLink>
+              <SocialLink href="https://youtube.com/@zackproser" icon={YouTubeIcon}>
+                Subscribe on YouTube
+              </SocialLink>
+              <SocialLink href="https://github.com/zackproser" icon={GitHubIcon}>
+                Follow on GitHub
+              </SocialLink>
+              <SocialLink href="https://linkedin.com/in/zackproser" icon={LinkedInIcon}>
+                Connect on LinkedIn
+              </SocialLink>
+              <SocialLink href="https://instagram.com/zackproser" icon={InstagramIcon}>
+                Follow on Instagram
+              </SocialLink>
+              <SocialLink href="mailto:zackproser@gmail.com" icon={MailIcon}>
+                zackproser@gmail.com
+              </SocialLink>
+            </ul>
+          </div>
+        </section>
+
+        {/* ----- Newsletter ----- */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-3xl px-4 md:px-6">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              The Modern Coding letter
+            </div>
+            <Newsletter />
+          </div>
+        </section>
+
+        {/* ----- CTA ----- */}
+        <section className="py-16 editorial-section-alt">
+          <div className="container mx-auto max-w-4xl px-4 md:px-6 text-center">
+            <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
+              Say hello
+            </div>
+            <h2 className="font-serif text-3xl md:text-4xl font-bold leading-tight tracking-tight mt-4 text-charcoal-50 dark:text-parchment-100">
+              Consulting enquiries, speaking invitations, and the occasional
+              note of pure curiosity all reach me the{' '}
+              <span className="text-burnt-400 dark:text-amber-400">same way</span>.
+            </h2>
+            <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href="/contact"
+                className="inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors"
+              >
+                Email me →
+              </Link>
+              <Link
+                href="/services"
+                className="inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-md border border-parchment-400 dark:border-slate-600 text-charcoal-50 dark:text-parchment-100 hover:border-burnt-400 dark:hover:border-amber-400 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors"
+              >
+                View my services →
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
 }

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -1,18 +1,8 @@
-import { Suspense } from "react"
 import Link from "next/link"
 import Image from "next/image"
-import Newsletter from "@/components/NewsletterWrapper"
-import {
-  GitHubIcon,
-  InstagramIcon,
-  LinkedInIcon,
-  TwitterIcon,
-  YouTubeIcon,
-  SocialLink,
-} from "@/components/SocialIcons"
-import { MailIcon } from "@/components/icons"
+import { EditorialNewsletter } from "@/components/EditorialNewsletter"
+import { Twitter, Youtube, Github, Linkedin, Instagram, Mail } from "lucide-react"
 import RenderNumYearsExperience from "@/components/NumYearsExperience"
-import RandomPortrait from "@/components/RandomPortrait"
 import { generateOgUrl } from "@/utils/ogUrl"
 import { resumeData } from "@/data/resume"
 
@@ -120,9 +110,14 @@ export default function About() {
 
             <div className="lg:justify-self-end">
               <div className="editorial-portrait" style={{ maxWidth: 440 }}>
-                <Suspense>
-                  <RandomPortrait width={600} height={600} />
-                </Suspense>
+                <Image
+                  src="https://zackproser.b-cdn.net/images/zack-sketch.webp"
+                  alt="Portrait of Zachary Proser"
+                  fill
+                  sizes="(max-width: 1024px) 80vw, 440px"
+                  className="editorial-portrait-image"
+                  priority
+                />
               </div>
               <div className="editorial-portrait-caption text-parchment-600 dark:text-slate-400">
                 Plate I · Applied AI · MMXXVI
@@ -185,8 +180,14 @@ export default function About() {
                 </Link>
                 . Before that I did developer-education and staff developer-
                 advocacy work at Pinecone, senior engineering at Cloudflare, and
-                tech-lead work at Gruntwork. {years} years in production,
-                mostly building the thing underneath the thing.
+                tech-lead work at Gruntwork. {years} years in production as a
+                full-stack engineer — databases, backends, middleware, and
+                frontends — with a deep love for{' '}
+                <span className="text-burnt-400 dark:text-amber-400 font-semibold">
+                  infrastructure-as-code and cloud systems
+                </span>
+                . I&apos;ll happily write the migration, the API, the React,
+                and the Terraform module that deploys it.
               </p>
               <p>
                 I offer{' '}
@@ -303,35 +304,44 @@ export default function About() {
             </header>
 
             <ul role="list" className="grid gap-3 md:grid-cols-2">
-              <SocialLink href="https://twitter.com/zackproser" icon={TwitterIcon}>
-                Follow on Twitter
-              </SocialLink>
-              <SocialLink href="https://youtube.com/@zackproser" icon={YouTubeIcon}>
-                Subscribe on YouTube
-              </SocialLink>
-              <SocialLink href="https://github.com/zackproser" icon={GitHubIcon}>
-                Follow on GitHub
-              </SocialLink>
-              <SocialLink href="https://linkedin.com/in/zackproser" icon={LinkedInIcon}>
-                Connect on LinkedIn
-              </SocialLink>
-              <SocialLink href="https://instagram.com/zackproser" icon={InstagramIcon}>
-                Follow on Instagram
-              </SocialLink>
-              <SocialLink href="mailto:zackproser@gmail.com" icon={MailIcon}>
-                zackproser@gmail.com
-              </SocialLink>
+              {[
+                { href: 'https://twitter.com/zackproser', icon: Twitter, label: 'Follow on Twitter', handle: '@zackproser' },
+                { href: 'https://youtube.com/@zackproser', icon: Youtube, label: 'Subscribe on YouTube', handle: '@zackproser' },
+                { href: 'https://github.com/zackproser', icon: Github, label: 'Follow on GitHub', handle: 'zackproser' },
+                { href: 'https://linkedin.com/in/zackproser', icon: Linkedin, label: 'Connect on LinkedIn', handle: 'in/zackproser' },
+                { href: 'https://instagram.com/zackproser', icon: Instagram, label: 'Follow on Instagram', handle: '@zackproser' },
+                { href: 'mailto:zackproser@gmail.com', icon: Mail, label: 'Email', handle: 'zackproser@gmail.com' },
+              ].map(({ href, icon: Icon, label, handle }) => (
+                <li key={href}>
+                  <a
+                    href={href}
+                    target={href.startsWith('http') ? '_blank' : undefined}
+                    rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
+                    className="group flex items-center gap-4 px-4 py-3 rounded-sm border border-parchment-300 dark:border-slate-700 bg-parchment-50 dark:bg-slate-800/60 hover:border-burnt-400 dark:hover:border-amber-400 transition-colors"
+                  >
+                    <Icon className="h-5 w-5 text-burnt-400 dark:text-amber-400 flex-none" strokeWidth={1.5} />
+                    <div className="flex-1 min-w-0">
+                      <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+                        {label}
+                      </div>
+                      <div className="font-serif text-[15px] font-semibold text-charcoal-50 dark:text-parchment-100 truncate group-hover:text-burnt-400 dark:group-hover:text-amber-400 transition-colors">
+                        {handle}
+                      </div>
+                    </div>
+                    <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500 group-hover:text-burnt-400 dark:group-hover:text-amber-400 transition-colors">
+                      →
+                    </span>
+                  </a>
+                </li>
+              ))}
             </ul>
           </div>
         </section>
 
         {/* ----- Newsletter ----- */}
         <section className="py-14">
-          <div className="container mx-auto max-w-3xl px-4 md:px-6">
-            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
-              The Modern Coding letter
-            </div>
-            <Newsletter />
+          <div className="container mx-auto max-w-2xl px-4 md:px-6">
+            <EditorialNewsletter location="about" />
           </div>
         </section>
 

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -14,6 +14,7 @@ import { MailIcon } from "@/components/icons"
 import RenderNumYearsExperience from "@/components/NumYearsExperience"
 import RandomPortrait from "@/components/RandomPortrait"
 import { generateOgUrl } from "@/utils/ogUrl"
+import { resumeData } from "@/data/resume"
 
 const data = {
   title: "About Zachary Proser",
@@ -38,69 +39,21 @@ export const metadata = {
   },
 }
 
-// Career history — single source is CV.jsx. Replicated here so the
-// timeline can render without the CV tile's chrome.
-const resume = [
-  {
-    company: "WorkOS",
-    title: "Developer Experience Engineer",
-    logo: "https://zackproser.b-cdn.net/images/logos/workos.svg",
-    start: "2025",
-    end: "Present",
-    blurb:
-      "Applied AI work on developer-facing products. Retrieval, agent harnesses, and the writing that helps teams adopt them.",
-  },
-  {
-    company: "WorkOS",
-    title: "Developer Education",
-    logo: "https://zackproser.b-cdn.net/images/logos/workos.svg",
-    start: "2024",
-    end: "2025",
-    blurb:
-      "Built and led the developer-education surface at WorkOS — documentation, workshops, and video.",
-  },
-  {
-    company: "Pinecone.io",
-    title: "Staff Developer Advocate",
-    logo: "https://zackproser.b-cdn.net/images/logos/pinecone-logo.png",
-    start: "2023",
-    end: "2024",
-    blurb:
-      "Designed the RAG reference architectures and tutorials that thousands of teams used to go from embeddings to a shipped retrieval system.",
-  },
-  {
-    company: "Gruntwork.io",
-    title: "Tech Lead",
-    logo: "https://zackproser.b-cdn.net/images/logos/grunty.png",
-    start: "2020",
-    end: "2023",
-    blurb:
-      "Wrote, maintained, and open-sourced Terraform modules used by hundreds of companies to run their AWS infrastructure.",
-  },
-  {
-    company: "Cloudflare",
-    title: "Senior Software Engineer",
-    logo: "https://zackproser.b-cdn.net/images/logos/cloudflare.svg",
-    start: "2017",
-    end: "2020",
-    blurb:
-      "Built and shipped developer-tooling features used by hundreds of thousands of developers per month.",
-  },
-  {
-    company: "Cloudmark",
-    title: "Software Engineer",
-    logo: "https://zackproser.b-cdn.net/images/logos/cloudmark.png",
-    start: "2015",
-    end: "2017",
-  },
-  {
-    company: "BrightContext",
-    title: "Software Engineer",
-    logo: "https://zackproser.b-cdn.net/images/logos/brightcontext.png",
-    start: "2012",
-    end: "2014",
-  },
-]
+// Career history with additional blurbs for the about page
+const resume = resumeData.map((role) => {
+  const blurbs = {
+    'WorkOS-Developer Experience Engineer': "Applied AI work on developer-facing products. Retrieval, agent harnesses, and the writing that helps teams adopt them.",
+    'WorkOS-Developer Education': "Built and led the developer-education surface at WorkOS — documentation, workshops, and video.",
+    'Pinecone.io-Staff Developer Advocate': "Designed the RAG reference architectures and tutorials that thousands of teams used to go from embeddings to a shipped retrieval system.",
+    'Gruntwork.io-Tech Lead': "Wrote, maintained, and open-sourced Terraform modules used by hundreds of companies to run their AWS infrastructure.",
+    'Cloudflare-Senior Software Engineer': "Built and shipped developer-tooling features used by hundreds of thousands of developers per month.",
+  }
+  const key = `${role.company}-${role.title}`
+  return {
+    ...role,
+    blurb: blurbs[key],
+  }
+})
 
 const pressLogos = [
   "Pinecone",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,7 +8,7 @@ import {
   renderPaywalledContent
 } from '@/lib/content-handlers'
 import { notFound } from 'next/navigation'
-import { ArticleLayout } from '@/components/ArticleLayout'
+import { EditorialArticleLayout } from '@/components/EditorialArticleLayout'
 import React from 'react'
 import { CheckCircle } from 'lucide-react'
 import { metadataLogger as logger } from '@/utils/logger'
@@ -94,8 +94,7 @@ export default async function Page({ params }: PageProps) {
   const hideNewsletter = !!(content?.commerce?.requiresEmail && !isSubscribed)
 
   return (
-    <>
-    <ArticleLayout metadata={content} serverHasPurchased={hasPurchased} hideNewsletter={hideNewsletter}>
+    <EditorialArticleLayout metadata={content} serverHasPurchased={hasPurchased} hideNewsletter={hideNewsletter}>
       {hasPurchased ? (
         <div className="purchased-content">
           <div className="inline-flex items-center gap-2 bg-green-50 border border-green-200 rounded-full px-4 py-2 mb-6">
@@ -107,7 +106,6 @@ export default async function Page({ params }: PageProps) {
       ) : (
         renderPaywalledContent(MdxContent, content, hasPurchased, isSubscribed)
       )}
-    </ArticleLayout>
-    </>
+    </EditorialArticleLayout>
   );
-} 
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Noto_Sans, Press_Start_2P, Source_Serif_4, Inter } from 'next/font/google';
+import { Noto_Sans, Press_Start_2P, Source_Serif_4, Inter, JetBrains_Mono } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/react';
 import { GoogleTagManager } from '@next/third-parties/google';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -8,6 +8,7 @@ import { ConsultancyNav } from '@/components/ConsultancyNav';
 import { Toaster } from '@/components/ui/toaster';
 import '@/styles/tailwind.css';
 import '@/styles/global.css';
+import '@/styles/editorial-home.css';
 import PlausibleProvider from 'next-plausible';
 
 const notoSans = Noto_Sans({
@@ -22,18 +23,25 @@ const pressStart2P = Press_Start_2P({
   variable: '--font-press-start-2p',
 });
 
-// Authority glow-up fonts
+// Editorial glow-up fonts
 const sourceSerif = Source_Serif_4({
   subsets: ['latin'],
-  weight: ['400', '600', '700'],
-  variable: '--font-source-serif',
+  weight: ['400', '600', '700', '800'],
+  variable: '--font-serif',
   display: 'swap',
 });
 
 const inter = Inter({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
-  variable: '--font-inter',
+  variable: '--font-sans',
+  display: 'swap',
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-mono',
   display: 'swap',
 });
 
@@ -43,7 +51,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={`h-full antialiased ${notoSans.variable} ${pressStart2P.variable} ${sourceSerif.variable} ${inter.variable}`} suppressHydrationWarning>
+    <html lang="en" className={`h-full antialiased ${notoSans.variable} ${pressStart2P.variable} ${sourceSerif.variable} ${inter.variable} ${jetbrainsMono.variable}`} suppressHydrationWarning>
       <GoogleTagManager gtmId="GTM-K9XTVH6V" />
       <head>
         <PlausibleProvider domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN ?? 'zackproser.com'} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { ConsultancyNav } from '@/components/ConsultancyNav';
 import { Toaster } from '@/components/ui/toaster';
 import '@/styles/tailwind.css';
 import '@/styles/global.css';
+import '@/styles/editorial-home.css';
 import PlausibleProvider from 'next-plausible';
 
 const notoSans = Noto_Sans({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,6 @@ import { ConsultancyNav } from '@/components/ConsultancyNav';
 import { Toaster } from '@/components/ui/toaster';
 import '@/styles/tailwind.css';
 import '@/styles/global.css';
-import '@/styles/editorial-home.css';
 import PlausibleProvider from 'next-plausible';
 
 const notoSans = Noto_Sans({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Toaster } from '@/components/ui/toaster';
 import '@/styles/tailwind.css';
 import '@/styles/global.css';
 import '@/styles/editorial-home.css';
+import '@/styles/blog-post.css';
 import PlausibleProvider from 'next-plausible';
 
 const notoSans = Noto_Sans({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { createMetadata } from '@/utils/createMetadata'
 import { getContentsByDirectorySlugs } from '@/lib/content-handlers'
 import HomepageClientComponent from './HomepageClientComponent'
 import { Metadata } from 'next'
+import '@/styles/editorial-home.css'
 
 export const dynamic = 'force-dynamic'
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,12 +71,6 @@ export default async function Page() {
     console.log(`- Career Advice: ${careerAdvice.length}/${careerAdviceSlugs.length}`)
     console.log(`- Videos: ${videos.length}/${videoSlugs.length}`)
 
-    // Server-side mobile detection
-    const headersList = await headers()
-    const userAgent = headersList.get('user-agent') || ''
-    const parser = new UAParser(userAgent)
-    const isMobile = parser.getDevice().type === 'mobile'
-
     return (
       <HomepageClientComponent
         deepMLTutorials={deepMLTutorials}
@@ -85,7 +79,6 @@ export default async function Page() {
         refArchitectures={refArchitectures}
         careerAdvice={careerAdvice}
         videos={videos}
-        isMobile={isMobile}
       />
     )
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import { createMetadata } from '@/utils/createMetadata'
 import { getContentsByDirectorySlugs } from '@/lib/content-handlers'
 import HomepageClientComponent from './HomepageClientComponent'
 import { Metadata } from 'next'
-import '@/styles/editorial-home.css'
 
 export const dynamic = 'force-dynamic'
 

--- a/src/app/speaking/page.jsx
+++ b/src/app/speaking/page.jsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import YoutubeEmbed from '@/components/YoutubeEmbed'
 import { createMetadata } from '@/utils/createMetadata'
 import { ExternalLinkButton } from '@/components/ExternalLinkButton'
+import { SectionHead } from '@/components/SectionHead'
 import { speakingEngagements, galleryImages } from './speaking-data'
 
 export const metadata = createMetadata({
@@ -46,6 +47,7 @@ function SpeakingEditorialCard({ engagement, index, prefix }) {
   const kind = engagement.type === 'internal' ? 'Internal' : 'Public'
   const href = engagement.slug ? `/speaking/${engagement.slug}` : null
   const imagePositionClass = engagement.imagePosition === 'top' ? 'object-top' : 'object-center'
+  const hasLinks = engagement.links && engagement.links.length > 0
 
   const Content = (
     <article className="editorial-card group h-full">
@@ -90,7 +92,7 @@ function SpeakingEditorialCard({ engagement, index, prefix }) {
             </span>
             <span className="editorial-card-index">{prefix}.{idx}</span>
           </div>
-          {engagement.links && engagement.links.length > 0 ? (
+          {hasLinks ? (
             <div className="flex flex-wrap gap-2 pt-2 border-t border-parchment-300/40 dark:border-slate-700/40">
               {engagement.links.map((link, i) => (
                 <ExternalLinkButton key={i} link={link} />
@@ -102,26 +104,12 @@ function SpeakingEditorialCard({ engagement, index, prefix }) {
     </article>
   )
 
-  if (!href) return Content
+  if (!href || hasLinks) return Content
 
   return (
     <Link href={href} className="block h-full">
       {Content}
     </Link>
-  )
-}
-
-function SectionHead({ num, title, moreHref, moreLabel = 'Archive →' }) {
-  return (
-    <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
-      <div className="editorial-section-num">§ {num}</div>
-      <h2 className="editorial-section-title">{title}</h2>
-      {moreHref ? (
-        <Link href={moreHref} className="editorial-section-more text-burnt-400 dark:text-amber-400 hover:underline">
-          {moreLabel}
-        </Link>
-      ) : <span />}
-    </header>
   )
 }
 

--- a/src/app/speaking/page.jsx
+++ b/src/app/speaking/page.jsx
@@ -113,9 +113,24 @@ function SpeakingEditorialCard({ engagement, index, prefix }) {
   )
 }
 
+function computeTopicCounts(engagements) {
+  const counts = new Map()
+  for (const e of engagements) {
+    for (const t of e.topics || []) {
+      counts.set(t, (counts.get(t) || 0) + 1)
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+}
+
 export default function Speaking() {
   const publicEngagements = speakingEngagements.filter(e => e.type === 'public')
   const internalEngagements = speakingEngagements.filter(e => e.type === 'internal')
+  const topicCounts = computeTopicCounts(speakingEngagements).slice(0, 14)
+  const sortedByDate = [...speakingEngagements].sort((a, b) =>
+    (b.isoDate || '').localeCompare(a.isoDate || '')
+  )
 
   return (
     <div className="editorial-home flex flex-col min-h-screen text-charcoal-50 dark:text-parchment-100 theme-transition">
@@ -125,7 +140,9 @@ export default function Speaking() {
           <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-10 lg:grid-cols-[1.35fr_1fr] lg:items-end">
             <div>
               <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
-                Speaking · Conferences · Corporate training
+                <Link href="/" className="hover:text-burnt-400 dark:hover:text-amber-400">Home</Link>
+                <span className="mx-2 opacity-40">/</span>
+                <span>Speaking</span>
               </div>
               <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
                 Talks, workshops, and trainings for teams that{' '}
@@ -173,11 +190,33 @@ export default function Speaking() {
           </div>
         </section>
 
-        {/* ----- § 01 Public engagements ----- */}
+        {/* ----- § 01 Topics I cover ----- */}
+        <section className="pb-8">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              § 01 · Topics I cover
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {topicCounts.map(([topic, n]) => (
+                <span
+                  key={topic}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-sm border border-parchment-300 dark:border-slate-600 bg-parchment-50 dark:bg-slate-800/60 text-[13px] text-charcoal-50 dark:text-parchment-100"
+                >
+                  <span>{topic}</span>
+                  <span className="font-mono text-[10px] tracking-wider text-burnt-400 dark:text-amber-400">
+                    {String(n).padStart(2, '0')}
+                  </span>
+                </span>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ----- § 02 Public engagements ----- */}
         <section className="py-14 editorial-section-alt">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
             <SectionHead
-              num="01"
+              num="02"
               title="Conference talks & public workshops"
               moreHref="/contact"
               moreLabel="Book a talk →"
@@ -221,11 +260,11 @@ export default function Speaking() {
           </div>
         </section>
 
-        {/* ----- § 02 Internal training ----- */}
+        {/* ----- § 03 Internal training ----- */}
         <section className="py-14 editorial-section-alt">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
             <SectionHead
-              num="02"
+              num="03"
               title="Corporate training & team development"
               moreHref="/ai-training"
               moreLabel="Training services →"
@@ -243,8 +282,62 @@ export default function Speaking() {
           </div>
         </section>
 
+        {/* ----- § 04 Past appearances ledger ----- */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="04"
+              title="Past appearances"
+              moreHref="/blog"
+              moreLabel="Archive →"
+            />
+            <div className="border-t border-parchment-300 dark:border-slate-700">
+              {sortedByDate.map((e) => {
+                const primaryLink = e.links?.[0]
+                const rowHref = e.slug ? `/speaking/${e.slug}` : (primaryLink?.url || null)
+                const kind = e.type === 'internal' ? 'Internal' : 'Public'
+                const RowTag = rowHref ? (rowHref.startsWith('http') ? 'a' : Link) : 'div'
+                const rowProps = rowHref
+                  ? (rowHref.startsWith('http')
+                      ? { href: rowHref, target: '_blank', rel: 'noopener noreferrer' }
+                      : { href: rowHref })
+                  : {}
+                return (
+                  <RowTag
+                    key={e.id}
+                    {...rowProps}
+                    className="grid grid-cols-[auto_1fr_auto] md:grid-cols-[110px_1.2fr_2fr_100px_90px] gap-4 py-4 border-b border-parchment-300 dark:border-slate-700 text-charcoal-50 dark:text-parchment-100 hover:bg-parchment-50/60 dark:hover:bg-slate-800/40 transition-colors group"
+                  >
+                    <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400 pt-1">
+                      {e.date}
+                    </div>
+                    <div className="font-serif text-[15px] font-semibold leading-snug">
+                      {e.event}
+                      <span className="block md:hidden font-mono text-[10px] uppercase tracking-wider text-parchment-500 dark:text-slate-500 mt-1">
+                        {e.location}
+                      </span>
+                      <span className="hidden md:block font-mono text-[10px] uppercase tracking-wider text-parchment-500 dark:text-slate-500 mt-1">
+                        {e.location}
+                      </span>
+                    </div>
+                    <div className="hidden md:block text-[14px] leading-snug text-parchment-600 dark:text-slate-300">
+                      {e.title}
+                    </div>
+                    <div className="hidden md:block font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400 pt-1">
+                      {kind}
+                    </div>
+                    <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-burnt-400 dark:text-amber-400 pt-1 text-right group-hover:underline">
+                      {rowHref ? 'Open →' : ''}
+                    </div>
+                  </RowTag>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+
         {/* ----- CTA ----- */}
-        <section className="py-20">
+        <section className="py-20 editorial-section-alt">
           <div className="container mx-auto max-w-4xl px-4 md:px-6 text-center">
             <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400 justify-center">
               Looking for a speaker?

--- a/src/app/speaking/page.jsx
+++ b/src/app/speaking/page.jsx
@@ -1,10 +1,8 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import YoutubeEmbed from '@/components/YoutubeEmbed'
-import { SimpleLayout } from '@/components/SimpleLayout'
 import { createMetadata } from '@/utils/createMetadata'
 import { ExternalLinkButton } from '@/components/ExternalLinkButton'
-import { ExternalLink, Calendar, Users, Building2, Youtube, Link as LinkIcon, Mic, Presentation, GraduationCap, Play } from 'lucide-react'
 import { speakingEngagements, galleryImages } from './speaking-data'
 
 export const metadata = createMetadata({
@@ -43,196 +41,248 @@ export const metadata = createMetadata({
   ]
 });
 
+function SpeakingEditorialCard({ engagement, index, prefix }) {
+  const idx = String(index).padStart(2, '0')
+  const kind = engagement.type === 'internal' ? 'Internal' : 'Public'
+  const href = engagement.slug ? `/speaking/${engagement.slug}` : null
+  const imagePositionClass = engagement.imagePosition === 'top' ? 'object-top' : 'object-center'
 
-// Component for a single speaking engagement card
-function SpeakingCard({ engagement }) {
-  const imagePositionClass = engagement.imagePosition === 'top' ? 'object-top' : 'object-center';
-
-  return (
-    <div className="bg-parchment-50 dark:bg-slate-800 rounded-lg shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden">
-      {/* Image */}
-      <Link href={engagement.slug ? `/speaking/${engagement.slug}` : '#'} className={engagement.slug ? '' : 'pointer-events-none'}>
-        <div className="relative h-48 bg-gradient-to-br from-burnt-400 to-burnt-500 dark:from-amber-500 dark:to-amber-600">
-          <Image src={engagement.image}
+  const Content = (
+    <article className="editorial-card group h-full">
+      <div className="editorial-card-link">
+        <div className="editorial-card-meta flex items-center justify-between">
+          <span>{prefix}{idx} · {kind}</span>
+          {engagement.slidevUrl ? (
+            <span className="text-burnt-400 dark:text-amber-400">Interactive deck</span>
+          ) : null}
+        </div>
+        <div className="editorial-card-media">
+          <Image
+            src={engagement.image}
             alt={engagement.title}
             fill
-            className={`object-cover ${imagePositionClass}`}
-           />
-          {/* Badge for internal vs public */}
-          <div className="absolute top-4 left-4 flex gap-2">
-            <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${
-              engagement.type === 'internal'
-                ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/20 dark:text-amber-400'
-                : 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400'
-            }`}>
-              {engagement.type === 'internal' ? <Building2 className="h-3 w-3" /> : <Users className="h-3 w-3" />}
-              {engagement.type === 'internal' ? 'Internal' : 'Public'}
-            </span>
-            {engagement.slidevUrl && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900/20 dark:text-indigo-400">
-                <Play className="h-3 w-3" />
-                Interactive Deck
-              </span>
-            )}
-          </div>
-
+            sizes="(max-width: 768px) 100vw, 50vw"
+            className={`editorial-card-image ${imagePositionClass}`}
+          />
+          <div className="editorial-card-rule" />
         </div>
-      </Link>
-
-      {/* Content */}
-      <div className="p-6">
-        <div className="flex items-center gap-2 text-sm text-parchment-500 dark:text-slate-400 mb-2">
-          <Calendar className="h-4 w-4" />
-          {engagement.date}
-        </div>
-        
-        {engagement.slug ? (
-          <Link href={`/speaking/${engagement.slug}`}>
-            <h3 className="text-xl font-bold text-charcoal-50 dark:text-slate-100 mb-2 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors">
-              {engagement.title}
-            </h3>
-          </Link>
-        ) : (
-          <h3 className="text-xl font-bold text-charcoal-50 dark:text-slate-100 mb-2">
-            {engagement.title}
-          </h3>
-        )}
-        
-        <p className="text-burnt-400 dark:text-amber-400 font-medium mb-3">
-          {engagement.event}
-        </p>
-        
-        <p className="text-parchment-600 dark:text-slate-300 mb-4 line-clamp-3">
-          {engagement.description}
-        </p>
-
-        {/* Details */}
-        <div className="space-y-2 mb-4 text-sm">
-          <div className="flex items-center gap-2 text-parchment-500 dark:text-slate-400">
-            <Users className="h-4 w-4" />
-            <span>{engagement.audience}</span>
+        <div className="editorial-card-body">
+          <div className="editorial-card-date">
+            {engagement.date} · {engagement.event}
           </div>
-          <div className="text-parchment-500 dark:text-slate-400">
-            📍 {engagement.location}
-          </div>
-        </div>
-
-        {/* Topics */}
-        <div className="mb-4">
-          <div className="flex flex-wrap gap-2">
-            {engagement.topics.map((topic, index) => (
+          <h3 className="editorial-card-title">{engagement.title}</h3>
+          {engagement.description ? (
+            <p className="editorial-card-desc">{engagement.description}</p>
+          ) : null}
+          <div className="flex flex-wrap gap-1.5 mt-1">
+            {engagement.topics.slice(0, 4).map((topic) => (
               <span
-                key={index}
-                className="inline-block px-2 py-1 bg-burnt-400/10 dark:bg-amber-500/20 text-burnt-500 dark:text-amber-400 text-xs rounded-md"
+                key={topic}
+                className="inline-block px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-burnt-500 dark:text-amber-400 border border-burnt-400/30 dark:border-amber-400/30 rounded-sm"
               >
                 {topic}
               </span>
             ))}
           </div>
-        </div>
-
-        {/* Links */}
-        {engagement.links && engagement.links.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {engagement.links.map((link, index) => (
-              <ExternalLinkButton key={index} link={link} />
-            ))}
+          <div className="editorial-card-footer">
+            <span className="editorial-card-read">
+              {engagement.audience.split(' ').slice(0, 3).join(' ')} · {engagement.location}
+            </span>
+            <span className="editorial-card-index">{prefix}.{idx}</span>
           </div>
-        )}
+          {engagement.links && engagement.links.length > 0 ? (
+            <div className="flex flex-wrap gap-2 pt-2 border-t border-parchment-300/40 dark:border-slate-700/40">
+              {engagement.links.map((link, i) => (
+                <ExternalLinkButton key={i} link={link} />
+              ))}
+            </div>
+          ) : null}
+        </div>
       </div>
-    </div>
-  );
+    </article>
+  )
+
+  if (!href) return Content
+
+  return (
+    <Link href={href} className="block h-full">
+      {Content}
+    </Link>
+  )
+}
+
+function SectionHead({ num, title, moreHref, moreLabel = 'Archive →' }) {
+  return (
+    <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
+      <div className="editorial-section-num">§ {num}</div>
+      <h2 className="editorial-section-title">{title}</h2>
+      {moreHref ? (
+        <Link href={moreHref} className="editorial-section-more text-burnt-400 dark:text-amber-400 hover:underline">
+          {moreLabel}
+        </Link>
+      ) : <span />}
+    </header>
+  )
 }
 
 export default function Speaking() {
-  const publicEngagements = speakingEngagements.filter(e => e.type === 'public');
-  const internalEngagements = speakingEngagements.filter(e => e.type === 'internal');
+  const publicEngagements = speakingEngagements.filter(e => e.type === 'public')
+  const internalEngagements = speakingEngagements.filter(e => e.type === 'internal')
 
   return (
-    <SimpleLayout
-        title="Speaking Engagements"
-        intro="I speak at conferences, meetups, and corporate events about AI, infrastructure as code, vector databases, and developer tools. I also provide internal training for engineering and content teams."
-      >
+    <div className="editorial-home flex flex-col min-h-screen text-charcoal-50 dark:text-parchment-100 theme-transition">
+      <main className="flex-1">
+        {/* ----- Hero ----- */}
+        <section className="pt-16 pb-12 md:pt-24 md:pb-16">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-10 lg:grid-cols-[1.35fr_1fr] lg:items-end">
+            <div>
+              <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
+                Speaking · Conferences · Corporate training
+              </div>
+              <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
+                Talks, workshops, and trainings for teams that{' '}
+                <span className="text-burnt-400 dark:text-amber-400">actually ship</span>.
+              </h1>
+              <p className="editorial-lede text-parchment-600 dark:text-slate-300">
+                Keynotes, hands-on workshops, and corporate training across AI engineering,
+                agent-assisted development, RAG, and developer tools. Fourteen years in production.
+              </p>
+              <div className="editorial-secondary text-parchment-600 dark:text-slate-400 mt-6">
+                <Link href="/contact">Book a talk →</Link>
+                <span>·</span>
+                <Link href="/workshops/claude-cowork">Workshops →</Link>
+                <span>·</span>
+                <Link href="/ai-training">Corporate training →</Link>
+              </div>
+              <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
+                <dt>Featured</dt>
+                <dd>DevSecCon 2025 keynote · AI Engineering World Fair workshop (70+ engineers)</dd>
+                <dt>Recent</dt>
+                <dd>AI Engineering London · WorkOS × Anthropic · a16z</dd>
+              </dl>
+            </div>
 
-        {/* Featured Keynote */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-4 flex items-center gap-2">
-            <Presentation className="h-6 w-6 text-red-600" />
-            DevSecCon 2025 Keynote
-          </h2>
-          <div className="">
-            <YoutubeEmbed urls="https://www.youtube.com/watch?v=kwIzRkzO_Z4" title="DevSecCon 2025 Keynote" />
-            <div className="mt-4">
-              <ExternalLinkButton link={{ type: 'youtube', url: 'https://www.youtube.com/watch?v=kwIzRkzO_Z4', label: 'Watch on YouTube' }} />
+            {/* Featured keynote preview on the right */}
+            <div>
+              <div className="editorial-rule-label text-parchment-600 dark:text-slate-400 mb-3">
+                Featured keynote
+              </div>
+              <div className="rounded-md overflow-hidden border border-parchment-300 dark:border-slate-700 shadow-lg">
+                <YoutubeEmbed urls="https://www.youtube.com/watch?v=kwIzRkzO_Z4" title="DevSecCon 2025 Keynote" />
+              </div>
+              <div className="mt-3 flex items-center justify-between text-[12px] font-mono uppercase tracking-wider text-parchment-600 dark:text-slate-400">
+                <span>DevSecCon 2025 · Keynote</span>
+                <a
+                  href="https://www.youtube.com/watch?v=kwIzRkzO_Z4"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-burnt-400 dark:text-amber-400 hover:underline"
+                >
+                  Watch →
+                </a>
+              </div>
             </div>
           </div>
         </section>
 
-
-        {/* Public Engagements */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-6 flex items-center gap-2">
-            <Mic className="h-6 w-6 text-burnt-400 dark:text-amber-400" />
-            Conference Talks & Public Workshops
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {publicEngagements.map((engagement) => (
-              <SpeakingCard key={engagement.id} engagement={engagement} />
-            ))}
+        {/* ----- § 01 Public engagements ----- */}
+        <section className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="01"
+              title="Conference talks & public workshops"
+              moreHref="/contact"
+              moreLabel="Book a talk →"
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {publicEngagements.map((engagement, i) => (
+                <SpeakingEditorialCard
+                  key={engagement.id}
+                  engagement={engagement}
+                  index={i + 1}
+                  prefix="T"
+                />
+              ))}
+            </div>
           </div>
         </section>
 
-        {/* Speaking Gallery */}
-        <section className="mb-12">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {galleryImages.map((img, index) => (
-              <div key={index} className="relative h-64 rounded-xl overflow-hidden shadow-lg">
-                <Image src={img.src}
-                  alt={img.alt}
-                  fill
-                  className="object-cover hover:scale-105 transition-transform duration-300"
-                 />
-              </div>
-            ))}
+        {/* ----- Gallery strip ----- */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              In the room
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {galleryImages.map((img, index) => (
+                <div
+                  key={index}
+                  className="relative aspect-[4/3] overflow-hidden rounded-sm border border-parchment-300 dark:border-slate-700 shadow-md"
+                >
+                  <Image
+                    src={img.src}
+                    alt={img.alt}
+                    fill
+                    sizes="(max-width: 768px) 100vw, 33vw"
+                    className="object-cover transition-transform duration-500 hover:scale-[1.03]"
+                    style={{ filter: 'contrast(1.05)' }}
+                  />
+                </div>
+              ))}
+            </div>
           </div>
         </section>
 
-        {/* Internal Training */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-6 flex items-center gap-2">
-            <GraduationCap className="h-6 w-6 text-amber-600" />
-            Corporate Training & Team Development
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {internalEngagements.map((engagement) => (
-              <SpeakingCard key={engagement.id} engagement={engagement} />
-            ))}
+        {/* ----- § 02 Internal training ----- */}
+        <section className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="02"
+              title="Corporate training & team development"
+              moreHref="/ai-training"
+              moreLabel="Training services →"
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {internalEngagements.map((engagement, i) => (
+                <SpeakingEditorialCard
+                  key={engagement.id}
+                  engagement={engagement}
+                  index={i + 1}
+                  prefix="I"
+                />
+              ))}
+            </div>
           </div>
         </section>
 
-        {/* CTA Section */}
-        <section className="bg-parchment-50 dark:bg-slate-800 border border-parchment-200 dark:border-slate-700 rounded-xl p-8 text-center">
-          <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-4">Looking for a Speaker?</h2>
-          <p className="text-parchment-600 dark:text-slate-300 mb-6 max-w-2xl mx-auto">
-            I&apos;m available for conference talks, meetups, corporate training, and workshops. 
-            I speak about AI engineering, infrastructure as code, vector databases, developer tools, 
-            and practical machine learning implementations.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link
-              href="/contact"
-              className="inline-flex items-center justify-center px-6 py-3 bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-500 dark:hover:bg-amber-400 text-white font-semibold rounded-md transition-colors"
-            >
-              Book a Speaking Engagement
-            </Link>
-            <Link
-              href="/ai-training"
-              className="inline-flex items-center justify-center px-6 py-3 bg-parchment-100 hover:bg-parchment-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-charcoal-50 dark:text-slate-100 font-semibold rounded-md transition-colors"
-            >
-              View Training Services
-            </Link>
+        {/* ----- CTA ----- */}
+        <section className="py-20">
+          <div className="container mx-auto max-w-4xl px-4 md:px-6 text-center">
+            <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400 justify-center">
+              Looking for a speaker?
+            </div>
+            <h2 className="font-serif text-3xl md:text-4xl font-bold leading-tight tracking-tight mt-4 text-charcoal-50 dark:text-parchment-100">
+              Conference talks, team workshops, and practical, hands-on training
+              — tell me what your team needs to{' '}
+              <span className="text-burnt-400 dark:text-amber-400">ship</span>.
+            </h2>
+            <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href="/contact"
+                className="inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors"
+              >
+                Book a speaking engagement →
+              </Link>
+              <Link
+                href="/workshops/claude-cowork"
+                className="inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-md border border-parchment-400 dark:border-slate-600 text-charcoal-50 dark:text-parchment-100 hover:border-burnt-400 dark:hover:border-amber-400 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors"
+              >
+                View the Claude Cowork workshop →
+              </Link>
+            </div>
           </div>
         </section>
-      </SimpleLayout>
-  );
-} 
+      </main>
+    </div>
+  )
+}

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
 import YoutubeEmbed from "@/components/YoutubeEmbed"
+import { SectionHead } from "@/components/SectionHead"
 
 export const metadata: Metadata = {
   title: "Claude Cowork Workshop | Hands-On AI-Assisted Development | Zachary Proser",
@@ -81,30 +82,6 @@ const credentials = [
   "Workshop co-hosted with Anthropic, February 2026",
   "35,000+ readers on zackproser.com",
 ]
-
-function SectionHead({
-  num,
-  title,
-  moreHref,
-  moreLabel = 'Archive →',
-}: {
-  num: string
-  title: string
-  moreHref?: string
-  moreLabel?: string
-}) {
-  return (
-    <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
-      <div className="editorial-section-num">§ {num}</div>
-      <h2 className="editorial-section-title">{title}</h2>
-      {moreHref ? (
-        <Link href={moreHref as Route} className="editorial-section-more text-burnt-400 dark:text-amber-400 hover:underline">
-          {moreLabel}
-        </Link>
-      ) : <span />}
-    </header>
-  )
-}
 
 export default function ClaudeCoworkWorkshop() {
   return (

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next"
+import type { Metadata, Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
-import { SimpleLayout } from "@/components/SimpleLayout"
 import YoutubeEmbed from "@/components/YoutubeEmbed"
-import { Clock, Users, Zap, CheckCircle, ArrowRight, Star, Code, Brain, Target, Mail } from "lucide-react"
 
 export const metadata: Metadata = {
   title: "Claude Cowork Workshop | Hands-On AI-Assisted Development | Zachary Proser",
@@ -17,9 +15,9 @@ export const metadata: Metadata = {
 
 const workshopPhases = [
   {
+    num: "01",
     phase: "Demo",
     duration: "30 min",
-    icon: <Zap className="h-6 w-6" />,
     title: "What's possible with Claude Code",
     items: [
       "Real projects built with Claude: Oura MCP integration, Handwave watchOS app",
@@ -29,9 +27,9 @@ const workshopPhases = [
     ],
   },
   {
-    phase: "Hands-On",
+    num: "02",
+    phase: "Hands-on",
     duration: "90 min",
-    icon: <Code className="h-6 w-6" />,
     title: "Build a complete GTM workflow",
     items: [
       "ICP identification and data scraping",
@@ -44,9 +42,9 @@ const workshopPhases = [
     ],
   },
   {
+    num: "03",
     phase: "Patterns",
     duration: "Throughout",
-    icon: <Brain className="h-6 w-6" />,
     title: "Context management and session craft",
     items: [
       "Managing context across long Claude Code sessions",
@@ -59,214 +57,322 @@ const workshopPhases = [
 
 const audiences = [
   {
-    title: "Engineering Teams",
-    description: "Ship features faster by learning AI-assisted development patterns that actually work in production.",
-    icon: <Code className="h-5 w-5" />,
+    idx: "A.01",
+    title: "Engineering teams",
+    description: "Ship features faster with AI-assisted development patterns that actually hold up in production.",
   },
   {
-    title: "GTM & Marketing Teams",
+    idx: "A.02",
+    title: "GTM & marketing teams",
     description: "Build automated research and content pipelines that run while you sleep.",
-    icon: <Target className="h-5 w-5" />,
   },
   {
-    title: "Technical Leaders",
-    description: "Understand what AI-assisted development looks like in practice so you can set strategy for your org.",
-    icon: <Star className="h-5 w-5" />,
+    idx: "A.03",
+    title: "Technical leaders",
+    description: "See what AI-assisted development looks like in practice so you can set strategy for your org.",
   },
 ]
 
+const credentials = [
+  "14 years shipping production systems",
+  "Previously Staff DevRel at Pinecone, Cloudflare, Gruntwork",
+  "DevSecCon 2025 keynote speaker",
+  "AI Engineering World Fair workshop instructor (70+ engineers)",
+  "Workshop co-hosted with Anthropic, February 2026",
+  "35,000+ readers on zackproser.com",
+]
+
+function SectionHead({
+  num,
+  title,
+  moreHref,
+  moreLabel = 'Archive →',
+}: {
+  num: string
+  title: string
+  moreHref?: string
+  moreLabel?: string
+}) {
+  return (
+    <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
+      <div className="editorial-section-num">§ {num}</div>
+      <h2 className="editorial-section-title">{title}</h2>
+      {moreHref ? (
+        <Link href={moreHref as Route} className="editorial-section-more text-burnt-400 dark:text-amber-400 hover:underline">
+          {moreLabel}
+        </Link>
+      ) : <span />}
+    </header>
+  )
+}
+
 export default function ClaudeCoworkWorkshop() {
   return (
-    <SimpleLayout
-      title="Claude Cowork Workshop"
-      intro="A hands-on session where you don't just watch — you build. Real workflows, real output, real skills you'll use Monday morning."
-    >
-      {/* Hero Details */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
-        <div className="bg-parchment-50 dark:bg-slate-800 rounded-xl p-6 text-center">
-          <Clock className="h-8 w-8 text-burnt-400 dark:text-amber-400 mx-auto mb-3" />
-          <div className="text-2xl font-bold text-charcoal-50 dark:text-slate-100">2 Hours</div>
-          <div className="text-parchment-500 dark:text-slate-400">Hands-on, not lecture</div>
-        </div>
-        <div className="bg-parchment-50 dark:bg-slate-800 rounded-xl p-6 text-center">
-          <Users className="h-8 w-8 text-burnt-400 dark:text-amber-400 mx-auto mb-3" />
-          <div className="text-2xl font-bold text-charcoal-50 dark:text-slate-100">Max 20 Seats</div>
-          <div className="text-parchment-500 dark:text-slate-400">Small enough to be useful</div>
-        </div>
-        <div className="bg-parchment-50 dark:bg-slate-800 rounded-xl p-6 text-center">
-          <Zap className="h-8 w-8 text-burnt-400 dark:text-amber-400 mx-auto mb-3" />
-          <div className="text-2xl font-bold text-charcoal-50 dark:text-slate-100">$750/person</div>
-          <div className="text-parchment-500 dark:text-slate-400">Team pricing available</div>
-        </div>
-      </div>
-
-      {/* Workshop Recording */}
-      <section className="mb-16">
-        <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-6">Watch the Workshop</h2>
-        <div className="rounded-xl overflow-hidden">
-          <YoutubeEmbed urls="https://www.youtube.com/watch?v=8bjcx5Hkj5w" title="Claude Cowork Workshop with Anthropic — February 2026" />
-        </div>
-        <p className="text-sm text-parchment-500 dark:text-slate-400 mt-3">
-          Recorded live at the WorkOS x Anthropic event in San Francisco, February 26, 2026.
-        </p>
-      </section>
-
-      {/* Workshop Photos */}
-      <section className="mb-16">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="relative h-72 rounded-xl overflow-hidden shadow-lg">
-            <Image src="https://zackproser.b-cdn.net/images/workshop-zack-presenting-v2.webp"
-              alt="Zack presenting at the Claude Cowork Workshop"
-              fill
-              className="object-cover"
-            />
-          </div>
-          <div className="relative h-72 rounded-xl overflow-hidden shadow-lg">
-            <Image src="https://zackproser.b-cdn.net/images/workshop-audience-coding-v2.webp"
-              alt="Workshop attendees building with Claude Cowork"
-              fill
-              className="object-cover"
-            />
-          </div>
-          <div className="relative h-72 rounded-xl overflow-hidden shadow-lg">
-            <Image src="https://zackproser.b-cdn.net/images/workshop-qa-lydia-zack-v2.webp"
-              alt="Q&A with Lydia from Anthropic's Claude Code team"
-              fill
-              className="object-cover"
-            />
-          </div>
-        </div>
-        <p className="text-sm text-parchment-500 dark:text-slate-400 mt-3 text-center">
-          From the WorkOS x Anthropic workshop, February 2026. Photos by Mark Robinson.
-        </p>
-      </section>
-
-      {/* The Pitch */}
-      <section className="mb-16">
-        <div className="bg-gradient-to-br from-burnt-400/10 to-amber-500/10 dark:from-amber-500/10 dark:to-burnt-400/10 rounded-2xl p-8 md:p-12">
-          <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-4">
-            Most AI workshops teach you to prompt. This one teaches you to build.
-          </h2>
-          <p className="text-lg text-parchment-600 dark:text-slate-300 mb-4">
-            I&apos;ve been shipping production code with Claude Code daily for over a year — from watchOS apps to MCP integrations
-            to full-stack features. This workshop compresses months of hard-won patterns into a single hands-on session.
-          </p>
-          <p className="text-lg text-parchment-600 dark:text-slate-300">
-            You&apos;ll walk in knowing Claude exists. You&apos;ll walk out knowing how to make it do real work — and how to
-            set up Cowork tasks that keep producing while you&apos;re offline.
-          </p>
-        </div>
-      </section>
-
-      {/* Workshop Flow */}
-      <section className="mb-16">
-        <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-8">What You&apos;ll Build</h2>
-        <div className="space-y-8">
-          {workshopPhases.map((phase, index) => (
-            <div key={index} className="bg-parchment-50 dark:bg-slate-800 rounded-xl p-8">
-              <div className="flex items-center gap-4 mb-4">
-                <div className="flex items-center justify-center w-12 h-12 rounded-full bg-burnt-400/20 dark:bg-amber-500/20 text-burnt-500 dark:text-amber-400">
-                  {phase.icon}
-                </div>
-                <div>
-                  <span className="text-sm font-medium text-burnt-400 dark:text-amber-400">{phase.phase} · {phase.duration}</span>
-                  <h3 className="text-xl font-bold text-charcoal-50 dark:text-slate-100">{phase.title}</h3>
-                </div>
-              </div>
-              <ul className="space-y-3 ml-16">
-                {phase.items.map((item, i) => (
-                  <li key={i} className="flex items-start gap-3 text-parchment-600 dark:text-slate-300">
-                    <CheckCircle className="h-5 w-5 text-green-500 dark:text-green-400 mt-0.5 flex-shrink-0" />
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Who It's For */}
-      <section className="mb-16">
-        <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-8">Who This Is For</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {audiences.map((audience, index) => (
-            <div key={index} className="bg-parchment-50 dark:bg-slate-800 rounded-xl p-6">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="text-burnt-400 dark:text-amber-400">{audience.icon}</div>
-                <h3 className="font-bold text-charcoal-50 dark:text-slate-100">{audience.title}</h3>
-              </div>
-              <p className="text-parchment-600 dark:text-slate-300">{audience.description}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Credentials */}
-      <section className="mb-16">
-        <h2 className="text-2xl font-bold text-charcoal-50 dark:text-slate-100 mb-6">Your Instructor</h2>
-        <div className="bg-parchment-50 dark:bg-slate-800 rounded-xl p-8">
-          <div className="flex flex-col md:flex-row gap-6">
+    <div className="editorial-home flex flex-col min-h-screen text-charcoal-50 dark:text-parchment-100 theme-transition">
+      <main className="flex-1">
+        {/* ----- Hero ----- */}
+        <section className="pt-16 pb-12 md:pt-24 md:pb-16">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-10 lg:grid-cols-[1.35fr_1fr] lg:items-start">
             <div>
-              <h3 className="text-xl font-bold text-charcoal-50 dark:text-slate-100 mb-2">Zachary Proser</h3>
-              <p className="text-burnt-400 dark:text-amber-400 font-medium mb-4">Applied AI Engineer · WorkOS</p>
-              <ul className="space-y-2 text-parchment-600 dark:text-slate-300">
-                <li className="flex items-start gap-2">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
-                  14 years shipping production systems
-                </li>
-                <li className="flex items-start gap-2">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
-                  Previously Staff DevRel at Pinecone, Cloudflare, Gruntwork
-                </li>
-                <li className="flex items-start gap-2">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
-                  DevSecCon 2025 keynote speaker
-                </li>
-                <li className="flex items-start gap-2">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
-                  AI Engineering World Fair workshop instructor (70+ engineers)
-                </li>
-                <li className="flex items-start gap-2">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
-                  Workshop co-hosted with Anthropic, February 2026
-                </li>
-                <li className="flex items-start gap-2">
-                  <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
-                  35,000+ readers on zackproser.com
-                </li>
-              </ul>
+              <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
+                Workshop · Hands-on · 2 hours
+              </div>
+              <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
+                Claude Cowork —{' '}
+                <span className="text-burnt-400 dark:text-amber-400">build</span>, don&apos;t watch.
+              </h1>
+              <p className="editorial-lede text-parchment-600 dark:text-slate-300">
+                Most AI workshops teach you to prompt. This one teaches you to ship.
+                A two-hour, hands-on session where your team builds a real GTM workflow
+                — ICP research, competitive data, cold email, content — with Claude Code
+                and Cowork running autonomously.
+              </p>
+              <div className="editorial-secondary text-parchment-600 dark:text-slate-400 mt-6">
+                <Link href="/contact">Book a workshop →</Link>
+                <span>·</span>
+                <Link href="/speaking">All talks →</Link>
+                <span>·</span>
+                <a href="#flow">Jump to the flow →</a>
+              </div>
+              <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
+                <dt>Format</dt>
+                <dd>Hands-on. Not a lecture. Attendees build alongside.</dd>
+                <dt>Co-hosted</dt>
+                <dd>WorkOS × Anthropic, February 2026</dd>
+              </dl>
+            </div>
+
+            <div>
+              <div className="editorial-rule-label text-parchment-600 dark:text-slate-400 mb-3">
+                Recorded live
+              </div>
+              <div className="rounded-md overflow-hidden border border-parchment-300 dark:border-slate-700 shadow-lg">
+                <YoutubeEmbed
+                  urls="https://www.youtube.com/watch?v=8bjcx5Hkj5w"
+                  title="Claude Cowork Workshop with Anthropic — February 2026"
+                />
+              </div>
+              <p className="mt-3 text-[12px] font-mono uppercase tracking-wider text-parchment-600 dark:text-slate-400">
+                SF · WorkOS × Anthropic · Feb 2026
+              </p>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* CTA */}
-      <section className="bg-gradient-to-br from-burnt-400 to-burnt-500 dark:from-amber-500 dark:to-amber-600 rounded-2xl p-8 md:p-12 text-center text-white">
-        <h2 className="text-3xl font-bold mb-4">Ready to level up your team?</h2>
-        <p className="text-lg mb-2 opacity-90">
-          Available for on-site workshops, virtual sessions, and conference appearances.
-        </p>
-        <p className="text-lg mb-8 opacity-90">
-          Team pricing available for groups of 5+.
-        </p>
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link
-            href="/contact"
-            className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white text-burnt-500 font-bold rounded-lg hover:bg-parchment-50 transition-colors text-lg"
-          >
-            <Mail className="h-5 w-5" />
-            Book a Workshop
-          </Link>
-          <Link
-            href="/speaking"
-            className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white/20 text-white font-bold rounded-lg hover:bg-white/30 transition-colors text-lg"
-          >
-            View All Speaking
-            <ArrowRight className="h-5 w-5" />
-          </Link>
-        </div>
-      </section>
-    </SimpleLayout>
+        {/* ----- Stat slab ----- */}
+        <section className="pb-12">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <div className="editorial-stats text-charcoal-50 dark:text-parchment-100">
+              <div className="editorial-stat">
+                <div className="editorial-stat-num">
+                  2<span className="unit">hr</span>
+                </div>
+                <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                  Hands-on, not lecture
+                </div>
+              </div>
+              <div className="editorial-stat">
+                <div className="editorial-stat-num">
+                  20<span className="unit">seats</span>
+                </div>
+                <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                  Max per session
+                </div>
+              </div>
+              <div className="editorial-stat">
+                <div className="editorial-stat-num">
+                  $750<span className="unit">/pp</span>
+                </div>
+                <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                  Team pricing available
+                </div>
+              </div>
+              <div className="editorial-stat">
+                <div className="editorial-stat-num">
+                  70<span className="unit">+</span>
+                </div>
+                <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
+                  Engineers trained at AIE
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ----- Photo strip ----- */}
+        <section className="py-12">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              In the room · SF · Feb 2026
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {[
+                { src: 'https://zackproser.b-cdn.net/images/workshop-zack-presenting-v2.webp', alt: 'Zack presenting at the Claude Cowork Workshop' },
+                { src: 'https://zackproser.b-cdn.net/images/workshop-audience-coding-v2.webp', alt: 'Workshop attendees building with Claude Cowork' },
+                { src: 'https://zackproser.b-cdn.net/images/workshop-qa-lydia-zack-v2.webp', alt: "Q&A with Lydia from Anthropic's Claude Code team" },
+              ].map((img) => (
+                <div
+                  key={img.src}
+                  className="relative aspect-[4/3] overflow-hidden rounded-sm border border-parchment-300 dark:border-slate-700 shadow-md"
+                >
+                  <Image
+                    src={img.src}
+                    alt={img.alt}
+                    fill
+                    sizes="(max-width: 768px) 100vw, 33vw"
+                    className="object-cover"
+                  />
+                </div>
+              ))}
+            </div>
+            <p className="mt-3 text-[11px] font-mono uppercase tracking-wider text-parchment-600 dark:text-slate-400 text-center">
+              Photos by Mark Robinson
+            </p>
+          </div>
+        </section>
+
+        {/* ----- The pitch (serif pull quote) ----- */}
+        <section className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-4xl px-4 md:px-6">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              The pitch
+            </div>
+            <blockquote className="font-serif text-2xl md:text-[32px] leading-[1.25] tracking-tight text-charcoal-50 dark:text-parchment-100">
+              I&apos;ve been shipping production code with Claude Code daily for over
+              a year — watchOS apps, MCP integrations, full-stack features. This
+              workshop compresses months of hard-won patterns into a single
+              hands-on session. You&apos;ll walk in knowing Claude exists. You&apos;ll
+              walk out knowing how to{' '}
+              <span className="text-burnt-400 dark:text-amber-400">make it do real work</span>
+              {' '}— and how to set up Cowork tasks that keep producing while
+              you&apos;re offline.
+            </blockquote>
+            <div className="mt-6 font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+              — Zachary Proser · Applied AI @ WorkOS
+            </div>
+          </div>
+        </section>
+
+        {/* ----- § 01 Workshop flow ----- */}
+        <section id="flow" className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead num="01" title="What you'll build" moreHref="/contact" moreLabel="Book a session →" />
+            <div className="grid gap-6 md:grid-cols-3">
+              {workshopPhases.map((phase) => (
+                <article key={phase.num} className="editorial-card">
+                  <div className="editorial-card-link">
+                    <div className="editorial-card-meta flex items-center justify-between">
+                      <span>P{phase.num} · {phase.phase}</span>
+                      <span className="text-burnt-400 dark:text-amber-400">{phase.duration}</span>
+                    </div>
+                    <div className="editorial-card-body" style={{ padding: '20px' }}>
+                      <h3 className="editorial-card-title">{phase.title}</h3>
+                      <ul className="mt-2 space-y-2 text-[14px] leading-snug text-parchment-600 dark:text-slate-300">
+                        {phase.items.map((item) => (
+                          <li key={item} className="flex items-start gap-2">
+                            <span className="text-burnt-400 dark:text-amber-400 font-mono mt-0.5">▸</span>
+                            <span>{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                      <div className="editorial-card-footer">
+                        <span className="editorial-card-read">Phase {phase.num}</span>
+                        <span className="editorial-card-index">P.{phase.num}</span>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ----- § 02 Who it's for ----- */}
+        <section className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead num="02" title="Who this is for" moreHref="/contact" moreLabel="Tell me about your team →" />
+            <div className="grid gap-6 md:grid-cols-3">
+              {audiences.map((a) => (
+                <article key={a.idx} className="editorial-card">
+                  <div className="editorial-card-link">
+                    <div className="editorial-card-meta flex items-center justify-between">
+                      <span>{a.idx} · Audience</span>
+                    </div>
+                    <div className="editorial-card-body" style={{ padding: '20px' }}>
+                      <h3 className="editorial-card-title">{a.title}</h3>
+                      <p className="editorial-card-desc" style={{ WebkitLineClamp: 4 }}>{a.description}</p>
+                      <div className="editorial-card-footer">
+                        <span className="editorial-card-read">Fit check →</span>
+                        <span className="editorial-card-index">{a.idx}</span>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ----- Instructor colophon ----- */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+              Your instructor
+            </div>
+            <div className="grid gap-10 md:grid-cols-[1fr_1.2fr] items-start">
+              <div>
+                <h3 className="font-serif text-3xl font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100">
+                  Zachary <span className="text-burnt-400 dark:text-amber-400">Proser</span>
+                </h3>
+                <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+                  Applied AI · WorkOS
+                </p>
+                <p className="mt-5 text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300 max-w-[48ch]">
+                  I ship production systems daily with Claude Code, Cowork, and voice-first
+                  tooling. I teach the patterns I actually use — no vapor.
+                </p>
+              </div>
+              <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-3 text-[14px] border-t border-parchment-300 dark:border-slate-700 pt-5">
+                {credentials.map((c, i) => (
+                  <div key={c} className="contents">
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500 pt-1">
+                      {String(i + 1).padStart(2, '0')}
+                    </dt>
+                    <dd className="text-charcoal-50 dark:text-parchment-100">{c}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </div>
+        </section>
+
+        {/* ----- Final CTA ----- */}
+        <section className="py-20 editorial-section-alt">
+          <div className="container mx-auto max-w-4xl px-4 md:px-6 text-center">
+            <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
+              Ready when you are
+            </div>
+            <h2 className="font-serif text-3xl md:text-4xl font-bold leading-tight tracking-tight mt-4 text-charcoal-50 dark:text-parchment-100">
+              On-site, virtual, conference, or private team session —
+              tell me what you need and when.
+            </h2>
+            <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href="/contact"
+                className="inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors"
+              >
+                Book a workshop →
+              </Link>
+              <Link
+                href="/speaking"
+                className="inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-md border border-parchment-400 dark:border-slate-600 text-charcoal-50 dark:text-parchment-100 hover:border-burnt-400 dark:hover:border-amber-400 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors"
+              >
+                View all talks →
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
   )
 }

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -92,7 +92,11 @@ export default function ClaudeCoworkWorkshop() {
           <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-10 lg:grid-cols-[1.35fr_1fr] lg:items-start">
             <div>
               <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
-                Workshop · Hands-on · 2 hours
+                <Link href="/" className="hover:text-burnt-400 dark:hover:text-amber-400">Home</Link>
+                <span className="mx-2 opacity-40">/</span>
+                <Link href="/speaking" className="hover:text-burnt-400 dark:hover:text-amber-400">Workshops</Link>
+                <span className="mx-2 opacity-40">/</span>
+                <span>Claude Cowork</span>
               </div>
               <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
                 Claude Cowork —{' '}
@@ -176,6 +180,89 @@ export default function ClaudeCoworkWorkshop() {
           </div>
         </section>
 
+        {/* ----- § 01 Workshop catalog (single card, full product treatment) ----- */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead num="01" title="The workshop" moreHref="/contact" moreLabel="Book for your team →" />
+            <article className="editorial-card grid md:grid-cols-[1.1fr_1fr] overflow-hidden">
+              <div className="relative aspect-[4/3] md:aspect-auto md:min-h-[420px]">
+                <Image
+                  src="https://zackproser.b-cdn.net/images/workshop-zack-presenting-v2.webp"
+                  alt="Zack presenting the Claude Cowork workshop at WorkOS x Anthropic, SF, February 2026"
+                  fill
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  className="object-cover"
+                />
+                <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-charcoal-50/40 dark:to-charcoal-500/60" />
+                <div className="absolute top-4 left-4 right-4 flex items-baseline justify-between">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-white/90 drop-shadow">
+                    Workshop № 01
+                  </span>
+                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/80 drop-shadow">
+                    Hands-on · 2 hr
+                  </span>
+                </div>
+                <div className="absolute bottom-4 left-4 right-4 font-serif text-[28px] md:text-[36px] font-bold leading-[1.05] tracking-tight text-white drop-shadow">
+                  Claude Cowork — <span className="text-amber-400">build</span>, don&apos;t watch.
+                </div>
+              </div>
+              <div className="p-6 md:p-8 flex flex-col gap-5">
+                <div className="flex items-start justify-between gap-4">
+                  <h3 className="font-serif text-[22px] font-bold leading-tight text-charcoal-50 dark:text-parchment-100">
+                    Claude Cowork Workshop
+                  </h3>
+                  <div className="font-mono text-[11px] uppercase tracking-[0.14em] border border-burnt-400/40 dark:border-amber-400/40 text-burnt-400 dark:text-amber-400 px-2 py-1 rounded-sm whitespace-nowrap">
+                    $750 / pp
+                  </div>
+                </div>
+                <p className="text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300">
+                  Two-hour, hands-on session. Your team builds a full GTM workflow
+                  with Claude Code and Cowork — ICP identification, competitive
+                  analysis, battlecards, cold email, content, and scheduled tasks
+                  that keep producing while you&apos;re offline.
+                </p>
+                <dl className="grid grid-cols-3 gap-4 pt-4 border-t border-parchment-300/50 dark:border-slate-700/50">
+                  <div>
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
+                      Format
+                    </dt>
+                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
+                      2-hour, hands-on
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
+                      Team size
+                    </dt>
+                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
+                      Up to 20
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
+                      Level
+                    </dt>
+                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
+                      All levels
+                    </dd>
+                  </div>
+                </dl>
+                <div className="flex items-center justify-between pt-4 border-t border-parchment-300/50 dark:border-slate-700/50 mt-auto">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+                    Delivered WorkOS × Anthropic · Feb 2026
+                  </span>
+                  <a
+                    href="#flow"
+                    className="font-mono text-[11px] uppercase tracking-[0.14em] text-burnt-400 dark:text-amber-400 hover:underline"
+                  >
+                    Syllabus →
+                  </a>
+                </div>
+              </div>
+            </article>
+          </div>
+        </section>
+
         {/* ----- Photo strip ----- */}
         <section className="py-12">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
@@ -233,7 +320,7 @@ export default function ClaudeCoworkWorkshop() {
         {/* ----- § 01 Workshop flow ----- */}
         <section id="flow" className="py-14">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <SectionHead num="01" title="What you'll build" moreHref="/contact" moreLabel="Book a session →" />
+            <SectionHead num="02" title="What you'll build" moreHref="/contact" moreLabel="Book a session →" />
             <div className="grid gap-6 md:grid-cols-3">
               {workshopPhases.map((phase) => (
                 <article key={phase.num} className="editorial-card">
@@ -267,7 +354,7 @@ export default function ClaudeCoworkWorkshop() {
         {/* ----- § 02 Who it's for ----- */}
         <section className="py-14 editorial-section-alt">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <SectionHead num="02" title="Who this is for" moreHref="/contact" moreLabel="Tell me about your team →" />
+            <SectionHead num="03" title="Who this is for" moreHref="/contact" moreLabel="Tell me about your team →" />
             <div className="grid gap-6 md:grid-cols-3">
               {audiences.map((a) => (
                 <article key={a.idx} className="editorial-card">
@@ -287,6 +374,84 @@ export default function ClaudeCoworkWorkshop() {
                 </article>
               ))}
             </div>
+          </div>
+        </section>
+
+        {/* ----- § 04 Custom engagement upsell ----- */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead num="04" title="Not in the catalog?" moreHref="/contact" moreLabel="Scope a project →" />
+            <article className="editorial-card grid md:grid-cols-[1.1fr_1fr] overflow-hidden">
+              <div className="relative min-h-[260px] md:min-h-[360px] bg-gradient-to-br from-burnt-400/25 via-parchment-200 to-parchment-100 dark:from-amber-400/20 dark:via-slate-800 dark:to-slate-900 flex items-center justify-center">
+                <div className="absolute top-4 left-4 right-4 flex items-baseline justify-between">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+                    Bespoke
+                  </span>
+                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+                    Custom scope
+                  </span>
+                </div>
+                <span className="font-serif text-[160px] md:text-[220px] leading-none text-burnt-400 dark:text-amber-400 select-none">
+                  ✱
+                </span>
+                <div className="absolute bottom-4 left-4 right-4 font-serif text-[22px] md:text-[28px] font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100">
+                  Designed around <span className="text-burnt-400 dark:text-amber-400">your stack</span>, your team, your deadline.
+                </div>
+              </div>
+              <div className="p-6 md:p-8 flex flex-col gap-5">
+                <div className="flex items-start justify-between gap-4">
+                  <h3 className="font-serif text-[22px] font-bold leading-tight text-charcoal-50 dark:text-parchment-100">
+                    Custom engagement
+                  </h3>
+                  <div className="font-mono text-[11px] uppercase tracking-[0.14em] border border-parchment-400 dark:border-slate-600 text-charcoal-50 dark:text-parchment-100 px-2 py-1 rounded-sm whitespace-nowrap">
+                    On request
+                  </div>
+                </div>
+                <p className="text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300">
+                  When Claude Cowork isn&apos;t the right shape — different team,
+                  different stack, different definition of done — we scope a
+                  workshop tuned to your codebase and the artifact you actually
+                  want to walk away with. Tell me what your team needs and when.
+                </p>
+                <dl className="grid grid-cols-3 gap-4 pt-4 border-t border-parchment-300/50 dark:border-slate-700/50">
+                  <div>
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
+                      Starts with
+                    </dt>
+                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
+                      30-min scoping call
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
+                      Delivered
+                    </dt>
+                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
+                      Live + recorded
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
+                      Leave with
+                    </dt>
+                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
+                      Code + playbook
+                    </dd>
+                  </div>
+                </dl>
+                <div className="flex items-center justify-between pt-4 border-t border-parchment-300/50 dark:border-slate-700/50 mt-auto">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+                    Reply within 48 hours
+                  </span>
+                  <Link
+                    href="/contact"
+                    className="font-mono text-[11px] uppercase tracking-[0.14em] text-burnt-400 dark:text-amber-400 hover:underline"
+                  >
+                    Scope a project →
+                  </Link>
+                </div>
+              </div>
+            </article>
           </div>
         </section>
 

--- a/src/components/CV.jsx
+++ b/src/components/CV.jsx
@@ -1,11 +1,5 @@
 import Image from 'next/image'
-
-const logoCloudflare = 'https://zackproser.b-cdn.net/images/logos/cloudflare.svg'
-const logoCloudmark = 'https://zackproser.b-cdn.net/images/logos/cloudmark.png'
-const logoGrunty = 'https://zackproser.b-cdn.net/images/logos/grunty.png'
-const logoPinecone = 'https://zackproser.b-cdn.net/images/logos/pinecone-logo.png'
-const logoBrightcontext = 'https://zackproser.b-cdn.net/images/logos/brightcontext.png'
-const logoWorkOS = 'https://zackproser.b-cdn.net/images/logos/workos.svg'
+import { resumeData } from '@/data/resume'
 
 function BriefcaseIcon(props) {
   return (
@@ -31,60 +25,12 @@ function BriefcaseIcon(props) {
 }
 
 export default function CV({ showHeading = true }) {
-  let resume = [
-    {
-      company: 'WorkOS',
-      title: 'Developer Experience Engineer',
-      logo: logoWorkOS,
-      start: '2025',
-      end: {
-        label: 'Present',
-        dateTime: new Date().getFullYear(),
-      },
-    },
-    {
-      company: 'WorkOS',
-      title: 'Developer Education',
-      logo: logoWorkOS,
-      start: '2024',
-      end: '2025',
-    },
-    {
-      company: 'Pinecone.io',
-      title: 'Staff Developer Advocate',
-      logo: logoPinecone,
-      start: '2023',
-      end: '2024',
-    },
-    {
-      company: 'Gruntwork.io',
-      title: 'Tech Lead',
-      logo: logoGrunty,
-      start: '2020',
-      end: '2023'
-    },
-    {
-      company: 'Cloudflare',
-      title: 'Senior Software Engineer',
-      logo: logoCloudflare,
-      start: '2017',
-      end: '2020',
-    },
-    {
-      company: 'Cloudmark',
-      title: 'Software Engineer',
-      logo: logoCloudmark,
-      start: '2015',
-      end: '2017',
-    },
-    {
-      company: 'BrightContext',
-      title: 'Software Engineer',
-      logo: logoBrightcontext,
-      start: '2012',
-      end: '2014',
-    },
-  ]
+  let resume = resumeData.map((role) => ({
+    ...role,
+    end: role.end === 'Present' 
+      ? { label: 'Present', dateTime: new Date().getFullYear() }
+      : role.end,
+  }))
 
   return (
     <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">

--- a/src/components/ConsultancyNav.jsx
+++ b/src/components/ConsultancyNav.jsx
@@ -2,110 +2,20 @@
 
 import React, { useState, useCallback } from 'react'
 import Link from 'next/link'
-import { Menu, X, ChevronDown } from 'lucide-react'
+import { Menu, X } from 'lucide-react'
 import { NavigationEvents } from './NavigationEvents'
 import { ThemeToggleWrapper } from './ThemeToggleWrapper'
 import { AuthStatus } from './AuthStatus'
 
-// Export navigation items to be used in components
+// Flat editorial navigation — a single line, mono/uppercase
 export const navItems = [
-  { name: 'Blog', href: '/blog' },
-  {
-    name: 'Tools & Demos',
-    dropdown: [
-      { name: 'Interactive Demos', href: '/demos' },
-      { name: 'Best AI Tools', href: '/best-ai-tools' },
-    ],
-  },
-  {
-    name: 'Learn',
-    dropdown: [
-      { name: 'Courses', href: '/products' },
-      { name: 'Videos', href: '/videos' },
-      { name: 'Publications', href: '/publications' },
-    ],
-  },
-  {
-    name: 'Services',
-    dropdown: [
-      { name: 'Custom Gen AI Solutions', href: '/services' },
-      { name: '90-Day AI Team Transformation', href: '/ai-training' },
-      { name: 'Workshops', href: '/workshops/claude-cowork' },
-    ],
-  },
-  {
-    name: 'About',
-    dropdown: [
-      { name: 'About Me', href: '/about' },
-      { name: 'Speaking', href: '/speaking' },
-      { name: 'Testimonials', href: '/testimonials' },
-      { name: 'Contact', href: '/contact' },
-    ],
-  },
+  { name: 'Writing', href: '/blog' },
+  { name: 'Builds', href: '/projects' },
+  { name: 'Videos', href: '/videos' },
+  { name: 'Workshops', href: '/workshops/claude-cowork' },
+  { name: 'About', href: '/about' },
 ];
-
-function DropdownMenu({ label, items }) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  // Toggle dropdown visibility
-  const toggleDropdown = (e) => {
-    e.stopPropagation();
-    setIsOpen(!isOpen);
-  };
-
-  // Close dropdown when clicking outside
-  const closeDropdown = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
-  // Add document click listener when dropdown is open
-  React.useEffect(() => {
-    if (isOpen) {
-      document.addEventListener('click', closeDropdown);
-    }
-    return () => {
-      document.removeEventListener('click', closeDropdown);
-    };
-  }, [isOpen, closeDropdown]);
-
-  return (
-    <div className="relative">
-      {/* Dropdown trigger button */}
-      <button
-        className="flex items-center gap-1 text-sm font-medium text-charcoal-50 dark:text-slate-200 hover:text-burnt-400 dark:hover:text-indigo-400 transition-colors"
-        onClick={toggleDropdown}
-        aria-expanded={isOpen}
-        aria-haspopup="true"
-      >
-        {label}
-        <ChevronDown
-          className={`h-4 w-4 transition-transform duration-200 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
-        />
-      </button>
-
-      {/* Dropdown menu */}
-      {isOpen && (
-        <div
-          className="absolute left-0 mt-2 w-48 rounded-lg shadow-lg bg-parchment-50 dark:bg-slate-800 backdrop-blur-sm ring-1 ring-parchment-300 dark:ring-slate-700 z-50"
-        >
-          <div className="py-1" role="menu" aria-orientation="vertical">
-            {items.map((item) => (
-              <Link
-                key={item.name}
-                href={item.href}
-                className="block px-4 py-2 text-sm text-charcoal-50 dark:text-slate-200 hover:bg-parchment-200 dark:hover:bg-slate-700 hover:text-burnt-400 dark:hover:text-indigo-400 transition-colors"
-                role="menuitem"
-                onClick={closeDropdown}
-              >
-                {item.name}
-              </Link>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
+export const navCta = { name: 'Hire →', href: '/contact' };
 
 export function ConsultancyNav() {
   const [menuOpen, setMenuOpen] = useState(false)
@@ -115,13 +25,19 @@ export function ConsultancyNav() {
   }, [])
 
   return (
-    <header className="w-full h-16 sm:h-18 flex bg-parchment-100 dark:bg-slate-900 border-b border-parchment-300 dark:border-slate-700 sticky top-0 shadow-sm relative z-50 transition-colors duration-300">
-      <div className="container mx-auto px-4 flex items-center justify-between">
-        <Link className="flex items-center justify-center shrink-0" href="/">
+    <header className="w-full flex bg-parchment-100 dark:bg-slate-900 border-b border-parchment-300 dark:border-slate-700 sticky top-0 shadow-sm relative z-50 transition-colors duration-300">
+      <div className="container mx-auto px-4 h-16 sm:h-18 flex items-center justify-between gap-6">
+        {/* Wordmark + meta */}
+        <Link className="flex items-baseline gap-3 shrink-0" href="/">
           <span className="text-xl font-bold font-serif text-charcoal-50 dark:text-white whitespace-nowrap">
             Zachary <span className="text-burnt-400 dark:text-amber-400">Proser</span>
           </span>
+          <span className="hidden md:inline font-mono text-[10px] tracking-[0.14em] uppercase text-parchment-600 dark:text-slate-400 whitespace-nowrap">
+            № MMXXVI · Applied AI
+          </span>
         </Link>
+
+        {/* Mobile toggle */}
         <div className="lg:hidden">
           <button
             type="button"
@@ -132,30 +48,30 @@ export function ConsultancyNav() {
             {menuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
           </button>
         </div>
+
         <nav
           className={`absolute top-16 sm:top-18 left-0 w-full bg-parchment-100 dark:bg-slate-900 lg:static lg:w-auto lg:bg-transparent dark:lg:bg-transparent
-                      flex-col lg:flex-row lg:flex gap-4 items-center border-t lg:border-t-0 border-parchment-300 dark:border-slate-700
-                      ${menuOpen ? 'flex py-4 shadow-lg' : 'hidden'} lg:flex`}>
-          <div className="flex flex-col lg:flex-row gap-2 items-center w-full lg:w-auto">
+                      flex-col lg:flex-row lg:flex gap-4 lg:gap-7 items-center border-t lg:border-t-0 border-parchment-300 dark:border-slate-700
+                      ${menuOpen ? 'flex py-4 shadow-lg' : 'hidden'} lg:flex`}
+        >
+          <div className="flex flex-col lg:flex-row gap-3 lg:gap-7 items-center w-full lg:w-auto">
             {navItems.map((item) => (
-              item.dropdown ? (
-                <DropdownMenu
-                  key={item.name}
-                  label={item.name}
-                  items={item.dropdown}
-                />
-              ) : (
-                <Link
-                  key={item.name}
-                  className="text-sm font-medium text-charcoal-50 dark:text-slate-200 hover:text-burnt-400 dark:hover:text-indigo-400 transition-colors py-2 lg:py-0 w-full lg:w-auto text-center lg:text-left px-2"
-                  href={item.href}
-                >
-                  {item.name}
-                </Link>
-              )
+              <Link
+                key={item.name}
+                href={item.href}
+                className="font-mono text-[11px] tracking-[0.14em] uppercase font-semibold text-charcoal-50 dark:text-slate-200 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors py-2 lg:py-0 w-full lg:w-auto text-center lg:text-left"
+              >
+                {item.name}
+              </Link>
             ))}
+            <Link
+              href={navCta.href}
+              className="font-mono text-[11px] tracking-[0.14em] uppercase font-semibold text-burnt-400 dark:text-amber-400 hover:opacity-80 transition-opacity py-2 lg:py-0 w-full lg:w-auto text-center lg:text-left"
+            >
+              {navCta.name}
+            </Link>
           </div>
-          <div className="flex items-center gap-2 mt-4 lg:mt-0">
+          <div className="flex items-center gap-2 mt-4 lg:mt-0 lg:pl-4 lg:border-l lg:border-parchment-300 dark:lg:border-slate-700">
             <ThemeToggleWrapper />
             <AuthStatus />
           </div>
@@ -164,4 +80,4 @@ export function ConsultancyNav() {
       <NavigationEvents onRouteChange={handleRouteChange} />
     </header>
   )
-} 
+}

--- a/src/components/ConsultancyNav.jsx
+++ b/src/components/ConsultancyNav.jsx
@@ -12,10 +12,10 @@ export const navItems = [
   { name: 'Writing', href: '/blog' },
   { name: 'Builds', href: '/projects' },
   { name: 'Videos', href: '/videos' },
-  { name: 'Workshops', href: '/workshops/claude-cowork' },
+  { name: 'Workshops', href: '/speaking' },
   { name: 'About', href: '/about' },
 ];
-export const navCta = { name: 'Hire →', href: '/contact' };
+export const navCta = { name: 'Hire \u2192', href: '/contact' };
 
 export function ConsultancyNav() {
   const [menuOpen, setMenuOpen] = useState(false)
@@ -27,13 +27,10 @@ export function ConsultancyNav() {
   return (
     <header className="w-full flex bg-parchment-100 dark:bg-slate-900 border-b border-parchment-300 dark:border-slate-700 sticky top-0 shadow-sm relative z-50 transition-colors duration-300">
       <div className="container mx-auto px-4 h-16 sm:h-18 flex items-center justify-between gap-6">
-        {/* Wordmark + meta */}
+        {/* Wordmark */}
         <Link className="flex items-baseline gap-3 shrink-0" href="/">
           <span className="text-xl font-bold font-serif text-charcoal-50 dark:text-white whitespace-nowrap">
             Zachary <span className="text-burnt-400 dark:text-amber-400">Proser</span>
-          </span>
-          <span className="hidden md:inline font-mono text-[10px] tracking-[0.14em] uppercase text-parchment-600 dark:text-slate-400 whitespace-nowrap">
-            № MMXXVI · Applied AI
           </span>
         </Link>
 
@@ -66,7 +63,7 @@ export function ConsultancyNav() {
             ))}
             <Link
               href={navCta.href}
-              className="font-mono text-[11px] tracking-[0.14em] uppercase font-semibold text-burnt-400 dark:text-amber-400 hover:opacity-80 transition-opacity py-2 lg:py-0 w-full lg:w-auto text-center lg:text-left"
+              className="font-mono text-[11px] tracking-[0.14em] uppercase font-semibold text-burnt-400 dark:text-amber-400 hover:opacity-80 transition-opacity py-2 lg:py-0 w-full lg:w-auto text-center lg:text-left whitespace-nowrap"
             >
               {navCta.name}
             </Link>

--- a/src/components/ConsultancyNav.jsx
+++ b/src/components/ConsultancyNav.jsx
@@ -118,7 +118,9 @@ export function ConsultancyNav() {
     <header className="w-full h-16 sm:h-18 flex bg-parchment-100 dark:bg-slate-900 border-b border-parchment-300 dark:border-slate-700 sticky top-0 shadow-sm relative z-50 transition-colors duration-300">
       <div className="container mx-auto px-4 flex items-center justify-between">
         <Link className="flex items-center justify-center shrink-0" href="/">
-          <span className="text-xl font-bold font-serif text-charcoal-50 dark:text-white whitespace-nowrap">Zachary Proser</span>
+          <span className="text-xl font-bold font-serif text-charcoal-50 dark:text-white whitespace-nowrap">
+            Zachary <span className="text-burnt-400 dark:text-amber-400">Proser</span>
+          </span>
         </Link>
         <div className="lg:hidden">
           <button

--- a/src/components/EditorialArticleLayout.tsx
+++ b/src/components/EditorialArticleLayout.tsx
@@ -109,6 +109,7 @@ export function EditorialArticleLayout({
   const progressFillRef = useRef<HTMLDivElement | null>(null)
   const [readingMin, setReadingMin] = useState<number | null>(null)
   const [copied, setCopied] = useState(false)
+  const [shareVisible, setShareVisible] = useState(false)
 
   useEffect(() => {
     const body = articleRef.current
@@ -135,12 +136,22 @@ export function EditorialArticleLayout({
 
   useEffect(() => {
     const fill = progressFillRef.current
-    if (!fill) return
+    const body = articleRef.current
     let raf = 0
     const update = () => {
       const h = document.documentElement
-      const pct = h.scrollTop / Math.max(1, h.scrollHeight - h.clientHeight)
-      fill.style.width = `${Math.min(100, Math.max(0, pct * 100))}%`
+      if (fill) {
+        const pct = h.scrollTop / Math.max(1, h.scrollHeight - h.clientHeight)
+        fill.style.width = `${Math.min(100, Math.max(0, pct * 100))}%`
+      }
+      if (body) {
+        // Fade the share rail in once the reader is ~2 sentences into the body.
+        const bodyTop = body.getBoundingClientRect().top
+        setShareVisible((prev) => {
+          const next = bodyTop < -160
+          return next === prev ? prev : next
+        })
+      }
       raf = 0
     }
     const onScroll = () => {
@@ -149,8 +160,10 @@ export function EditorialArticleLayout({
     }
     update()
     window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll, { passive: true })
     return () => {
       window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
       if (raf) window.cancelAnimationFrame(raf)
     }
   }, [])
@@ -275,7 +288,11 @@ export function EditorialArticleLayout({
         </section>
 
         {/* Share rail */}
-        <aside className="share-rail" aria-label="Share">
+        <aside
+          className={`share-rail${shareVisible ? ' visible' : ''}`}
+          aria-label="Share"
+          aria-hidden={!shareVisible}
+        >
           <div className="share-btn-label">Share</div>
           <button className="share-btn" aria-label="Copy link" title="Copy link" onClick={handleCopy}>
             {copied ? <Check /> : <LinkIcon />}

--- a/src/components/EditorialArticleLayout.tsx
+++ b/src/components/EditorialArticleLayout.tsx
@@ -1,0 +1,367 @@
+'use client'
+
+import Head from 'next/head'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Suspense, useEffect, useRef, useState } from 'react'
+import { Twitter, Linkedin, Github, Link as LinkIcon, Bookmark, Check } from 'lucide-react'
+import GiscusWrapper from '@/components/GiscusWrapper'
+import MiniPaywall from '@/components/MiniPaywall'
+import StickyAffiliateCTA from '@/components/StickyAffiliateCTA'
+import { EditorialNewsletter } from '@/components/EditorialNewsletter'
+import type { ExtendedMetadata, Content } from '@/types'
+import { generateOgUrl } from '@/utils/ogUrl'
+
+const VOICE_AFFILIATE_SLUGS = [
+  'wisprflow', 'granola', 'voice-to-text', 'voice-tools', 'voice-ai',
+  'walking-and-talking', 'small-business', 'lawyers', 'record-meetings',
+  'ai-engineer-setup', 'doctors', 'real-estate',
+]
+
+function shouldShowVoiceAffiliateCTA(slug: string): boolean {
+  const lower = slug.toLowerCase()
+  return VOICE_AFFILIATE_SLUGS.some(k => lower.includes(k))
+}
+
+function resolveImageSrc(image: Content['image']): string | null {
+  if (!image) return null
+  if (typeof image === 'string') return image
+  if (typeof image === 'object' && 'src' in image && image.src) return image.src
+  return null
+}
+
+function formatPublished(date?: string): string {
+  if (!date) return ''
+  try {
+    return new Date(`${date}T00:00:00Z`).toLocaleDateString('en-US', {
+      year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC',
+    })
+  } catch { return date }
+}
+
+function kindFromContent(content: Partial<ExtendedMetadata> & { tags?: string[] }): string {
+  if (content?.type === 'video') return 'Video'
+  if (content?.type === 'course') return 'Course'
+  if (content?.type === 'demo') return 'Demo'
+  const t = (content?.tags || []).map(s => s.toLowerCase())
+  if (t.some(x => x.includes('tutorial'))) return 'Tutorial'
+  if (t.some(x => x.includes('review'))) return 'Review'
+  if (t.some(x => x.includes('reference') || x.includes('architecture'))) return 'Ref arch'
+  return 'Essay'
+}
+
+function glyphFromTitle(title: string): string {
+  const first = (title || 'Z').trim().charAt(0).toUpperCase()
+  return /[A-Z]/.test(first) ? first : 'Z'
+}
+
+function sectionNumFromKind(kind: string): string {
+  switch (kind) {
+    case 'Tutorial': return '01'
+    case 'Essay': return '03'
+    case 'Ref arch': return '04'
+    case 'Review': return '03'
+    case 'Video': return '06'
+    default: return '03'
+  }
+}
+
+interface Props {
+  children: React.ReactNode
+  metadata: ExtendedMetadata & {
+    hideMiniPaywall?: boolean
+    miniPaywallTitle?: string | null
+    miniPaywallDescription?: string | null
+    tags?: string[]
+    githubUrl?: string
+  }
+  serverHasPurchased?: boolean
+  hideNewsletter?: boolean
+}
+
+export function EditorialArticleLayout({
+  children,
+  metadata,
+  serverHasPurchased = false,
+  hideNewsletter = false,
+}: Props) {
+  const safeSlug = metadata?.slug || ''
+  const safeTitle = (metadata?.title as string) || 'Untitled'
+  const safeDescription = (metadata?.description as string) || ''
+  const baseSlug = safeSlug ? safeSlug.split('/').pop() || safeSlug : ''
+  const imageSrc = resolveImageSrc(metadata?.image)
+  const kind = kindFromContent(metadata)
+  const sectionNum = sectionNumFromKind(kind)
+  const publishedLabel = formatPublished(metadata?.date)
+  const tags = metadata?.tags || []
+  const category = tags[0] || 'Applied AI'
+
+  const ogUrl = generateOgUrl({
+    title: safeTitle,
+    description: safeDescription || undefined,
+    image: metadata?.image,
+    slug: baseSlug as any,
+  })
+
+  const fullUrl = `${process.env.NEXT_PUBLIC_SITE_URL || 'https://zackproser.com'}/blog/${baseSlug}`
+
+  const articleRef = useRef<HTMLDivElement | null>(null)
+  const progressFillRef = useRef<HTMLDivElement | null>(null)
+  const [readingMin, setReadingMin] = useState<number | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    const body = articleRef.current
+    if (!body) return
+
+    // Mark the first paragraph as .lede for drop cap
+    const firstP = body.querySelector('p')
+    if (firstP && !firstP.classList.contains('lede')) {
+      firstP.classList.add('lede')
+    }
+
+    // Number h2s with § 01, § 02 ...
+    const h2s = body.querySelectorAll<HTMLHeadingElement>('h2')
+    h2s.forEach((h, i) => {
+      if (!h.getAttribute('data-n')) {
+        h.setAttribute('data-n', `§ ${String(i + 1).padStart(2, '0')}`)
+      }
+    })
+
+    // Reading time estimate (~220 wpm)
+    const words = (body.textContent || '').trim().split(/\s+/).filter(Boolean).length
+    setReadingMin(Math.max(1, Math.round(words / 220)))
+  }, [children])
+
+  useEffect(() => {
+    const fill = progressFillRef.current
+    if (!fill) return
+    let raf = 0
+    const update = () => {
+      const h = document.documentElement
+      const pct = h.scrollTop / Math.max(1, h.scrollHeight - h.clientHeight)
+      fill.style.width = `${Math.min(100, Math.max(0, pct * 100))}%`
+      raf = 0
+    }
+    const onScroll = () => {
+      if (raf) return
+      raf = window.requestAnimationFrame(update)
+    }
+    update()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      if (raf) window.cancelAnimationFrame(raf)
+    }
+  }, [])
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(fullUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch { /* ignore */ }
+  }
+
+  const shareXUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(safeTitle)}&url=${encodeURIComponent(fullUrl)}`
+  const shareLinkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(fullUrl)}`
+
+  const shouldShowMiniPaywall =
+    metadata?.commerce?.isPaid &&
+    !metadata?.hideMiniPaywall &&
+    !serverHasPurchased &&
+    (metadata?.miniPaywallTitle || metadata?.commerce?.miniPaywallTitle) &&
+    (metadata?.miniPaywallDescription || metadata?.commerce?.miniPaywallDescription)
+
+  return (
+    <>
+      <Head>
+        <title>{`${safeTitle} - Zachary Proser`}</title>
+        <meta name="description" content={safeDescription} />
+        <meta property="og:title" content={safeTitle} />
+        <meta property="og:description" content={safeDescription} />
+        <meta property="og:url" content={fullUrl} />
+        <meta property="og:type" content="article" />
+        <meta property="og:image" content={ogUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={safeTitle} />
+        <meta name="twitter:description" content={safeDescription} />
+        <meta name="twitter:image" content={ogUrl} />
+        <meta name="twitter:domain" content="zackproser.com" />
+      </Head>
+
+      <div className="blog-post-page">
+        {/* Reading progress */}
+        <div className="reading-progress">
+          <div className="reading-progress-fill" ref={progressFillRef} />
+        </div>
+
+        {/* Breadcrumb */}
+        <div className="post-container">
+          <div className="post-crumbs">
+            <Link href="/blog">Writing</Link>
+            <span className="sep">/</span>
+            <span className="current">{safeTitle}</span>
+          </div>
+        </div>
+
+        {/* Editorial portrait header */}
+        <section className="hdr-A">
+          <div className="post-container">
+            <div className="hdr-A-grid">
+              <div>
+                <div className="post-kicker">
+                  § {sectionNum} · {category}
+                </div>
+                <h1 className="post-title">{safeTitle}</h1>
+                {safeDescription && (
+                  <p className="post-dek">{safeDescription}</p>
+                )}
+                <dl className="post-meta-dl">
+                  <div>
+                    <dt>Published</dt>
+                    <dd>{publishedLabel || '—'}</dd>
+                  </div>
+                  <div>
+                    <dt>Reading</dt>
+                    <dd>
+                      {readingMin !== null ? (
+                        <>
+                          {readingMin}<span className="unit">min</span>
+                        </>
+                      ) : '—'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Kind</dt>
+                    <dd>{kind}</dd>
+                  </div>
+                  <div>
+                    <dt>{metadata?.githubUrl ? 'Code' : 'Tags'}</dt>
+                    <dd>
+                      {metadata?.githubUrl ? (
+                        <a href={metadata.githubUrl} target="_blank" rel="noopener noreferrer">
+                          ↗ github
+                        </a>
+                      ) : (
+                        <span>{tags[0] || '—'}</span>
+                      )}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+
+              <div className="portrait-wrap">
+                <div className="hdr-A-plate">
+                  {imageSrc ? (
+                    <Image
+                      src={imageSrc}
+                      alt={safeTitle}
+                      fill
+                      sizes="(max-width: 900px) 80vw, 360px"
+                      className="plate-image"
+                      priority
+                    />
+                  ) : (
+                    <div className="glyph">{glyphFromTitle(safeTitle)}</div>
+                  )}
+                  <div className="plate-caption">
+                    Plate · {kind} · {publishedLabel || 'MMXXVI'}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Share rail */}
+        <aside className="share-rail" aria-label="Share">
+          <div className="share-btn-label">Share</div>
+          <button className="share-btn" aria-label="Copy link" title="Copy link" onClick={handleCopy}>
+            {copied ? <Check /> : <LinkIcon />}
+          </button>
+          <a className="share-btn" href={shareXUrl} target="_blank" rel="noopener noreferrer" aria-label="Share on X">
+            <Twitter />
+          </a>
+          <a className="share-btn" href={shareLinkedInUrl} target="_blank" rel="noopener noreferrer" aria-label="Share on LinkedIn">
+            <Linkedin />
+          </a>
+          <button
+            className="share-btn"
+            aria-label="Save for later"
+            title="Save for later"
+            onClick={() => { try { localStorage.setItem(`bookmark:${baseSlug}`, '1') } catch {} }}
+          >
+            <Bookmark />
+          </button>
+        </aside>
+
+        {/* Article */}
+        <article className="layout-A">
+          {shouldShowMiniPaywall && (
+            <MiniPaywall content={metadata as Content} />
+          )}
+          <div className="post-body" ref={articleRef}>
+            {children}
+          </div>
+
+          {!hideNewsletter && (
+            <div className="inline-newsletter-card">
+              <EditorialNewsletter location={`blog:${baseSlug}`} />
+            </div>
+          )}
+
+          {/* Author bio */}
+          <div className="post-bio">
+            <div className="bio-plate">
+              <Image
+                src="https://zackproser.b-cdn.net/images/zack-sketch.webp"
+                alt="Zachary Proser"
+                fill
+                sizes="120px"
+                className="plate-image"
+              />
+            </div>
+            <div className="bio-content">
+              <div className="bio-label">About the author</div>
+              <h3 className="bio-name">Zachary Proser</h3>
+              <p className="bio-desc">
+                Applied AI at WorkOS. Formerly Pinecone, Cloudflare, Gruntwork.
+                Full-stack — databases, backends, middleware, frontends — with
+                a long streak of infrastructure-as-code and cloud systems.
+              </p>
+              <div className="bio-links">
+                <Link href="/newsletter">Newsletter →</Link>
+                <Link href="/blog">All essays →</Link>
+                <a href="https://github.com/zackproser" target="_blank" rel="noopener noreferrer">
+                  <Github className="inline h-3 w-3 mr-1" strokeWidth={2} />GitHub
+                </a>
+                <a href="https://twitter.com/zackproser" target="_blank" rel="noopener noreferrer">
+                  <Twitter className="inline h-3 w-3 mr-1" strokeWidth={2} />X / Twitter
+                </a>
+                <a href="https://linkedin.com/in/zackproser" target="_blank" rel="noopener noreferrer">
+                  <Linkedin className="inline h-3 w-3 mr-1" strokeWidth={2} />LinkedIn
+                </a>
+              </div>
+            </div>
+          </div>
+
+          {/* Comments */}
+          <section className="post-comments">
+            <div className="comments-head">
+              <h3>Discussion</h3>
+              <span className="count">Giscus</span>
+            </div>
+            <Suspense fallback={<div className="text-sm text-slate-500">Loading comments…</div>}>
+              <GiscusWrapper />
+            </Suspense>
+          </section>
+        </article>
+      </div>
+
+      {shouldShowVoiceAffiliateCTA(safeSlug) && (
+        <StickyAffiliateCTA product="both" campaign={safeSlug} />
+      )}
+    </>
+  )
+}

--- a/src/components/EditorialCard.tsx
+++ b/src/components/EditorialCard.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import type { Route } from 'next'
+import type { Content } from '@/types/content'
+
+const fallbackImage = 'https://zackproser.b-cdn.net/images/wakka.webp'
+
+function resolveImage(image: Content['image']): string {
+  if (!image) return fallbackImage
+  if (typeof image === 'string') return image
+  if (typeof image === 'object' && 'src' in image && image.src) return image.src
+  return fallbackImage
+}
+
+function labelFor(type?: string, override?: string) {
+  if (override) return override
+  switch (type) {
+    case 'video':
+      return 'Video'
+    case 'demo':
+      return 'Demo'
+    case 'course':
+      return 'Course'
+    default:
+      return 'Essay'
+  }
+}
+
+function hrefFor(slug?: string) {
+  if (!slug) return '#'
+  if (slug.startsWith('http://') || slug.startsWith('https://')) return slug
+  return slug
+}
+
+interface EditorialCardProps {
+  article: Content
+  index: number
+  kind?: string
+}
+
+export function EditorialCard({ article, index, kind }: EditorialCardProps) {
+  const { title = 'Untitled', date = '', description = '', image, type, slug } = article
+  const href = hrefFor(slug)
+  const imageSource = resolveImage(image)
+  const label = labelFor(type, kind)
+  const idx = String(index).padStart(2, '0')
+
+  const formattedDate = date
+    ? new Date(`${date}T00:00:00Z`).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        timeZone: 'UTC',
+      })
+    : ''
+
+  const isExternal = href.startsWith('http')
+  const LinkTag: typeof Link | 'a' = isExternal ? 'a' : Link
+  const linkProps = isExternal
+    ? { href, target: '_blank', rel: 'noopener noreferrer' as const }
+    : { href: href as Route }
+
+  return (
+    <article className="editorial-card group">
+      {/* @ts-expect-error - LinkTag is either Link or 'a', both accept href */}
+      <LinkTag {...linkProps} className="editorial-card-link">
+        <div className="editorial-card-meta">
+          <span>C{idx} · {label}</span>
+        </div>
+        <div className="editorial-card-media">
+          <Image
+            src={imageSource}
+            alt={title}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            className="editorial-card-image"
+          />
+          <div className="editorial-card-rule" />
+        </div>
+        <div className="editorial-card-body">
+          <div className="editorial-card-date">
+            {formattedDate}
+          </div>
+          <h3 className="editorial-card-title">{title}</h3>
+          {description ? (
+            <p className="editorial-card-desc">{description}</p>
+          ) : null}
+          <div className="editorial-card-footer">
+            <span className="editorial-card-read">Read →</span>
+            <span className="editorial-card-index">C.{idx}</span>
+          </div>
+        </div>
+      </LinkTag>
+    </article>
+  )
+}

--- a/src/components/EditorialNewsletter.tsx
+++ b/src/components/EditorialNewsletter.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, FormEvent } from 'react'
+import { usePathname } from 'next/navigation'
 import { track } from '@vercel/analytics'
 import { sendGTMEvent } from '@next/third-parties/google'
 
@@ -17,6 +18,7 @@ export function EditorialNewsletter({
   title = 'Applied AI dispatches read by 5,000+ engineers',
   fine = 'No spam. Unsubscribe in one click.',
 }: EditorialNewsletterProps) {
+  const referrer = usePathname()
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
   const [errorMessage, setErrorMessage] = useState<string>('')
 
@@ -29,25 +31,26 @@ export function EditorialNewsletter({
     setStatus('submitting')
     setErrorMessage('')
 
+    track('newsletter-signup', { location })
+    sendGTMEvent({
+      event: 'newsletter-signup-conversion',
+      method: 'newsletter',
+      source: referrer,
+      position: location,
+      tags: '',
+      slug: referrer?.split('/').pop() || 'homepage',
+    })
+
     try {
       const response = await fetch('/api/form', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, referrer: '/', tags: [] }),
+        body: JSON.stringify({ email, referrer, tags: [] }),
       })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) {
         throw new Error(data?.data || 'Failed to subscribe')
       }
-      track('newsletter-signup', { location })
-      sendGTMEvent({
-        event: 'newsletter-signup-conversion',
-        method: 'newsletter',
-        source: '/',
-        position: location,
-        tags: '',
-        slug: location,
-      })
       setStatus('success')
       form.reset()
     } catch (err) {

--- a/src/components/EditorialNewsletter.tsx
+++ b/src/components/EditorialNewsletter.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+import { track } from '@vercel/analytics'
+import { sendGTMEvent } from '@next/third-parties/google'
+
+interface EditorialNewsletterProps {
+  location?: string
+  label?: string
+  title?: string
+  fine?: string
+}
+
+export function EditorialNewsletter({
+  location = 'inline',
+  label = 'The Modern Coding letter',
+  title = 'Applied AI dispatches read by 5,000+ engineers',
+  fine = 'No spam. Unsubscribe in one click.',
+}: EditorialNewsletterProps) {
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState<string>('')
+
+  async function handleSubscribe(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = event.currentTarget
+    const email = (form.elements.namedItem('email') as HTMLInputElement)?.value?.trim()
+    if (!email) return
+
+    setStatus('submitting')
+    setErrorMessage('')
+
+    try {
+      const response = await fetch('/api/form', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, referrer: '/', tags: [] }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        throw new Error(data?.data || 'Failed to subscribe')
+      }
+      track('newsletter-signup', { location })
+      sendGTMEvent({
+        event: 'newsletter-signup-conversion',
+        method: 'newsletter',
+        source: '/',
+        position: location,
+        tags: '',
+        slug: location,
+      })
+      setStatus('success')
+      form.reset()
+    } catch (err) {
+      setStatus('error')
+      setErrorMessage(err instanceof Error ? err.message : 'Something went wrong')
+    }
+  }
+
+  return (
+    <form className="editorial-capture" onSubmit={handleSubscribe} noValidate>
+      <div className="editorial-capture-label text-parchment-600 dark:text-slate-400">
+        <span className="text-burnt-400 dark:text-amber-400">✱</span>
+        <span>{label}</span>
+      </div>
+      <div className="editorial-capture-title text-burnt-400 dark:text-amber-400">
+        {title}
+      </div>
+      {status === 'success' ? (
+        <div className="editorial-capture-fine text-burnt-400 dark:text-amber-400" role="status">
+          ✓ Subscribed. Check your inbox to confirm.
+        </div>
+      ) : (
+        <>
+          <div className="editorial-capture-row">
+            <input
+              type="email"
+              name="email"
+              required
+              placeholder="you@company.com"
+              aria-label="Email"
+              disabled={status === 'submitting'}
+            />
+            <button
+              type="submit"
+              disabled={status === 'submitting'}
+              className="inline-flex items-center justify-center px-5 py-[13px] text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors disabled:opacity-60"
+            >
+              {status === 'submitting' ? 'Subscribing…' : 'Subscribe →'}
+            </button>
+          </div>
+          <div className="editorial-capture-fine text-parchment-500 dark:text-slate-500">
+            {status === 'error' && errorMessage ? errorMessage : fine}
+          </div>
+        </>
+      )}
+    </form>
+  )
+}

--- a/src/components/SectionHead.tsx
+++ b/src/components/SectionHead.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import type { Route } from 'next'
+
+interface SectionHeadProps {
+  num: string
+  title: string
+  moreHref?: string
+  moreLabel?: string
+}
+
+export function SectionHead({ num, title, moreHref, moreLabel = 'Archive →' }: SectionHeadProps) {
+  return (
+    <header className="editorial-section-head text-charcoal-50 dark:text-parchment-100">
+      <div className="editorial-section-num">§ {num}</div>
+      <h2 className="editorial-section-title">{title}</h2>
+      {moreHref ? (
+        <Link href={moreHref as Route} className="editorial-section-more text-burnt-400 dark:text-amber-400 hover:underline">
+          {moreLabel}
+        </Link>
+      ) : <span />}
+    </header>
+  )
+}

--- a/src/data/resume.js
+++ b/src/data/resume.js
@@ -1,0 +1,51 @@
+export const resumeData = [
+  {
+    company: 'WorkOS',
+    title: 'Developer Experience Engineer',
+    logo: 'https://zackproser.b-cdn.net/images/logos/workos.svg',
+    start: '2025',
+    end: 'Present',
+  },
+  {
+    company: 'WorkOS',
+    title: 'Developer Education',
+    logo: 'https://zackproser.b-cdn.net/images/logos/workos.svg',
+    start: '2024',
+    end: '2025',
+  },
+  {
+    company: 'Pinecone.io',
+    title: 'Staff Developer Advocate',
+    logo: 'https://zackproser.b-cdn.net/images/logos/pinecone-logo.png',
+    start: '2023',
+    end: '2024',
+  },
+  {
+    company: 'Gruntwork.io',
+    title: 'Tech Lead',
+    logo: 'https://zackproser.b-cdn.net/images/logos/grunty.png',
+    start: '2020',
+    end: '2023',
+  },
+  {
+    company: 'Cloudflare',
+    title: 'Senior Software Engineer',
+    logo: 'https://zackproser.b-cdn.net/images/logos/cloudflare.svg',
+    start: '2017',
+    end: '2020',
+  },
+  {
+    company: 'Cloudmark',
+    title: 'Software Engineer',
+    logo: 'https://zackproser.b-cdn.net/images/logos/cloudmark.png',
+    start: '2015',
+    end: '2017',
+  },
+  {
+    company: 'BrightContext',
+    title: 'Software Engineer',
+    logo: 'https://zackproser.b-cdn.net/images/logos/brightcontext.png',
+    start: '2012',
+    end: '2014',
+  },
+]

--- a/src/styles/blog-post.css
+++ b/src/styles/blog-post.css
@@ -276,6 +276,15 @@
   top: 40%;
   display: flex; flex-direction: column; gap: 8px;
   z-index: 20;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-6px);
+  transition: opacity .28s ease, transform .28s ease;
+}
+.blog-post-page .share-rail.visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
 }
 @media (max-width: 1380px) { .blog-post-page .share-rail { display: none; } }
 .blog-post-page .share-btn {

--- a/src/styles/blog-post.css
+++ b/src/styles/blog-post.css
@@ -52,10 +52,6 @@
   --shadow-lg: 0 18px 32px -16px rgb(24 24 40 / .25);
   --shadow-xl: 0 24px 48px -20px rgb(24 24 40 / .35);
 
-  --font-serif: var(--font-serif, 'Source Serif 4'), Georgia, serif;
-  --font-sans:  var(--font-sans, Inter), system-ui, sans-serif;
-  --font-mono:  var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
-
   background-color: var(--bg);
   color: var(--fg);
 }
@@ -115,7 +111,7 @@
 /* Breadcrumb strip */
 .blog-post-page .post-crumbs {
   display: flex; align-items: center; gap: 10px;
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: .12em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; letter-spacing: .12em;
   text-transform: uppercase; color: var(--fg-subtle);
   padding: 22px 0 0;
   flex-wrap: wrap;
@@ -139,7 +135,7 @@
 /* Header kicker + title + dek + meta */
 .blog-post-page .post-kicker {
   display: inline-flex; align-items: center; gap: 10px;
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; letter-spacing: .14em;
   text-transform: uppercase; color: var(--fg-subtle); font-weight: 600;
 }
 .blog-post-page .post-kicker::before {
@@ -147,14 +143,14 @@
 }
 .blog-post-page .post-title {
   margin: 4px 0 0;
-  font-family: var(--font-serif); font-weight: 800;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 800;
   font-size: clamp(40px, 4.6vw, 64px); line-height: 1.04;
   letter-spacing: -.025em; color: var(--fg);
   text-wrap: balance;
 }
 .blog-post-page .post-title em { font-style: normal; color: var(--accent); font-weight: 700; }
 .blog-post-page .post-dek {
-  font-family: var(--font-serif); font-weight: 400;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 400;
   font-size: clamp(18px, 1.6vw, 22px); line-height: 1.5;
   color: var(--fg-muted);
   max-width: 62ch; text-wrap: pretty;
@@ -175,15 +171,15 @@
 .blog-post-page .post-meta-dl > div:first-child { padding-left: 0; }
 .blog-post-page .post-meta-dl > div:last-child { border-right: 0; padding-right: 0; }
 .blog-post-page .post-meta-dl dt {
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 10px; letter-spacing: .12em;
   color: var(--fg-subtle); text-transform: uppercase; margin: 0;
 }
 .blog-post-page .post-meta-dl dd {
-  margin: 0; font-family: var(--font-serif); font-weight: 700;
+  margin: 0; font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 700;
   font-size: 16px; letter-spacing: -.005em; color: var(--fg);
 }
 .blog-post-page .post-meta-dl dd .unit {
-  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; font-weight: 500;
   color: var(--accent); letter-spacing: .04em; margin-left: 4px;
 }
 .blog-post-page .post-meta-dl dd a {
@@ -240,14 +236,14 @@
 .blog-post-page .hdr-A-plate .glyph {
   position: absolute; inset: 0; z-index: 2;
   display: flex; align-items: center; justify-content: center;
-  font-family: var(--font-serif); font-weight: 800; font-size: 160px;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 800; font-size: 160px;
   color: rgba(255,255,255,.3); letter-spacing: -.04em;
   pointer-events: none;
 }
 .blog-post-page .hdr-A-plate .plate-caption {
   position: absolute; z-index: 3;
   left: 16px; bottom: 14px; right: 16px;
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 10px; letter-spacing: .12em;
   text-transform: uppercase; color: rgba(255,255,255,.72);
 }
 @media (max-width: 900px) {
@@ -265,12 +261,12 @@
 .blog-post-page .post-hero-bleed figcaption {
   max-width: 880px; margin-left: auto; margin-right: auto; padding: 10px 0 0;
   display: flex; align-items: baseline; gap: 10px;
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; letter-spacing: .08em;
   text-transform: uppercase; color: var(--fg-subtle);
 }
 .blog-post-page .post-hero-bleed figcaption .num { color: var(--accent); font-weight: 700; }
 .blog-post-page .post-hero-bleed figcaption .cap {
-  font-family: var(--font-serif); font-style: italic; text-transform: none;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-style: italic; text-transform: none;
   letter-spacing: 0; font-size: 13px; color: var(--fg-muted);
 }
 
@@ -291,7 +287,7 @@
 .blog-post-page .share-btn:hover { color: var(--accent); border-color: var(--accent); transform: translateY(-1px); }
 .blog-post-page .share-btn svg { width: 15px; height: 15px; }
 .blog-post-page .share-btn-label {
-  font-family: var(--font-mono); font-size: 9px; letter-spacing: .12em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 9px; letter-spacing: .12em;
   text-transform: uppercase; color: var(--fg-subtle); text-align: center;
   writing-mode: vertical-rl; transform: rotate(180deg);
   padding: 6px 0 4px;
@@ -304,7 +300,7 @@
 
 /* Post body — longform */
 .blog-post-page .post-body {
-  font-family: var(--font-serif);
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
   font-size: 19px;
   line-height: 1.72;
   color: var(--fg);
@@ -324,20 +320,20 @@
 
 .blog-post-page .post-body h1 {
   margin: 1.6em 0 .4em;
-  font-family: var(--font-serif); font-weight: 800;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 800;
   font-size: 1.8em; line-height: 1.15; letter-spacing: -.02em;
   color: var(--fg);
 }
 .blog-post-page .post-body h2 {
   margin: 2.2em 0 .6em;
-  font-family: var(--font-serif); font-weight: 800;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 800;
   font-size: 1.55em; line-height: 1.2; letter-spacing: -.015em;
   color: var(--fg);
   display: flex; align-items: baseline; gap: 14px;
 }
 .blog-post-page .post-body h2[data-n]::before {
   content: attr(data-n);
-  font-family: var(--font-mono); font-size: .44em; font-weight: 600;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: .44em; font-weight: 600;
   letter-spacing: .12em; color: var(--accent);
   padding-top: .35em;
   min-width: 3em;
@@ -345,13 +341,13 @@
 }
 .blog-post-page .post-body h3 {
   margin: 1.8em 0 .4em;
-  font-family: var(--font-serif); font-weight: 700;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 700;
   font-size: 1.22em; line-height: 1.25; letter-spacing: -.01em;
   color: var(--fg);
 }
 .blog-post-page .post-body h4 {
   margin: 1.4em 0 .3em;
-  font-family: var(--font-sans); font-weight: 600;
+  font-family: var(--font-sans, Inter), system-ui, sans-serif; font-weight: 600;
   font-size: 1em; letter-spacing: .02em;
   color: var(--fg-muted); text-transform: uppercase;
 }
@@ -366,7 +362,7 @@
 
 /* Drop cap on the first paragraph */
 .blog-post-page .post-body .lede::first-letter {
-  font-family: var(--font-serif); font-weight: 800;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 800;
   float: left; font-size: 4.6em; line-height: .86;
   padding: 6px 14px 0 0; color: var(--accent);
   letter-spacing: -.02em;
@@ -378,7 +374,7 @@
 
 /* Inline code */
 .blog-post-page .post-body code {
-  font-family: var(--font-mono); font-size: .86em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: .86em;
   background: var(--accent-soft); color: var(--burnt-500);
   padding: 2px 6px; border-radius: 4px; font-weight: 600;
   letter-spacing: 0;
@@ -393,7 +389,7 @@
   border-radius: 6px;
   padding: 18px 20px;
   overflow-x: auto;
-  font-family: var(--font-mono); font-size: 13.5px; line-height: 1.7;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 13.5px; line-height: 1.7;
   white-space: pre;
   tab-size: 2;
 }
@@ -406,13 +402,13 @@
   margin: 1.8em 0;
   padding: 4px 0 4px 24px;
   border-left: 3px solid var(--accent);
-  font-family: var(--font-serif); font-style: italic;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-style: italic;
   font-size: 1.08em; line-height: 1.55;
   color: var(--fg-muted);
 }
 .blog-post-page .post-body blockquote cite {
   display: block; margin-top: 10px;
-  font-family: var(--font-mono); font-style: normal;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-style: normal;
   font-size: 11px; letter-spacing: .1em;
   color: var(--fg-subtle); text-transform: uppercase;
 }
@@ -422,7 +418,7 @@
   margin: 2.4em 0;
   padding: 28px 0;
   border-top: 2px solid var(--fg); border-bottom: 1px solid var(--border);
-  font-family: var(--font-serif); font-weight: 600;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 600;
   font-size: 1.55em; line-height: 1.28; letter-spacing: -.015em;
   color: var(--fg); text-wrap: balance;
 }
@@ -435,15 +431,15 @@
   background: var(--bg-elevated);
   padding: 18px 20px;
   border-radius: 4px;
-  font-family: var(--font-sans); font-size: .88em; line-height: 1.6;
+  font-family: var(--font-sans, Inter), system-ui, sans-serif; font-size: .88em; line-height: 1.6;
   color: var(--fg);
 }
 .blog-post-page .post-body .callout-label {
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: .14em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 10px; letter-spacing: .14em;
   text-transform: uppercase; color: var(--accent); font-weight: 700;
   margin-bottom: 6px; display: block;
 }
-.blog-post-page .post-body .callout p { font-family: var(--font-sans); font-size: inherit; line-height: inherit; }
+.blog-post-page .post-body .callout p { font-family: var(--font-sans, Inter), system-ui, sans-serif; font-size: inherit; line-height: inherit; }
 
 /* Figure */
 .blog-post-page .post-body figure { margin: 2em 0; }
@@ -454,12 +450,12 @@
 .blog-post-page .post-body figure figcaption {
   margin-top: 10px;
   display: flex; align-items: baseline; gap: 10px;
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; letter-spacing: .08em;
   text-transform: uppercase; color: var(--fg-subtle);
 }
 .blog-post-page .post-body figure figcaption .num { color: var(--accent); font-weight: 700; }
 .blog-post-page .post-body figure figcaption .cap {
-  font-family: var(--font-serif); font-style: italic; text-transform: none;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-style: italic; text-transform: none;
   letter-spacing: 0; font-size: 13px; color: var(--fg-muted);
 }
 
@@ -477,12 +473,12 @@
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--bg-secondary);
-  font-family: var(--font-sans);
+  font-family: var(--font-sans, Inter), system-ui, sans-serif;
   font-size: 15px;
 }
 .blog-post-page .post-toc-label {
   display: flex; align-items: center; gap: 12px;
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: .14em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 10px; letter-spacing: .14em;
   text-transform: uppercase; color: var(--fg-subtle); font-weight: 600;
   margin-bottom: 12px;
 }
@@ -502,7 +498,7 @@
 }
 .blog-post-page .post-toc ol li::before {
   content: counter(toc, decimal-leading-zero);
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; letter-spacing: .08em;
   color: var(--accent); font-weight: 600;
   min-width: 2.4em;
 }
@@ -520,7 +516,7 @@
   border-top: 1px solid var(--border);
 }
 .blog-post-page .post-footnotes-label {
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; letter-spacing: .14em;
   text-transform: uppercase; color: var(--fg-subtle); font-weight: 600;
   margin-bottom: 18px;
 }
@@ -563,20 +559,20 @@
 }
 .blog-post-page .post-bio .bio-content { display: flex; flex-direction: column; gap: 8px; }
 .blog-post-page .post-bio .bio-label {
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: .14em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 10px; letter-spacing: .14em;
   text-transform: uppercase; color: var(--accent); font-weight: 700;
 }
 .blog-post-page .post-bio .bio-name {
-  margin: 0; font-family: var(--font-serif); font-weight: 800;
+  margin: 0; font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 800;
   font-size: 22px; letter-spacing: -.01em; color: var(--fg);
 }
 .blog-post-page .post-bio .bio-desc {
-  margin: 0; font-family: var(--font-sans); font-size: 14px; line-height: 1.6;
+  margin: 0; font-family: var(--font-sans, Inter), system-ui, sans-serif; font-size: 14px; line-height: 1.6;
   color: var(--fg-muted); max-width: 60ch;
 }
 .blog-post-page .post-bio .bio-links {
   display: flex; gap: 14px; margin-top: 6px; flex-wrap: wrap;
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; letter-spacing: .08em;
   text-transform: uppercase;
 }
 .blog-post-page .post-bio .bio-links a {
@@ -615,11 +611,11 @@
   border-bottom: 1px solid var(--border);
 }
 .blog-post-page .comments-head h3 {
-  margin: 0; font-family: var(--font-serif); font-weight: 700;
+  margin: 0; font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 700;
   font-size: 22px; letter-spacing: -.01em;
 }
 .blog-post-page .comments-head .count {
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; letter-spacing: .08em;
   color: var(--accent); text-transform: uppercase;
 }
 
@@ -645,15 +641,15 @@
   border-bottom: 1px solid var(--border);
 }
 .blog-post-page .related-section .section-head .num {
-  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 11px; font-weight: 600;
   letter-spacing: .14em; text-transform: uppercase; opacity: .6;
 }
 .blog-post-page .related-section .section-head h2 {
-  font-family: var(--font-serif); font-weight: 700;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif; font-weight: 700;
   font-size: 28px; letter-spacing: -.015em; margin: 0; line-height: 1.2;
 }
 .blog-post-page .related-section .section-head .more {
-  font-family: var(--font-mono); font-size: 12px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace; font-size: 12px;
   text-transform: uppercase; letter-spacing: .08em;
   color: var(--accent); text-decoration: none;
 }

--- a/src/styles/blog-post.css
+++ b/src/styles/blog-post.css
@@ -1,0 +1,660 @@
+/* =========================================================
+   Blog post page — editorial "portrait" variation.
+   Ported from handoff-portrait/styles/post.css, scoped under
+   .blog-post-page so it cannot leak into other routes.
+   ========================================================= */
+
+.blog-post-page {
+  /* Palette aliases (match editorial-home.css + Tailwind tokens) */
+  --parchment-50:  #fefdfb;
+  --parchment-100: #fbf7f0;
+  --parchment-200: #f5f0e6;
+  --parchment-300: #e8e0d0;
+  --parchment-400: #d1c7b7;
+  --parchment-500: #b8a88f;
+  --parchment-600: #8b7355;
+  --charcoal-50:   #2c3e50;
+  --charcoal-100:  #1f2d3d;
+  --charcoal-300:  #16213e;
+  --charcoal-400:  #1a1a2e;
+  --charcoal-500:  #141428;
+  --charcoal-600:  #0f0f1f;
+  --burnt-300: #f6ad55;
+  --burnt-400: #e67e22;
+  --burnt-500: #d35400;
+  --amber-300: #fcd34d;
+  --amber-400: #f39c12;
+  --amber-500: #f59e0b;
+  --sky-400:  #38bdf8;
+  --blue-600: #2563eb;
+  --green-500: #22c55e;
+  --green-700: #15803d;
+
+  --bg:           var(--parchment-100);
+  --bg-secondary: var(--parchment-200);
+  --bg-elevated:  var(--parchment-50);
+
+  --fg:           var(--charcoal-50);
+  --fg-muted:     var(--parchment-600);
+  --fg-subtle:    var(--parchment-500);
+
+  --border:        rgb(139 115 85 / .25);
+  --border-strong: rgb(139 115 85 / .5);
+
+  --accent:       var(--burnt-400);
+  --accent-hover: var(--burnt-500);
+  --accent-soft:  rgb(230 126 34 / .10);
+  --accent-ring:  rgb(230 126 34 / .25);
+
+  --link:       var(--burnt-500);
+  --link-hover: var(--burnt-400);
+
+  --shadow-lg: 0 18px 32px -16px rgb(24 24 40 / .25);
+  --shadow-xl: 0 24px 48px -20px rgb(24 24 40 / .35);
+
+  --font-serif: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  --font-sans:  var(--font-sans, Inter), system-ui, sans-serif;
+  --font-mono:  var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+
+  background-color: var(--bg);
+  color: var(--fg);
+}
+
+.dark .blog-post-page {
+  --bg:           var(--charcoal-400);
+  --bg-secondary: var(--charcoal-500);
+  --bg-elevated:  var(--charcoal-300);
+
+  --fg:         #fbf7f0;
+  --fg-muted:   #cbd5e1;
+  --fg-subtle:  #94a3b8;
+
+  --border:        rgb(148 163 184 / .2);
+  --border-strong: rgb(148 163 184 / .4);
+
+  --accent:       var(--amber-400);
+  --accent-hover: var(--amber-300);
+  --accent-soft:  rgb(243 156 18 / .12);
+  --accent-ring:  rgb(243 156 18 / .25);
+
+  --link:       var(--amber-300);
+  --link-hover: var(--amber-400);
+}
+
+.blog-post-page {
+  min-height: 100vh;
+  position: relative;
+  isolation: isolate;
+}
+.blog-post-page::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-image:
+    linear-gradient(rgb(139 115 85 / .05) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(139 115 85 / .05) 1px, transparent 1px),
+    radial-gradient(ellipse at top left, rgb(230 126 34 / .025), transparent 60%);
+  background-size: 120px 120px, 120px 120px, 100% 100%;
+  pointer-events: none;
+}
+.dark .blog-post-page::before {
+  background-image:
+    linear-gradient(rgb(148 163 184 / .03) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(148 163 184 / .03) 1px, transparent 1px);
+  background-size: 120px 120px, 120px 120px;
+}
+
+.blog-post-page .post-container {
+  max-width: 1280px; margin: 0 auto; padding: 0 24px;
+}
+.blog-post-page .container-narrow {
+  max-width: 720px; margin: 0 auto; padding: 0 24px;
+}
+
+/* Breadcrumb strip */
+.blog-post-page .post-crumbs {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--fg-subtle);
+  padding: 22px 0 0;
+  flex-wrap: wrap;
+}
+.blog-post-page .post-crumbs a { color: var(--fg-muted); text-decoration: none; border-bottom: 1px solid var(--border); padding-bottom: 1px; }
+.blog-post-page .post-crumbs a:hover { color: var(--accent); border-color: var(--accent); }
+.blog-post-page .post-crumbs .sep { opacity: .5; }
+.blog-post-page .post-crumbs .current { color: var(--accent); }
+
+/* Reading progress */
+.blog-post-page .reading-progress {
+  position: fixed; top: 0; left: 0; right: 0; height: 2px;
+  background: transparent; z-index: 50; pointer-events: none;
+}
+.blog-post-page .reading-progress-fill {
+  height: 100%; width: 0%; background: var(--accent);
+  transition: width .12s linear;
+  box-shadow: 0 0 8px rgba(230,126,34,.5);
+}
+
+/* Header kicker + title + dek + meta */
+.blog-post-page .post-kicker {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--fg-subtle); font-weight: 600;
+}
+.blog-post-page .post-kicker::before {
+  content: ''; width: 24px; height: 1px; background: var(--accent);
+}
+.blog-post-page .post-title {
+  margin: 4px 0 0;
+  font-family: var(--font-serif); font-weight: 800;
+  font-size: clamp(40px, 4.6vw, 64px); line-height: 1.04;
+  letter-spacing: -.025em; color: var(--fg);
+  text-wrap: balance;
+}
+.blog-post-page .post-title em { font-style: normal; color: var(--accent); font-weight: 700; }
+.blog-post-page .post-dek {
+  font-family: var(--font-serif); font-weight: 400;
+  font-size: clamp(18px, 1.6vw, 22px); line-height: 1.5;
+  color: var(--fg-muted);
+  max-width: 62ch; text-wrap: pretty;
+  margin: 22px 0 0;
+}
+.blog-post-page .post-meta-dl {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  padding: 18px 0;
+  border-top: 1px solid var(--border); border-bottom: 1px solid var(--border);
+  margin-top: 36px;
+}
+.blog-post-page .post-meta-dl > div {
+  padding: 0 20px;
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 4px;
+}
+.blog-post-page .post-meta-dl > div:first-child { padding-left: 0; }
+.blog-post-page .post-meta-dl > div:last-child { border-right: 0; padding-right: 0; }
+.blog-post-page .post-meta-dl dt {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em;
+  color: var(--fg-subtle); text-transform: uppercase; margin: 0;
+}
+.blog-post-page .post-meta-dl dd {
+  margin: 0; font-family: var(--font-serif); font-weight: 700;
+  font-size: 16px; letter-spacing: -.005em; color: var(--fg);
+}
+.blog-post-page .post-meta-dl dd .unit {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  color: var(--accent); letter-spacing: .04em; margin-left: 4px;
+}
+.blog-post-page .post-meta-dl dd a {
+  color: var(--accent); text-decoration: none;
+  border-bottom: 1px solid var(--accent-ring); padding-bottom: 1px;
+}
+.blog-post-page .post-meta-dl dd a:hover { border-bottom-color: var(--accent); }
+@media (max-width: 720px) {
+  .blog-post-page .post-meta-dl { grid-template-columns: repeat(2, 1fr); gap: 14px 0; }
+  .blog-post-page .post-meta-dl > div { padding: 0 16px; }
+  .blog-post-page .post-meta-dl > div:nth-child(2) { border-right: 0; }
+  .blog-post-page .post-meta-dl > div:nth-child(3) { padding-left: 0; }
+}
+
+/* Editorial portrait header */
+.blog-post-page .hdr-A { padding: 32px 0 40px; }
+.blog-post-page .hdr-A-grid {
+  display: grid; grid-template-columns: 1.5fr 1fr; gap: 56px; align-items: end;
+}
+.blog-post-page .hdr-A .post-kicker { margin-bottom: 24px; }
+.blog-post-page .hdr-A .post-title { margin-top: 4px; }
+.blog-post-page .hdr-A-plate {
+  aspect-ratio: 4/5; width: 100%; max-width: 360px;
+  border-radius: 2px;
+  background: linear-gradient(160deg, #b08968 0%, #6b5842 45%, #2c3e50 100%);
+  position: relative; overflow: hidden;
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 1px 0 0 rgba(230,126,34,.9), 0 24px 40px -20px rgba(24,24,40,.25);
+  margin-left: auto;
+}
+.blog-post-page .hdr-A-plate::before {
+  content: ''; position: absolute; inset: 0; z-index: 1;
+  background: repeating-linear-gradient(0deg, rgba(230,126,34,.16) 0 1px, transparent 1px 4px);
+}
+.dark .blog-post-page .hdr-A-plate {
+  background: linear-gradient(160deg, #475569 0%, #1e293b 55%, #0f172a 100%);
+  box-shadow: 0 1px 0 0 rgba(243,156,18,.7), 0 24px 40px -20px rgba(0,0,0,.6);
+}
+.dark .blog-post-page .hdr-A-plate::before {
+  background: repeating-linear-gradient(0deg, rgba(252,211,77,.13) 0 1px, transparent 1px 4px);
+}
+.blog-post-page .hdr-A-plate .plate-image {
+  object-fit: cover;
+  object-position: center;
+  filter: grayscale(100%) contrast(1.12) brightness(1.04);
+  mix-blend-mode: multiply;
+  z-index: 0;
+}
+.dark .blog-post-page .hdr-A-plate .plate-image {
+  filter: grayscale(100%) contrast(1.15) brightness(1.08);
+  mix-blend-mode: lighten;
+  opacity: .9;
+}
+.blog-post-page .hdr-A-plate .glyph {
+  position: absolute; inset: 0; z-index: 2;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-serif); font-weight: 800; font-size: 160px;
+  color: rgba(255,255,255,.3); letter-spacing: -.04em;
+  pointer-events: none;
+}
+.blog-post-page .hdr-A-plate .plate-caption {
+  position: absolute; z-index: 3;
+  left: 16px; bottom: 14px; right: 16px;
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em;
+  text-transform: uppercase; color: rgba(255,255,255,.72);
+}
+@media (max-width: 900px) {
+  .blog-post-page .hdr-A-grid { grid-template-columns: 1fr; gap: 32px; }
+  .blog-post-page .hdr-A-plate { margin-left: 0; max-width: 280px; }
+}
+
+/* Full-bleed hero figure */
+.blog-post-page .post-hero-bleed { margin-top: 36px; }
+.blog-post-page .post-figure { max-width: 880px; margin: 0 auto; padding: 0 24px; }
+.blog-post-page .post-hero-bleed figure img {
+  display: block; width: 100%; height: auto;
+  border: 1px solid var(--border); border-radius: 4px;
+}
+.blog-post-page .post-hero-bleed figcaption {
+  max-width: 880px; margin-left: auto; margin-right: auto; padding: 10px 0 0;
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--fg-subtle);
+}
+.blog-post-page .post-hero-bleed figcaption .num { color: var(--accent); font-weight: 700; }
+.blog-post-page .post-hero-bleed figcaption .cap {
+  font-family: var(--font-serif); font-style: italic; text-transform: none;
+  letter-spacing: 0; font-size: 13px; color: var(--fg-muted);
+}
+
+/* Share rail */
+.blog-post-page .share-rail {
+  position: fixed; left: calc((100vw - 1280px) / 2 + 12px);
+  top: 40%;
+  display: flex; flex-direction: column; gap: 8px;
+  z-index: 20;
+}
+@media (max-width: 1380px) { .blog-post-page .share-rail { display: none; } }
+.blog-post-page .share-btn {
+  width: 38px; height: 38px; border-radius: 6px;
+  border: 1px solid var(--border-strong); background: var(--bg-elevated);
+  color: var(--fg); display: inline-flex; align-items: center; justify-content: center;
+  cursor: pointer; transition: color .15s, border-color .15s, transform .15s;
+}
+.blog-post-page .share-btn:hover { color: var(--accent); border-color: var(--accent); transform: translateY(-1px); }
+.blog-post-page .share-btn svg { width: 15px; height: 15px; }
+.blog-post-page .share-btn-label {
+  font-family: var(--font-mono); font-size: 9px; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--fg-subtle); text-align: center;
+  writing-mode: vertical-rl; transform: rotate(180deg);
+  padding: 6px 0 4px;
+}
+
+/* Layout */
+.blog-post-page .layout-A {
+  max-width: 720px; margin: 0 auto; padding: 40px 24px 40px;
+}
+
+/* Post body — longform */
+.blog-post-page .post-body {
+  font-family: var(--font-serif);
+  font-size: 19px;
+  line-height: 1.72;
+  color: var(--fg);
+  letter-spacing: -.003em;
+}
+.blog-post-page .post-body > * + * { margin-top: 1.1em; }
+.blog-post-page .post-body p { margin: 0; text-wrap: pretty; color: var(--fg); }
+.blog-post-page .post-body p + p { margin-top: 1.1em; }
+.blog-post-page .post-body strong { color: var(--fg); font-weight: 700; }
+.blog-post-page .post-body em { font-style: italic; }
+.blog-post-page .post-body a {
+  color: var(--link); text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, var(--link) 40%, transparent);
+  text-underline-offset: 3px;
+}
+.blog-post-page .post-body a:hover { color: var(--link-hover); text-decoration-color: var(--link-hover); }
+
+.blog-post-page .post-body h1 {
+  margin: 1.6em 0 .4em;
+  font-family: var(--font-serif); font-weight: 800;
+  font-size: 1.8em; line-height: 1.15; letter-spacing: -.02em;
+  color: var(--fg);
+}
+.blog-post-page .post-body h2 {
+  margin: 2.2em 0 .6em;
+  font-family: var(--font-serif); font-weight: 800;
+  font-size: 1.55em; line-height: 1.2; letter-spacing: -.015em;
+  color: var(--fg);
+  display: flex; align-items: baseline; gap: 14px;
+}
+.blog-post-page .post-body h2[data-n]::before {
+  content: attr(data-n);
+  font-family: var(--font-mono); font-size: .44em; font-weight: 600;
+  letter-spacing: .12em; color: var(--accent);
+  padding-top: .35em;
+  min-width: 3em;
+  flex-shrink: 0;
+}
+.blog-post-page .post-body h3 {
+  margin: 1.8em 0 .4em;
+  font-family: var(--font-serif); font-weight: 700;
+  font-size: 1.22em; line-height: 1.25; letter-spacing: -.01em;
+  color: var(--fg);
+}
+.blog-post-page .post-body h4 {
+  margin: 1.4em 0 .3em;
+  font-family: var(--font-sans); font-weight: 600;
+  font-size: 1em; letter-spacing: .02em;
+  color: var(--fg-muted); text-transform: uppercase;
+}
+.blog-post-page .post-body ul,
+.blog-post-page .post-body ol { padding-left: 1.3em; margin: 1em 0; }
+.blog-post-page .post-body li { margin: .4em 0; }
+.blog-post-page .post-body li::marker { color: var(--accent); }
+.blog-post-page .post-body hr {
+  border: 0; height: 1px; background: var(--border);
+  margin: 2.6em auto; max-width: 80px;
+}
+
+/* Drop cap on the first paragraph */
+.blog-post-page .post-body .lede::first-letter {
+  font-family: var(--font-serif); font-weight: 800;
+  float: left; font-size: 4.6em; line-height: .86;
+  padding: 6px 14px 0 0; color: var(--accent);
+  letter-spacing: -.02em;
+}
+.blog-post-page .post-body .lede {
+  font-size: 1.08em; line-height: 1.65;
+  color: var(--fg);
+}
+
+/* Inline code */
+.blog-post-page .post-body code {
+  font-family: var(--font-mono); font-size: .86em;
+  background: var(--accent-soft); color: var(--burnt-500);
+  padding: 2px 6px; border-radius: 4px; font-weight: 600;
+  letter-spacing: 0;
+}
+.dark .blog-post-page .post-body code { color: var(--amber-300); background: rgb(28 25 23 / .5); }
+
+/* Code blocks — terminal-style chrome wrapping whatever Shiki/Prism emits */
+.blog-post-page .post-body pre {
+  margin: 1.8em 0;
+  background: #0f0f1f; color: #e2e8f0;
+  border: 1px solid #1f2d3d;
+  border-radius: 6px;
+  padding: 18px 20px;
+  overflow-x: auto;
+  font-family: var(--font-mono); font-size: 13.5px; line-height: 1.7;
+  white-space: pre;
+  tab-size: 2;
+}
+.blog-post-page .post-body pre code {
+  background: transparent; color: inherit; padding: 0; font-size: inherit;
+}
+
+/* Blockquote */
+.blog-post-page .post-body blockquote {
+  margin: 1.8em 0;
+  padding: 4px 0 4px 24px;
+  border-left: 3px solid var(--accent);
+  font-family: var(--font-serif); font-style: italic;
+  font-size: 1.08em; line-height: 1.55;
+  color: var(--fg-muted);
+}
+.blog-post-page .post-body blockquote cite {
+  display: block; margin-top: 10px;
+  font-family: var(--font-mono); font-style: normal;
+  font-size: 11px; letter-spacing: .1em;
+  color: var(--fg-subtle); text-transform: uppercase;
+}
+
+/* Pullquote */
+.blog-post-page .post-body .pullquote {
+  margin: 2.4em 0;
+  padding: 28px 0;
+  border-top: 2px solid var(--fg); border-bottom: 1px solid var(--border);
+  font-family: var(--font-serif); font-weight: 600;
+  font-size: 1.55em; line-height: 1.28; letter-spacing: -.015em;
+  color: var(--fg); text-wrap: balance;
+}
+
+/* Callout */
+.blog-post-page .post-body .callout {
+  margin: 1.8em 0;
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--accent);
+  background: var(--bg-elevated);
+  padding: 18px 20px;
+  border-radius: 4px;
+  font-family: var(--font-sans); font-size: .88em; line-height: 1.6;
+  color: var(--fg);
+}
+.blog-post-page .post-body .callout-label {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--accent); font-weight: 700;
+  margin-bottom: 6px; display: block;
+}
+.blog-post-page .post-body .callout p { font-family: var(--font-sans); font-size: inherit; line-height: inherit; }
+
+/* Figure */
+.blog-post-page .post-body figure { margin: 2em 0; }
+.blog-post-page .post-body figure img {
+  display: block; width: 100%; height: auto;
+  border: 1px solid var(--border); border-radius: 4px;
+}
+.blog-post-page .post-body figure figcaption {
+  margin-top: 10px;
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--fg-subtle);
+}
+.blog-post-page .post-body figure figcaption .num { color: var(--accent); font-weight: 700; }
+.blog-post-page .post-body figure figcaption .cap {
+  font-family: var(--font-serif); font-style: italic; text-transform: none;
+  letter-spacing: 0; font-size: 13px; color: var(--fg-muted);
+}
+
+/* Inline images without <figure> wrapper */
+.blog-post-page .post-body img {
+  max-width: 100%; height: auto; border: 1px solid var(--border); border-radius: 4px;
+  display: block; margin: 1.6em auto;
+}
+
+/* TOC (matches remark-generated list) */
+.blog-post-page .post-body .post-toc,
+.blog-post-page .post-toc {
+  margin: 2em 0;
+  padding: 22px 26px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  font-family: var(--font-sans);
+  font-size: 15px;
+}
+.blog-post-page .post-toc-label {
+  display: flex; align-items: center; gap: 12px;
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--fg-subtle); font-weight: 600;
+  margin-bottom: 12px;
+}
+.blog-post-page .post-toc-label::after {
+  content: ''; flex: 1; height: 1px; background: var(--border);
+}
+.blog-post-page .post-toc ol {
+  list-style: none; counter-reset: toc;
+  padding: 0; margin: 0;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 6px 32px;
+}
+.blog-post-page .post-toc ol li {
+  counter-increment: toc;
+  margin: 0; padding: 0;
+  display: flex; align-items: baseline; gap: 10px;
+  line-height: 1.5;
+}
+.blog-post-page .post-toc ol li::before {
+  content: counter(toc, decimal-leading-zero);
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  color: var(--accent); font-weight: 600;
+  min-width: 2.4em;
+}
+.blog-post-page .post-toc ol li::marker { content: ''; }
+.blog-post-page .post-toc a {
+  color: var(--fg); text-decoration: none; border-bottom: 1px solid transparent;
+}
+.blog-post-page .post-toc a:hover { color: var(--accent); border-color: var(--accent); }
+@media (max-width: 700px) { .blog-post-page .post-toc ol { grid-template-columns: 1fr; } }
+
+/* Footnotes */
+.blog-post-page .post-footnotes {
+  margin-top: 4em;
+  padding-top: 28px; padding-bottom: 8px;
+  border-top: 1px solid var(--border);
+}
+.blog-post-page .post-footnotes-label {
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--fg-subtle); font-weight: 600;
+  margin-bottom: 18px;
+}
+
+/* Author bio */
+.blog-post-page .post-bio {
+  margin-top: 3em;
+  display: grid; grid-template-columns: 120px 1fr;
+  gap: 24px;
+  padding: 28px 0;
+  border-top: 2px solid var(--fg); border-bottom: 1px solid var(--border);
+}
+.blog-post-page .post-bio .bio-plate {
+  width: 120px; aspect-ratio: 4/5;
+  border-radius: 2px;
+  background: linear-gradient(160deg, #b08968 0%, #6b5842 45%, #2c3e50 100%);
+  position: relative; overflow: hidden;
+  border: 1px solid var(--border-strong);
+}
+.dark .blog-post-page .post-bio .bio-plate {
+  background: linear-gradient(160deg, #475569 0%, #1e293b 55%, #0f172a 100%);
+}
+.blog-post-page .post-bio .bio-plate::before {
+  content: ''; position: absolute; inset: 0; z-index: 1;
+  background: repeating-linear-gradient(0deg, rgba(230,126,34,.16) 0 1px, transparent 1px 4px);
+}
+.dark .blog-post-page .post-bio .bio-plate::before {
+  background: repeating-linear-gradient(0deg, rgba(252,211,77,.13) 0 1px, transparent 1px 4px);
+}
+.blog-post-page .post-bio .bio-plate .plate-image {
+  object-fit: cover; object-position: center;
+  filter: grayscale(100%) contrast(1.12) brightness(1.04);
+  mix-blend-mode: multiply;
+  z-index: 0;
+}
+.dark .blog-post-page .post-bio .bio-plate .plate-image {
+  filter: grayscale(100%) contrast(1.15) brightness(1.08);
+  mix-blend-mode: lighten;
+  opacity: .9;
+}
+.blog-post-page .post-bio .bio-content { display: flex; flex-direction: column; gap: 8px; }
+.blog-post-page .post-bio .bio-label {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--accent); font-weight: 700;
+}
+.blog-post-page .post-bio .bio-name {
+  margin: 0; font-family: var(--font-serif); font-weight: 800;
+  font-size: 22px; letter-spacing: -.01em; color: var(--fg);
+}
+.blog-post-page .post-bio .bio-desc {
+  margin: 0; font-family: var(--font-sans); font-size: 14px; line-height: 1.6;
+  color: var(--fg-muted); max-width: 60ch;
+}
+.blog-post-page .post-bio .bio-links {
+  display: flex; gap: 14px; margin-top: 6px; flex-wrap: wrap;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.blog-post-page .post-bio .bio-links a {
+  color: var(--fg-muted); text-decoration: none;
+  border-bottom: 1px solid var(--border); padding-bottom: 1px;
+}
+.blog-post-page .post-bio .bio-links a:hover { color: var(--accent); border-color: var(--accent); }
+@media (max-width: 600px) {
+  .blog-post-page .post-bio { grid-template-columns: 1fr; }
+  .blog-post-page .post-bio .bio-plate { width: 84px; }
+}
+
+/* Inline newsletter card (in-article) */
+.blog-post-page .inline-newsletter-card {
+  margin: 3em 0;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  padding: 28px 30px;
+  border-radius: 6px;
+  position: relative;
+}
+.blog-post-page .inline-newsletter-card::before {
+  content: '';
+  position: absolute; top: -1px; left: -1px; width: 40%; height: 3px;
+  background: var(--accent);
+}
+
+/* Comments wrapper */
+.blog-post-page .post-comments {
+  padding: 48px 0 32px;
+  border-top: 1px solid var(--border);
+}
+.blog-post-page .comments-head {
+  display: flex; align-items: baseline; gap: 16px;
+  margin-bottom: 24px; padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+}
+.blog-post-page .comments-head h3 {
+  margin: 0; font-family: var(--font-serif); font-weight: 700;
+  font-size: 22px; letter-spacing: -.01em;
+}
+.blog-post-page .comments-head .count {
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+  color: var(--accent); text-transform: uppercase;
+}
+
+/* Related/further reading */
+.blog-post-page .related-section {
+  padding: 64px 0 48px;
+  border-top: 1px solid var(--border);
+  background-color: var(--bg-secondary);
+  background-image:
+    linear-gradient(rgb(139 115 85 / .05) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(139 115 85 / .05) 1px, transparent 1px);
+  background-size: 40px 40px, 40px 40px;
+}
+.dark .blog-post-page .related-section {
+  background-image:
+    linear-gradient(rgb(148 163 184 / .035) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(148 163 184 / .035) 1px, transparent 1px);
+}
+.blog-post-page .related-section .section-head {
+  display: grid; grid-template-columns: auto 1fr auto;
+  align-items: baseline; gap: 16px;
+  margin-bottom: 28px; padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.blog-post-page .related-section .section-head .num {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  letter-spacing: .14em; text-transform: uppercase; opacity: .6;
+}
+.blog-post-page .related-section .section-head h2 {
+  font-family: var(--font-serif); font-weight: 700;
+  font-size: 28px; letter-spacing: -.015em; margin: 0; line-height: 1.2;
+}
+.blog-post-page .related-section .section-head .more {
+  font-family: var(--font-mono); font-size: 12px;
+  text-transform: uppercase; letter-spacing: .08em;
+  color: var(--accent); text-decoration: none;
+}
+.blog-post-page .related-section .section-head .more:hover { text-decoration: underline; }

--- a/src/styles/editorial-home.css
+++ b/src/styles/editorial-home.css
@@ -222,11 +222,23 @@
     0 24px 40px -20px rgba(0, 0, 0, 0.6);
   background: linear-gradient(160deg, #475569 0%, #1e293b 55%, #0f172a 100%);
 }
+.editorial-portrait-image {
+  object-fit: cover;
+  object-position: center top;
+  filter: grayscale(100%) contrast(1.12) brightness(1.04);
+  mix-blend-mode: multiply;
+}
+.dark .editorial-portrait-image {
+  filter: grayscale(100%) contrast(1.15) brightness(1.08);
+  mix-blend-mode: lighten;
+  opacity: 0.9;
+}
 .editorial-portrait::before {
   content: '';
   position: absolute;
   inset: 0;
-  z-index: 1;
+  z-index: 2;
+  pointer-events: none;
   background: repeating-linear-gradient(
     0deg,
     rgba(230, 126, 34, 0.18) 0 1px,

--- a/src/styles/editorial-home.css
+++ b/src/styles/editorial-home.css
@@ -1,0 +1,408 @@
+/* Editorial homepage — engineering-paper background + hero primitives.
+ * Import once from src/app/layout.tsx or src/app/globals.css.
+ *
+ * Relies on tokens already present in the repo's Tailwind config:
+ *   parchment-*, charcoal-*, burnt-*, amber-*, slate-* ...
+ * plus the fonts registered in layout.tsx: --font-serif (Source Serif 4),
+ * --font-sans (Inter), --font-mono (adds JetBrains Mono — see DIFF.md).
+ *
+ * Everything here is additive. Remove this file to revert.
+ */
+
+/* ---------- Engineering paper background (whole page) ----- */
+.editorial-home {
+  background-color: #fbf7f0; /* parchment-100 */
+  background-image:
+    linear-gradient(rgba(139, 115, 85, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139, 115, 85, 0.05) 1px, transparent 1px),
+    radial-gradient(ellipse at top left, rgba(230, 126, 34, 0.025), transparent 60%);
+  background-size: 120px 120px, 120px 120px, 100% 100%;
+  background-attachment: fixed;
+}
+.dark .editorial-home {
+  background-color: #1a1a2e; /* charcoal-400 */
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.03) 1px, transparent 1px);
+  background-size: 120px 120px, 120px 120px;
+}
+
+/* Sections with .editorial-section-alt get a slightly stronger 40px grid */
+.editorial-section-alt {
+  background-color: #f5f0e6; /* parchment-200 */
+  background-image:
+    linear-gradient(rgba(139, 115, 85, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139, 115, 85, 0.05) 1px, transparent 1px);
+  background-size: 40px 40px, 40px 40px;
+}
+.dark .editorial-section-alt {
+  background-color: #141428; /* charcoal-500 */
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.035) 1px, transparent 1px);
+  background-size: 40px 40px, 40px 40px;
+}
+
+/* ---------- Hero typography -------------------------------- */
+.editorial-hero-h1 {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 800;
+  font-size: clamp(40px, 5vw, 58px);
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+  margin: 16px 0 0;
+}
+
+.editorial-eyebrow {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.editorial-lede {
+  margin: 28px 0 0;
+  font-size: 19px;
+  line-height: 1.6;
+  max-width: 56ch;
+  text-wrap: pretty;
+}
+
+/* Hero newsletter — inline (no card, no border) */
+.editorial-capture {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 560px;
+}
+.editorial-capture-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.editorial-capture-label::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.2;
+}
+.editorial-capture-title {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  line-height: 1.35;
+  margin: 0;
+}
+.editorial-capture-row {
+  display: flex;
+  gap: 8px;
+}
+.editorial-capture-row input {
+  flex: 1;
+  font-family: inherit;
+  font-size: 15px;
+  padding: 13px 16px;
+  border-radius: 6px;
+  background: #fefdfb;
+  border: 1px solid #d1c7b7;
+  color: #2c3e50;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.dark .editorial-capture-row input {
+  background: #1e293b;
+  border-color: #475569;
+  color: #fbf7f0;
+}
+.editorial-capture-row input:focus {
+  outline: none;
+  border-color: #e67e22;
+  box-shadow: 0 0 0 3px rgba(230, 126, 34, 0.25);
+}
+.dark .editorial-capture-row input:focus {
+  border-color: #f39c12;
+  box-shadow: 0 0 0 3px rgba(243, 156, 18, 0.25);
+}
+.editorial-capture-fine {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+@media (max-width: 540px) {
+  .editorial-capture-row {
+    flex-direction: column;
+  }
+}
+
+/* Secondary links under hero */
+.editorial-secondary {
+  margin-top: 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+.editorial-secondary a {
+  text-decoration: none;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+  padding-bottom: 1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.dark .editorial-secondary a {
+  border-bottom-color: rgba(255, 255, 255, 0.15);
+}
+.editorial-secondary a:hover {
+  border-bottom-color: currentColor;
+}
+
+/* Hero meta (DL) */
+.editorial-meta {
+  margin: 28px 0 0;
+  padding: 14px 0 0;
+  border-top: 1px solid rgba(139, 115, 85, 0.25);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 18px;
+  row-gap: 6px;
+  font-size: 13px;
+}
+.dark .editorial-meta {
+  border-top-color: rgba(148, 163, 184, 0.2);
+}
+.editorial-meta dt {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.editorial-meta dd {
+  margin: 0;
+}
+
+/* Portrait frame */
+.editorial-portrait {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  max-width: 340px;
+  border-radius: 2px;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid #d1c7b7;
+  box-shadow: 0 1px 0 0 rgba(230, 126, 34, 0.9),
+    0 24px 40px -20px rgba(24, 24, 40, 0.25);
+  background: linear-gradient(160deg, #b08968 0%, #6b5842 45%, #2c3e50 100%);
+}
+.dark .editorial-portrait {
+  border-color: #475569;
+  box-shadow: 0 1px 0 0 rgba(243, 156, 18, 0.7),
+    0 24px 40px -20px rgba(0, 0, 0, 0.6);
+  background: linear-gradient(160deg, #475569 0%, #1e293b 55%, #0f172a 100%);
+}
+.editorial-portrait::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(230, 126, 34, 0.18) 0 1px,
+    transparent 1px 4px
+  );
+}
+.dark .editorial-portrait::before {
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(252, 211, 77, 0.15) 0 1px,
+    transparent 1px 4px
+  );
+}
+.editorial-portrait-caption {
+  margin-top: 10px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+/* ---------- Stat row --------------------------------------- */
+.editorial-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid rgba(139, 115, 85, 0.3);
+  border-bottom: 1px solid rgba(139, 115, 85, 0.3);
+}
+.dark .editorial-stats {
+  border-color: rgba(148, 163, 184, 0.25);
+}
+.editorial-stat {
+  padding: 24px 20px;
+  border-right: 1px solid rgba(139, 115, 85, 0.15);
+}
+.dark .editorial-stat {
+  border-right-color: rgba(148, 163, 184, 0.15);
+}
+.editorial-stat:last-child {
+  border-right: 0;
+}
+.editorial-stat-num {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 800;
+  font-size: 40px;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.editorial-stat-num .unit {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 14px;
+  font-weight: 600;
+  margin-left: 4px;
+  opacity: 0.6;
+}
+.editorial-stat-label {
+  margin-top: 8px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 500;
+  opacity: 0.7;
+}
+@media (max-width: 780px) {
+  .editorial-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .editorial-stat:nth-child(2) {
+    border-right: 0;
+  }
+  .editorial-stat:nth-child(1),
+  .editorial-stat:nth-child(2) {
+    border-bottom: 1px solid rgba(139, 115, 85, 0.15);
+  }
+}
+
+/* ---------- Section head (rule + number + title + more) ---- */
+.editorial-section-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 16px;
+  margin-bottom: 28px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(139, 115, 85, 0.3);
+}
+.dark .editorial-section-head {
+  border-bottom-color: rgba(148, 163, 184, 0.2);
+}
+.editorial-section-num {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+.editorial-section-title {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 700;
+  font-size: 28px;
+  letter-spacing: -0.015em;
+  margin: 0;
+  line-height: 1.2;
+}
+.editorial-section-more {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+}
+
+/* ---------- Rule label (pre-feature) ----------------------- */
+.editorial-rule-label {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.55;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.editorial-rule-label::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.25;
+}
+
+/* ---------- Colophon footer -------------------------------- */
+.editorial-colophon {
+  border-top: 1px solid rgba(139, 115, 85, 0.3);
+  padding-top: 48px;
+  padding-bottom: 40px;
+  font-size: 14px;
+}
+.dark .editorial-colophon {
+  border-top-color: rgba(148, 163, 184, 0.2);
+}
+.editorial-colophon h4 {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin: 0 0 12px;
+  opacity: 0.6;
+}
+.editorial-colophon ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.editorial-colophon a {
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s;
+}
+.editorial-colophon a:hover {
+  border-bottom-color: currentColor;
+}
+.editorial-colophon-rule {
+  margin-top: 40px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(139, 115, 85, 0.25);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  opacity: 0.55;
+}
+.dark .editorial-colophon-rule {
+  border-top-color: rgba(148, 163, 184, 0.15);
+}
+@media (max-width: 720px) {
+  .editorial-colophon-rule {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/editorial-home.css
+++ b/src/styles/editorial-home.css
@@ -208,7 +208,7 @@
 .editorial-portrait {
   width: 100%;
   aspect-ratio: 4 / 5;
-  max-width: 340px;
+  max-width: 440px;
   border-radius: 2px;
   position: relative;
   overflow: hidden;

--- a/src/styles/editorial-home.css
+++ b/src/styles/editorial-home.css
@@ -204,11 +204,34 @@
   margin: 0;
 }
 
+/* Hero right-column plate: portrait + caption + meta + pull-quote */
+.editorial-hero-plate {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.editorial-hero-plate .editorial-meta {
+  margin: 0;
+  padding: 18px 0 0;
+}
+.editorial-hero-plate-quote {
+  margin-top: 6px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .editorial-hero-plate-quote {
+  border-top-color: rgba(148, 163, 184, 0.2);
+}
+.editorial-hero-plate-quote blockquote {
+  margin: 10px 0 0;
+  text-wrap: balance;
+  quotes: "\201C" "\201D";
+}
+
 /* Portrait frame */
 .editorial-portrait {
   width: 100%;
   aspect-ratio: 4 / 5;
-  max-width: 440px;
   border-radius: 2px;
   position: relative;
   overflow: hidden;

--- a/src/styles/editorial-home.css
+++ b/src/styles/editorial-home.css
@@ -11,16 +11,28 @@
 
 /* ---------- Engineering paper background (whole page) ----- */
 .editorial-home {
+  position: relative;
   background-color: #fbf7f0; /* parchment-100 */
+}
+.editorial-home::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
   background-image:
     linear-gradient(rgba(139, 115, 85, 0.05) 1px, transparent 1px),
     linear-gradient(90deg, rgba(139, 115, 85, 0.05) 1px, transparent 1px),
     radial-gradient(ellipse at top left, rgba(230, 126, 34, 0.025), transparent 60%);
   background-size: 120px 120px, 120px 120px, 100% 100%;
-  background-attachment: fixed;
+  pointer-events: none;
 }
 .dark .editorial-home {
   background-color: #1a1a2e; /* charcoal-400 */
+}
+.dark .editorial-home::before {
   background-image:
     linear-gradient(rgba(148, 163, 184, 0.03) 1px, transparent 1px),
     linear-gradient(90deg, rgba(148, 163, 184, 0.03) 1px, transparent 1px);
@@ -290,6 +302,10 @@
   .editorial-stat:nth-child(1),
   .editorial-stat:nth-child(2) {
     border-bottom: 1px solid rgba(139, 115, 85, 0.15);
+  }
+  .dark .editorial-stat:nth-child(1),
+  .dark .editorial-stat:nth-child(2) {
+    border-bottom-color: rgba(148, 163, 184, 0.15);
   }
 }
 

--- a/src/styles/editorial-home.css
+++ b/src/styles/editorial-home.css
@@ -12,6 +12,7 @@
 /* ---------- Engineering paper background (whole page) ----- */
 .editorial-home {
   position: relative;
+  isolation: isolate;
   background-color: #fbf7f0; /* parchment-100 */
 }
 .editorial-home::before {

--- a/src/styles/editorial-home.css
+++ b/src/styles/editorial-home.css
@@ -434,3 +434,159 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ---------- Editorial card ---------------------------------- */
+.editorial-card {
+  position: relative;
+  background: #fefdfb;
+  border: 1px solid rgba(139, 115, 85, 0.25);
+  border-radius: 2px;
+  overflow: hidden;
+  transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+.dark .editorial-card {
+  background: #1e293b;
+  border-color: rgba(148, 163, 184, 0.2);
+}
+.editorial-card:hover {
+  border-color: rgba(230, 126, 34, 0.6);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px -18px rgba(24, 24, 40, 0.35);
+}
+.dark .editorial-card:hover {
+  border-color: rgba(243, 156, 18, 0.55);
+  box-shadow: 0 12px 28px -18px rgba(0, 0, 0, 0.6);
+}
+.editorial-card-link {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+.editorial-card-meta {
+  padding: 12px 16px 10px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(44, 62, 80, 0.55);
+  border-bottom: 1px dashed rgba(139, 115, 85, 0.2);
+}
+.dark .editorial-card-meta {
+  color: rgba(226, 232, 240, 0.55);
+  border-bottom-color: rgba(148, 163, 184, 0.18);
+}
+.editorial-card-media {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  background-color: #f5f0e6;
+  background-image:
+    linear-gradient(rgba(139, 115, 85, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139, 115, 85, 0.08) 1px, transparent 1px);
+  background-size: 24px 24px;
+  overflow: hidden;
+}
+.dark .editorial-card-media {
+  background-color: #0f172a;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.06) 1px, transparent 1px);
+}
+.editorial-card-image {
+  object-fit: cover;
+  object-position: center;
+  transition: transform 0.5s ease;
+}
+.editorial-card:hover .editorial-card-image {
+  transform: scale(1.03);
+}
+.editorial-card-rule {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    #e67e22 0%,
+    rgba(230, 126, 34, 0.25) 60%,
+    transparent 100%
+  );
+}
+.dark .editorial-card-rule {
+  background: linear-gradient(
+    90deg,
+    #f39c12 0%,
+    rgba(243, 156, 18, 0.25) 60%,
+    transparent 100%
+  );
+}
+.editorial-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  flex: 1;
+}
+.editorial-card-date {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(44, 62, 80, 0.6);
+}
+.dark .editorial-card-date {
+  color: rgba(226, 232, 240, 0.55);
+}
+.editorial-card-title {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 700;
+  font-size: 19px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: #1a1a2e;
+  text-wrap: balance;
+}
+.dark .editorial-card-title {
+  color: #fbf7f0;
+}
+.editorial-card-desc {
+  font-size: 14px;
+  line-height: 1.55;
+  color: rgba(44, 62, 80, 0.75);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.dark .editorial-card-desc {
+  color: rgba(226, 232, 240, 0.75);
+}
+.editorial-card-footer {
+  margin-top: auto;
+  padding-top: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.editorial-card-read {
+  color: #e67e22;
+  font-weight: 600;
+}
+.dark .editorial-card-read {
+  color: #f39c12;
+}
+.editorial-card-index {
+  color: rgba(44, 62, 80, 0.45);
+}
+.dark .editorial-card-index {
+  color: rgba(226, 232, 240, 0.4);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -102,7 +102,7 @@
 
 /* Serif headline styling */
 .authority-headline {
-  font-family: var(--font-source-serif), Georgia, serif;
+  font-family: var(--font-serif), Georgia, serif;
   @apply text-charcoal-50 dark:text-parchment-100;
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,8 +29,9 @@ export default {
     typography: typographyStyles,
     extend: {
       fontFamily: {
-        serif: ['var(--font-source-serif)', 'Georgia', 'serif'],
-        sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
+        serif: ['var(--font-serif)', 'Georgia', 'serif'],
+        sans: ['var(--font-sans)', 'system-ui', 'sans-serif'],
+        mono: ['var(--font-mono)', 'ui-monospace', 'monospace'],
       },
       colors: {
         // Parchment theme - Authority glow-up palette


### PR DESCRIPTION
## Summary

Replaces the current `AuthorityHero` + `EngagementGrid` homepage with a restrained, engineering-paper editorial layout from the Claude Code design handoff. Preserves all six content loaders in `page.tsx` and all existing analytics events.

## What changed vs. the previous homepage

**Removed**
- `AuthorityHero` component usage
- `EngagementGrid` component usage
- `YoutubeEmbed` import (was unused)
- Interactive Demos section (chatbot / embeddings / tokenize `ContentCard`s) — moved off-homepage; link from Featured Project demo button
- "Knowledge Collections" header section with 3 CTA buttons
- Inline 5-star rating block + Scott McCallum blockquote (testimonials page handles this now)
- Blue gradient featured-project card

**Added**
- `EditorialHero` — serif H1, inline newsletter capture, secondary link row, meta DL, portrait plate
- `StatRow` — four-stat slab with engineering-paper borders
- `FeaturedProject` — editorial two-column with static terminal readout instead of gradient card
- Section rails now use `SectionHead` (§ number · serif title · archive link) with engineering-paper grid backgrounds on odd rails
- `ColophonFooter` — four-column end-of-page block

**Preserved**
- All six content loaders in `page.tsx` (deepMLTutorials, mlProjects, aiDev, refArchitectures, careerAdvice, videos) — zero loader changes
- `ContentCard` component — used as-is for every rail
- `ConsultationForm` modal — still wired to the "Book a consult" link in the hero
- All existing `track()` analytics calls for featured-product buttons
- Light/dark theme via existing `parchment-*` / `charcoal-*` / `burnt-*` / `amber-*` tokens

## Files changed

| File | Change |
| --- | --- |
| `src/app/HomepageClientComponent.tsx` | Full rewrite (editorial layout) |
| `src/styles/editorial-home.css` | New — engineering-paper background + primitives |
| `src/app/layout.tsx` | Added `JetBrains_Mono` (`--font-mono`), imported the new stylesheet, renamed existing font variables to `--font-serif` / `--font-sans` so the editorial CSS resolves correctly |
| `tailwind.config.ts` | Mirrored the variable rename, added `font-mono` alias |
| `src/styles/global.css` | Mirrored the variable rename (one reference) |

## Deviations from the design-handoff DIFF

1. **Newsletter endpoint** — the DIFF ships with `action="/api/subscribe"`. The repo doesn't have that route; the real endpoint is `/api/form` (EmailOctopus, JSON body). Swapped the action and converted the form from a bare `<form action>` to a JS handler that POSTs JSON to `/api/form`, preserving the `newsletter_subscribe_submit` Vercel Analytics event and adding the existing `newsletter-signup-conversion` GTM event + success/error UI. Matches the pattern in `src/components/Newsletter.jsx`.
2. **Font variables** — the existing layout exposed `--font-source-serif` / `--font-inter`. Renamed to `--font-serif` / `--font-sans` (and updated the one `global.css` / two `tailwind.config.ts` references) so the editorial CSS's `var(--font-serif)` / `var(--font-sans)` / `var(--font-mono)` all resolve. Kept the Tailwind `font-mono` alias since we were already touching that config — DIFF said the alias was nice-to-have and we're already there.
3. **`moreHref` typed-routes cast** — `typedRoutes: true` is enabled in `next.config`, so `Link href={moreHref}` with a generic `string` fails type-check. Cast `as Route` to match the repo's convention (see `src/components/AuthorityHero.tsx`).
4. **`Article` type** — replaced with `Content` (from `src/types/content.ts`) so the props match `getContentsByDirectorySlugs` return type without widening.

## Reviewer checklist (open questions from DIFF)

- [ ] **Portrait plate** — still the CSS-gradient placeholder (`.editorial-portrait`). Swap in a real B/W or duotone 4:5 portrait by replacing the `<div>` with `<Image>` or setting `background-image` in `editorial-home.css`.
- [ ] **Terminal readout values** — the `$0.14`, `0.94 faithfulness`, `340ms p95` numbers in `FeaturedProject` are editorial placeholders. Leave them or swap for real eval-run values.
- [ ] **Stat #3 `184 wpm`** — confirm you want the voice-coding line in the stat row, or drop that column (CSS handles 4/2/1 gracefully).
- [ ] **Section rail `moreHref`s** — `/blog` is correct today (no category filter exists at `/blog`). If you add `/blog?category=...` filtering later, update rails 01, 03, 04, 05.
- [ ] **Colophon /rss/feed.xml** — verify the RSS URL matches the site's real feed path.

## Analytics preserved

- `featured_product_click` (buy / demo) — hero section
- `main_cta_click` with `destination: 'consultation'`
- `newsletter_subscribe_submit` with `location: 'hero'` (new, from the rewrite)
- `newsletter-signup-conversion` GTM event (added to match the site's existing Newsletter component)

## Test plan

- [ ] `npm run build` passes locally with zero type errors (verified)
- [ ] Visual check in dev server — light and dark themes, full-width and mobile breakpoints
- [ ] Newsletter submission posts to `/api/form` and hits EmailOctopus (check a test email lands)
- [ ] All six content rails render three cards each
- [ ] "Book a consult" opens `ConsultationForm` modal
- [ ] Featured-project buy/demo buttons still fire `featured_product_click`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI/layout refactor across multiple high-traffic pages plus a new client-side blog layout with scroll/copy/bookmark effects; main risk is visual regressions, hydration issues, and broken links/analytics wiring rather than data/security concerns.
> 
> **Overview**
> Implements a site-wide **editorial “engineering-paper” redesign**: the homepage is rewritten into modular editorial sections (hero/newsletter CTA, stat slab, featured project, and standardized content rails) and adds a colophon-style footer.
> 
> Updates key pages (About, Speaking, Claude Cowork workshop) to the same editorial layout and components, including new `SectionHead`/card patterns and refreshed navigation (flattens dropdowns into a single-line nav + `Hire →` CTA).
> 
> Introduces a new `EditorialArticleLayout` for blog posts (replacing `ArticleLayout` on `/blog/[slug]`) with dedicated `blog-post.css`, reading progress/share rail, inline newsletter placement, and paywall/comment integrations; adds shared `resumeData` and new editorial styles/fonts (`JetBrains_Mono`, new CSS, Tailwind font variable renames).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69604dca4b098e4da8c6775eb6230905911cd608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->