### PR TITLE
contact: editorial Dispatch layout

### DIFF
--- a/src/app/api/consultation/route.ts
+++ b/src/app/api/consultation/route.ts
@@ -53,7 +53,7 @@ export async function POST(req: NextRequest) {
             .header { background-color: #1e40af; color: white; padding: 20px; border-radius: 5px 5px 0 0; }
             .content { background-color: #f9fafb; padding: 20px; border-radius: 0 0 5px 5px; border: 1px solid #e5e7eb; border-top: none; }
             .label { font-weight: bold; margin-bottom: 5px; color: #4b5563; }
-            .value { margin-bottom: 15px; }
+            .value { margin-bottom: 15px; white-space: pre-line; }
             .footer { margin-top: 20px; font-size: 12px; color: #6b7280; border-top: 1px solid #e5e7eb; padding-top: 10px; }
           </style>
         </head>

--- a/src/app/contact/ContactContent.jsx
+++ b/src/app/contact/ContactContent.jsx
@@ -99,7 +99,11 @@ export function ContactContent() {
     const email = form.elements.namedItem('email')?.value?.trim()
     const company = form.elements.namedItem('company')?.value?.trim()
     const rawMessage = form.elements.namedItem('message')?.value?.trim()
-    if (!name || !email || !rawMessage) return
+    if (!name || !email || !rawMessage) {
+      setStatus('err')
+      setErrorMessage('Please fill in all required fields (Name, Email, and Message)')
+      return
+    }
 
     const trackLabel = tracks.find((t) => t.id === track)?.num || track
     const scopeLine = scope ? `Budget / Timeline: ${scope}\n\n` : ''

--- a/src/app/contact/ContactContent.jsx
+++ b/src/app/contact/ContactContent.jsx
@@ -302,12 +302,12 @@ export function ContactContent() {
                   </div>
                 ) : status === 'err' ? (
                   <div className="form-status err" role="alert">
-                    {errorMessage || 'Something went wrong. Email zack@workos.com instead.'}
+                    {errorMessage || 'Something went wrong. Email zackproser@gmail.com instead.'}
                   </div>
                 ) : null}
 
                 <div className="ed-submit-row">
-                  <span className="fine">Forwarded to zack@workos.com · paid work answered first</span>
+                  <span className="fine">Forwarded to zackproser@gmail.com · paid work answered first</span>
                   <button className="ed-submit" type="submit" disabled={status === 'submitting'}>
                     {status === 'submitting' ? 'Sending…' : 'Send dispatch'} <span>→</span>
                   </button>
@@ -326,12 +326,12 @@ export function ContactContent() {
                 <button
                   type="button"
                   className="channel"
-                  onClick={() => handleCopy('zack@workos.com')}
+                  onClick={() => handleCopy('zackproser@gmail.com')}
                 >
                   <div className="ch-icon">@</div>
                   <div className="ch-body">
                     <div className="ch-title">Email</div>
-                    <div className="ch-sub">zack@workos.com</div>
+                    <div className="ch-sub">zackproser@gmail.com</div>
                   </div>
                   <div className="ch-go">Copy →</div>
                 </button>

--- a/src/app/contact/ContactContent.jsx
+++ b/src/app/contact/ContactContent.jsx
@@ -1,141 +1,412 @@
 'use client'
 
-import { useTheme } from 'next-themes'
-import { useState, useEffect } from 'react'
-import RandomPortrait from '@/components/RandomPortrait'
-import {
-  LinkedInIcon,
-  GitHubIcon,
-  TwitterIcon
-} from '@/components/SocialIcons'
-import { Mail } from 'lucide-react'
+import { useState } from 'react'
+import Link from 'next/link'
+
+const tracks = [
+  {
+    id: 'consulting',
+    num: 'T.01 · Consulting',
+    title: 'Retainer or project work.',
+    desc: 'RAG pipelines, agent harnesses, eval, developer-tool scoping. Usually 4–12 weeks, part-time.',
+    specs: [
+      ['Rate', 'From low-thousands'],
+      ['Availability', 'Selective'],
+      ['Lead time', '2–3 wks'],
+    ],
+    cta: 'Start a thread →',
+    label: 'Consulting',
+  },
+  {
+    id: 'workshops',
+    num: 'T.02 · Workshops',
+    title: 'Hands-on team training.',
+    desc: 'Applied-AI for engineering teams. Half-day, full-day, or multi-day. Remote or on-site.',
+    specs: [
+      ['Team size', '4–40'],
+      ['Pricing', 'Per-head'],
+      ['Lead time', '4–6 wks'],
+    ],
+    cta: 'Request syllabus →',
+    label: 'Workshops',
+  },
+  {
+    id: 'speaking',
+    num: 'T.03 · Speaking',
+    title: 'Conferences & podcasts.',
+    desc: 'Applied AI, retrieval, voice-coding velocity, the real-world shape of agent failure modes.',
+    specs: [
+      ['Format', 'Keynote · Panel'],
+      ['Travel', 'Global'],
+      ['Lead time', '6–8 wks'],
+    ],
+    cta: 'Send brief →',
+    label: 'Speaking',
+  },
+  {
+    id: 'hello',
+    num: 'T.04 · Press & readers',
+    title: 'Press, students, readers.',
+    desc: 'Interviews, cited essays, students working on something specific, readers of the newsletter. A specific question goes a long way.',
+    specs: [
+      ['Best for', 'Specific Qs'],
+      ['Reply', 'When I can'],
+      ['Rate', 'Free'],
+    ],
+    cta: 'Say hi →',
+    label: 'Press / Hello',
+  },
+]
+
+const faqs = [
+  {
+    q: 'Are you currently taking new consulting work?',
+    a: "Selectively — but always the right thing. I'm only adding work that's a strong fit: applied-AI problems where the plan matters more than the hours. If yours sounds like that, write anyway. Worst case I point you somewhere useful.",
+  },
+  {
+    q: "What's the smallest engagement that makes sense?",
+    a: 'Engagements generally start in the low-thousands and scale from there depending on scope. A paid one-day advisory is usually the lightest shape: you get a written plan and a clear next step; it often turns into a longer retainer.',
+  },
+  {
+    q: 'Can you sign our NDA / MSA?',
+    a: "Yes — once we've agreed the work is happening. I sign NDAs and MSAs as part of accepting the engagement, not as a step toward one. Standard mutual NDAs are usually same-day; MSAs with heavier indemnity clauses take 1–2 weeks with counsel.",
+  },
+  {
+    q: 'Do you travel for workshops?',
+    a: 'Yes. Workshops are priced per head with a minimum, and travel for multi-day engagements is built into that. North America and EU most easily; Asia-Pacific doable with enough lead time. Half-day formats run best remote.',
+  },
+  {
+    q: 'Will you take a commission / advisory equity?',
+    a: "Yes — open to both. Commission arrangements and advisory equity work well for early-stage teams where applied AI is a load-bearing part of the product. Structure's flexible; cash + equity mixes are usually where we land.",
+  },
+  {
+    q: 'How fast do you reply?',
+    a: "I don't SLA it. Paid-work inquiries get my attention first and usually land a reply within a week or so. Other notes go in the queue and come back when I've got something useful to say. If two weeks go by, a polite nudge is welcome — I'd rather you nudge than assume I'm not interested.",
+  },
+]
 
 export function ContactContent() {
-  const { resolvedTheme } = useTheme()
-  const [mounted, setMounted] = useState(false)
+  const [track, setTrack] = useState('consulting')
+  const [scope, setScope] = useState('')
+  const [status, setStatus] = useState('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+  const [toast, setToast] = useState('')
 
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  async function handleSubmit(event) {
+    event.preventDefault()
+    const form = event.currentTarget
+    const name = form.elements.namedItem('name')?.value?.trim()
+    const email = form.elements.namedItem('email')?.value?.trim()
+    const company = form.elements.namedItem('company')?.value?.trim()
+    const rawMessage = form.elements.namedItem('message')?.value?.trim()
+    if (!name || !email || !rawMessage) return
 
-  const isDark = mounted && resolvedTheme === 'dark'
+    const trackLabel = tracks.find((t) => t.id === track)?.num || track
+    const scopeLine = scope ? `Budget / Timeline: ${scope}\n\n` : ''
+    const message = `Track: ${trackLabel}\n${scopeLine}${rawMessage}`
+
+    setStatus('submitting')
+    setErrorMessage('')
+
+    try {
+      const res = await fetch('/api/consultation', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, company, message }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error(data?.error || 'Something went wrong')
+      }
+      setStatus('ok')
+      form.reset()
+      setScope('')
+    } catch (err) {
+      setStatus('err')
+      setErrorMessage(err instanceof Error ? err.message : 'Something went wrong')
+    }
+  }
+
+  function handleCopy(value) {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return
+    navigator.clipboard.writeText(value).then(() => {
+      setToast(`Copied ${value}`)
+      setTimeout(() => setToast(''), 1600)
+    }).catch(() => { /* ignore */ })
+  }
 
   return (
-    <div className={`min-h-screen transition-colors duration-500 ${
-      isDark
-        ? 'bg-gradient-to-br from-slate-900 via-slate-800 to-slate-950'
-        : 'bg-gradient-to-b from-parchment-50 via-parchment-100 to-parchment-200'
-    }`}>
-      <div className="container mx-auto px-4 py-16 sm:py-24">
-        <div className="max-w-4xl mx-auto">
-          {/* Header */}
-          <div className="text-center mb-12">
-            <h1 className={`font-serif text-4xl md:text-5xl font-extrabold mb-4 ${
-              isDark ? 'text-amber-400' : 'text-burnt-400'
-            }`}>
-              Get in Touch
-            </h1>
-            <p className={`text-lg max-w-2xl mx-auto ${
-              isDark ? 'text-slate-300' : 'text-parchment-600'
-            }`}>
-              Have a project in mind? Let&apos;s discuss how I can help.
-            </p>
+    <div className="contact-page editorial-home min-h-screen text-charcoal-50 dark:text-parchment-100">
+      {/* Breadcrumb */}
+      <div className="container mx-auto max-w-6xl px-4 md:px-6">
+        <div className="post-crumbs">
+          <Link href="/">Home</Link>
+          <span className="sep">/</span>
+          <span className="current">Contact</span>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <section className="c-hero">
+        <div className="container mx-auto max-w-6xl px-4 md:px-6">
+          <div className="kicker">
+            § C · <em>Contact</em> · Consulting · Workshops · Speaking
           </div>
 
-          <div className="flex flex-col lg:flex-row gap-12 items-center">
-            {/* Left column - Portrait */}
-            <div className="lg:w-1/3">
-              <div className={`relative mx-auto w-full max-w-xs rounded-2xl overflow-hidden shadow-xl ${
-                isDark ? 'ring-2 ring-amber-500/30' : 'ring-1 ring-burnt-400/20'
-              }`}>
-                <RandomPortrait width={300} height={300} />
-              </div>
+          <div className="dispatch">
+            <div>
+              <h1 className="dispatch-display">
+                Send a dispatch. I&apos;ll <em>write back</em> when I&apos;ve got something useful to say.
+              </h1>
+              <p className="dispatch-lead">
+                Four lanes below. Consulting and workshop slots are limited and
+                get answered first. I work alone and I reply in waves, not
+                minutes — but the more specific your note, the faster I&apos;ll
+                have something real to send back.
+              </p>
             </div>
+            <aside className="dispatch-side">
+              <span className="label">Signed</span>
+              <div className="a-plate">ZP</div>
+              <div className="who">Zachary Proser</div>
+              <div className="role">Applied AI · WorkOS</div>
+            </aside>
+          </div>
 
-            {/* Right column - Contact options */}
-            <div className="lg:w-2/3 w-full">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {/* Email */}
-                <a
-                  href="mailto:zackproser@gmail.com"
-                  className={`flex items-center gap-4 p-5 rounded-xl transition-all hover:-translate-y-1 hover:shadow-lg ${
-                    isDark
-                      ? 'bg-slate-800/60 border border-slate-700 hover:border-amber-500/50'
-                      : 'bg-white border border-parchment-200 hover:border-burnt-400/50'
-                  }`}
-                >
-                  <div className={`p-3 rounded-lg ${isDark ? 'bg-amber-500/20' : 'bg-burnt-400/10'}`}>
-                    <Mail className={`h-6 w-6 ${isDark ? 'text-amber-400' : 'text-burnt-400'}`} />
-                  </div>
-                  <div className="flex flex-col">
-                    <span className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-charcoal-50'}`}>Email</span>
-                    <span className={`text-sm ${isDark ? 'text-slate-400' : 'text-parchment-500'}`}>zackproser@gmail.com</span>
-                  </div>
-                </a>
-
-                {/* LinkedIn */}
-                <a
-                  href="https://linkedin.com/in/zackproser"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`flex items-center gap-4 p-5 rounded-xl transition-all hover:-translate-y-1 hover:shadow-lg ${
-                    isDark
-                      ? 'bg-slate-800/60 border border-slate-700 hover:border-amber-500/50'
-                      : 'bg-white border border-parchment-200 hover:border-burnt-400/50'
-                  }`}
-                >
-                  <div className={`p-3 rounded-lg ${isDark ? 'bg-amber-500/20' : 'bg-burnt-400/10'}`}>
-                    <LinkedInIcon className={`h-6 w-6 ${isDark ? 'text-amber-400' : 'text-burnt-400'}`} />
-                  </div>
-                  <div className="flex flex-col">
-                    <span className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-charcoal-50'}`}>LinkedIn</span>
-                    <span className={`text-sm ${isDark ? 'text-slate-400' : 'text-parchment-500'}`}>Connect with me</span>
-                  </div>
-                </a>
-
-                {/* GitHub */}
-                <a
-                  href="https://github.com/zackproser"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`flex items-center gap-4 p-5 rounded-xl transition-all hover:-translate-y-1 hover:shadow-lg ${
-                    isDark
-                      ? 'bg-slate-800/60 border border-slate-700 hover:border-amber-500/50'
-                      : 'bg-white border border-parchment-200 hover:border-burnt-400/50'
-                  }`}
-                >
-                  <div className={`p-3 rounded-lg ${isDark ? 'bg-amber-500/20' : 'bg-burnt-400/10'}`}>
-                    <GitHubIcon className={`h-6 w-6 ${isDark ? 'text-amber-400' : 'text-burnt-400'}`} />
-                  </div>
-                  <div className="flex flex-col">
-                    <span className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-charcoal-50'}`}>GitHub</span>
-                    <span className={`text-sm ${isDark ? 'text-slate-400' : 'text-parchment-500'}`}>See my code</span>
-                  </div>
-                </a>
-
-                {/* Twitter */}
-                <a
-                  href="https://twitter.com/zackproser"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`flex items-center gap-4 p-5 rounded-xl transition-all hover:-translate-y-1 hover:shadow-lg ${
-                    isDark
-                      ? 'bg-slate-800/60 border border-slate-700 hover:border-amber-500/50'
-                      : 'bg-white border border-parchment-200 hover:border-burnt-400/50'
-                  }`}
-                >
-                  <div className={`p-3 rounded-lg ${isDark ? 'bg-amber-500/20' : 'bg-burnt-400/10'}`}>
-                    <TwitterIcon className={`h-6 w-6 ${isDark ? 'text-amber-400' : 'text-burnt-400'}`} />
-                  </div>
-                  <div className="flex flex-col">
-                    <span className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-charcoal-50'}`}>Twitter</span>
-                    <span className={`text-sm ${isDark ? 'text-slate-400' : 'text-parchment-500'}`}>Follow me</span>
-                  </div>
-                </a>
-              </div>
-            </div>
+          <div className="avail-strip">
+            <span className="slot"><span className="dot warn" /><span className="k">Consulting</span>&nbsp;<span className="v">Selective · right fit only</span></span>
+            <span className="sep">·</span>
+            <span className="slot"><span className="dot" /><span className="k">Workshops</span>&nbsp;<span className="v">Booking · per-head</span></span>
+            <span className="sep">·</span>
+            <span className="slot"><span className="dot" /><span className="k">Speaking</span>&nbsp;<span className="v">Selectively</span></span>
+            <span className="sep">·</span>
+            <span className="slot"><span className="dot" /><span className="k">Advisory / equity</span>&nbsp;<span className="v">Open to the right team</span></span>
           </div>
         </div>
+      </section>
+
+      {/* Tracks */}
+      <section>
+        <div className="container mx-auto max-w-6xl px-4 md:px-6 tracks-wrap">
+          <header className="tracks-head">
+            <div className="num">§ 01</div>
+            <h2>Pick a track.</h2>
+            <span className="more">T.01 — T.04</span>
+          </header>
+
+          <div className="tracks-grid">
+            {tracks.map((t) => (
+              <a
+                key={t.id}
+                className="track"
+                href="#form"
+                onClick={() => setTrack(t.id)}
+              >
+                <div className="track-num">{t.num}</div>
+                <h3 className="track-title">{t.title}</h3>
+                <p className="track-desc">{t.desc}</p>
+                <div className="track-specs">
+                  {t.specs.map(([label, value]) => (
+                    <div key={label} className="r">
+                      <span>{label}</span>
+                      <b>{value}</b>
+                    </div>
+                  ))}
+                </div>
+                <span className="track-cta">{t.cta}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* Form + channels */}
+        <div className="container mx-auto max-w-6xl px-4 md:px-6" id="form">
+          <div className="dispatch-body">
+            {/* Form */}
+            <div>
+              <div className="db-head">
+                <div className="num">§ 02</div>
+                <h3>Draft a message.</h3>
+              </div>
+
+              <form className="ed-form" onSubmit={handleSubmit} noValidate>
+                <div className="ed-field">
+                  <div className="ed-label"><span>Track</span><span className="num">01</span></div>
+                  <div className="ed-seg" role="radiogroup" aria-label="Engagement track">
+                    {tracks.map((t) => (
+                      <label key={t.id}>
+                        <input
+                          type="radio"
+                          name="track"
+                          value={t.id}
+                          checked={track === t.id}
+                          onChange={() => setTrack(t.id)}
+                        />
+                        <span>{t.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="ed-row">
+                  <div className="ed-field">
+                    <div className="ed-label"><span>Name</span><span className="num">02</span></div>
+                    <input className="ed-input" type="text" name="name" placeholder="Your name" required />
+                  </div>
+                  <div className="ed-field">
+                    <div className="ed-label"><span>Email</span><span className="num">03</span></div>
+                    <input className="ed-input" type="email" name="email" placeholder="you@company.com" required />
+                  </div>
+                </div>
+
+                <div className="ed-row">
+                  <div className="ed-field">
+                    <div className="ed-label"><span>Company</span><span className="num">04</span></div>
+                    <input className="ed-input" type="text" name="company" placeholder="Optional" />
+                  </div>
+                  <div className="ed-field">
+                    <div className="ed-label"><span>Budget / Timeline</span><span className="num">05</span></div>
+                    <select
+                      className="ed-select"
+                      name="scope"
+                      value={scope}
+                      onChange={(e) => setScope(e.target.value)}
+                    >
+                      <option value="">Select —</option>
+                      <option>Under $10k · 1–2 wks</option>
+                      <option>$10–25k · 1 month</option>
+                      <option>$25–75k · 1 quarter</option>
+                      <option>$75k+ · Ongoing retainer</option>
+                      <option>Not sure yet</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div className="ed-field">
+                  <div className="ed-label"><span>Message</span><span className="num">06</span></div>
+                  <textarea
+                    className="ed-textarea"
+                    name="message"
+                    placeholder="What are you trying to ship? What shape is the team? What have you tried? A short paragraph is fine."
+                    required
+                  />
+                </div>
+
+                {status === 'ok' ? (
+                  <div className="form-status ok" role="status">
+                    ✓ Sent. I&apos;ll reply in waves — paid work first.
+                  </div>
+                ) : status === 'err' ? (
+                  <div className="form-status err" role="alert">
+                    {errorMessage || 'Something went wrong. Email zack@workos.com instead.'}
+                  </div>
+                ) : null}
+
+                <div className="ed-submit-row">
+                  <span className="fine">Forwarded to zack@workos.com · paid work answered first</span>
+                  <button className="ed-submit" type="submit" disabled={status === 'submitting'}>
+                    {status === 'submitting' ? 'Sending…' : 'Send dispatch'} <span>→</span>
+                  </button>
+                </div>
+              </form>
+            </div>
+
+            {/* Channels */}
+            <aside>
+              <div className="db-head">
+                <div className="num">§ 03</div>
+                <h3>Or reach directly.</h3>
+              </div>
+
+              <div className="channels">
+                <button
+                  type="button"
+                  className="channel"
+                  onClick={() => handleCopy('zack@workos.com')}
+                >
+                  <div className="ch-icon">@</div>
+                  <div className="ch-body">
+                    <div className="ch-title">Email</div>
+                    <div className="ch-sub">zack@workos.com</div>
+                  </div>
+                  <div className="ch-go">Copy →</div>
+                </button>
+                <a className="channel" href="https://cal.com/zackproser/30min" target="_blank" rel="noopener noreferrer">
+                  <div className="ch-icon">◷</div>
+                  <div className="ch-body">
+                    <div className="ch-title">Book a 30-min intro</div>
+                    <div className="ch-sub">cal.com/zackproser · usually same-week</div>
+                  </div>
+                  <div className="ch-go">Schedule →</div>
+                </a>
+                <a className="channel" href="https://linkedin.com/in/zackproser" target="_blank" rel="noopener noreferrer">
+                  <div className="ch-icon">in</div>
+                  <div className="ch-body">
+                    <div className="ch-title">LinkedIn</div>
+                    <div className="ch-sub">linkedin.com/in/zackproser</div>
+                  </div>
+                  <div className="ch-go">Open →</div>
+                </a>
+                <a className="channel" href="https://github.com/zackproser" target="_blank" rel="noopener noreferrer">
+                  <div className="ch-icon">{'{ }'}</div>
+                  <div className="ch-body">
+                    <div className="ch-title">GitHub</div>
+                    <div className="ch-sub">github.com/zackproser</div>
+                  </div>
+                  <div className="ch-go">Open →</div>
+                </a>
+                <a className="channel" href="https://x.com/zackproser" target="_blank" rel="noopener noreferrer">
+                  <div className="ch-icon">𝕏</div>
+                  <div className="ch-body">
+                    <div className="ch-title">Twitter / X</div>
+                    <div className="ch-sub">@zackproser</div>
+                  </div>
+                  <div className="ch-go">Open →</div>
+                </a>
+                <Link className="channel" href="/newsletter">
+                  <div className="ch-icon">✉</div>
+                  <div className="ch-body">
+                    <div className="ch-title">Modern Coding newsletter</div>
+                    <div className="ch-sub">5,000+ engineers · monthly</div>
+                  </div>
+                  <div className="ch-go">Subscribe →</div>
+                </Link>
+              </div>
+
+              <div className="channels-foot">
+                <span>GMT−5</span>
+                <span>PGP on request</span>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="faq-wrap">
+        <div className="faq-inner">
+          <div className="faq-head">
+            <span>§ 04 · Before you write</span>
+            <strong>Six quick answers</strong>
+          </div>
+          <div className="faq">
+            {faqs.map((f, i) => (
+              <details key={i} open={i === 0}>
+                <summary>
+                  <span className="num">Q.{String(i + 1).padStart(2, '0')}</span>
+                  <span className="q">{f.q}</span>
+                  <span className="chev">+</span>
+                </summary>
+                <p className="a">{f.a}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Copy toast */}
+      <div className={`toast${toast ? ' visible' : ''}`} aria-live="polite">
+        {toast}
       </div>
     </div>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,8 @@ import '@/styles/global.css';
 import '@/styles/editorial-home.css';
 import '@/styles/blog-post.css';
 import '@/styles/testimonials.css';
+import '@/styles/contact.css';
+import '@/styles/videos.css';
 import PlausibleProvider from 'next-plausible';
 
 const notoSans = Noto_Sans({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,6 @@ import '@/styles/editorial-home.css';
 import '@/styles/blog-post.css';
 import '@/styles/testimonials.css';
 import '@/styles/contact.css';
-import '@/styles/videos.css';
 import PlausibleProvider from 'next-plausible';
 
 const notoSans = Noto_Sans({

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -1,0 +1,533 @@
+/* =========================================================
+   Contact page — Variation A "Dispatch" from the handoff.
+   Scoped under .contact-page so rules can't leak to other routes.
+   ========================================================= */
+
+.contact-page {
+  /* Palette aliases to match editorial-home.css */
+  --parchment-50:  #fefdfb;
+  --parchment-100: #fbf7f0;
+  --parchment-200: #f5f0e6;
+  --parchment-300: #e8e0d0;
+  --parchment-400: #d1c7b7;
+  --parchment-500: #b8a88f;
+  --parchment-600: #8b7355;
+  --charcoal-50:   #2c3e50;
+  --charcoal-400:  #1a1a2e;
+  --charcoal-500:  #141428;
+  --charcoal-600:  #0f0f1f;
+  --burnt-400: #e67e22;
+  --burnt-500: #d35400;
+  --amber-300: #fcd34d;
+  --amber-400: #f39c12;
+  --amber-500: #f59e0b;
+  --slate-500: #64748b;
+  --slate-800: #1e293b;
+  --slate-900: #0f172a;
+  --green-500: #22c55e;
+  --green-700: #15803d;
+
+  --bg:           var(--parchment-100);
+  --bg-secondary: var(--parchment-200);
+  --bg-elevated:  var(--parchment-50);
+
+  --fg:        var(--charcoal-50);
+  --fg-muted:  var(--parchment-600);
+  --fg-subtle: var(--parchment-500);
+
+  --border:        rgb(139 115 85 / .25);
+  --border-strong: rgb(139 115 85 / .5);
+
+  --accent:       var(--burnt-400);
+  --accent-hover: var(--burnt-500);
+
+  --ink: var(--fg);
+  --ink-dim: var(--fg-muted);
+  --rule: var(--border);
+  --rule-strong: var(--border-strong);
+  --paper: var(--bg);
+}
+.dark .contact-page {
+  --bg:           var(--charcoal-400);
+  --bg-secondary: var(--charcoal-500);
+  --bg-elevated:  var(--slate-800);
+
+  --fg:        #fbf7f0;
+  --fg-muted:  #cbd5e1;
+  --fg-subtle: #94a3b8;
+
+  --border:        rgb(148 163 184 / .2);
+  --border-strong: rgb(148 163 184 / .4);
+
+  --accent:       var(--amber-400);
+  --accent-hover: var(--amber-300);
+
+  --ink: var(--fg);
+  --ink-dim: var(--fg-muted);
+  --rule: var(--border);
+  --rule-strong: var(--border-strong);
+  --paper: var(--bg);
+}
+
+/* Hero chrome */
+.contact-page .c-hero {
+  padding: 80px 0 56px;
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+}
+.contact-page .c-hero .kicker {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-bottom: 26px;
+}
+.contact-page .c-hero .kicker em { font-style: normal; color: var(--accent); }
+
+.contact-page .post-crumbs {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .12em; text-transform: uppercase;
+  color: var(--fg-subtle);
+  padding: 24px 0 0;
+  display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+}
+.contact-page .post-crumbs a { color: var(--fg-muted); text-decoration: none; }
+.contact-page .post-crumbs a:hover { color: var(--accent); }
+.contact-page .post-crumbs .sep { opacity: .5; }
+.contact-page .post-crumbs .current { color: var(--fg); }
+
+/* Availability strip */
+.contact-page .avail-strip {
+  display: flex; align-items: center; gap: 18px; flex-wrap: wrap;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .1em; text-transform: uppercase;
+  color: var(--ink-dim);
+  padding: 14px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  margin-top: 48px;
+}
+.contact-page .avail-strip .slot { display: inline-flex; align-items: center; gap: 8px; }
+.contact-page .avail-strip .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--green-500);
+  box-shadow: 0 0 0 3px rgb(34 197 94 / .15);
+}
+.contact-page .avail-strip .dot.warn {
+  background: var(--amber-500);
+  box-shadow: 0 0 0 3px rgb(245 158 11 / .18);
+}
+.contact-page .avail-strip .dot.off {
+  background: var(--slate-500); box-shadow: none;
+}
+.contact-page .avail-strip .k { color: var(--fg-subtle); }
+.contact-page .avail-strip .v { color: var(--fg); }
+.contact-page .avail-strip .sep { opacity: .4; }
+
+/* Dispatch: monument + attribution */
+.contact-page .dispatch {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 80px;
+  align-items: end;
+}
+.contact-page .dispatch-display {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 400;
+  font-size: clamp(56px, 7.6vw, 112px);
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  color: var(--ink);
+  margin: 0 0 0 -0.03em;
+  text-wrap: balance;
+}
+.contact-page .dispatch-display em { font-style: italic; color: var(--accent); font-weight: 400; }
+.contact-page .dispatch-lead {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 21px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  max-width: 52ch;
+  margin: 28px 0 0;
+  text-wrap: pretty;
+}
+.contact-page .dispatch-side {
+  border-top: 1px solid var(--rule);
+  padding-top: 20px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+.contact-page .dispatch-side .label {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .14em; text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.contact-page .dispatch-side .a-plate {
+  width: 72px; height: 88px; margin-bottom: 6px;
+  background: linear-gradient(180deg, var(--parchment-100), var(--parchment-200));
+  border: 1px solid var(--rule);
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 34px; color: var(--ink);
+  position: relative; overflow: hidden;
+}
+.dark .contact-page .dispatch-side .a-plate {
+  background: linear-gradient(180deg, var(--slate-800), var(--slate-900));
+}
+.contact-page .dispatch-side .who {
+  font-family: var(--font-sans, Inter), system-ui, sans-serif;
+  font-size: 14px; font-weight: 600; color: var(--ink);
+}
+.contact-page .dispatch-side .role {
+  font-family: var(--font-sans, Inter), system-ui, sans-serif;
+  font-size: 12.5px; color: var(--ink-dim); line-height: 1.45;
+  text-wrap: balance;
+}
+@media (max-width: 900px) {
+  .contact-page .dispatch { grid-template-columns: 1fr; gap: 40px; }
+}
+
+/* Tracks */
+.contact-page .tracks-wrap { padding: 72px 0 56px; }
+.contact-page .tracks-head {
+  display: grid; grid-template-columns: 80px 1fr auto; gap: 28px;
+  align-items: baseline; padding-bottom: 20px;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 36px;
+}
+.contact-page .tracks-head .num {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .14em; color: var(--accent); text-transform: uppercase;
+}
+.contact-page .tracks-head h2 {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 34px; font-weight: 500;
+  letter-spacing: -0.02em; color: var(--ink); margin: 0;
+}
+.contact-page .tracks-head .more {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .1em; color: var(--ink-dim); text-transform: uppercase;
+}
+
+.contact-page .tracks-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+  border-top: 1px solid var(--rule);
+}
+@media (max-width: 980px) { .contact-page .tracks-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 560px) { .contact-page .tracks-grid { grid-template-columns: 1fr; } }
+
+.contact-page .track {
+  display: flex; flex-direction: column; gap: 14px;
+  padding: 28px 28px 24px;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  text-decoration: none; color: inherit;
+  background: transparent;
+  transition: background .15s ease;
+  position: relative;
+}
+.contact-page .track:last-child { border-right: 0; }
+@media (max-width: 980px) {
+  .contact-page .track:nth-child(even) { border-right: 0; }
+}
+@media (max-width: 560px) {
+  .contact-page .track { border-right: 0; }
+}
+.contact-page .track:hover { background: var(--bg-secondary); }
+.contact-page .track:hover .track-title { color: var(--accent); }
+.contact-page .track .track-num {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--accent); font-weight: 600;
+}
+.contact-page .track .track-title {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 22px; font-weight: 600;
+  letter-spacing: -0.01em; color: var(--ink); line-height: 1.2; margin: 0;
+}
+.contact-page .track .track-desc {
+  font-family: var(--font-sans, Inter), system-ui, sans-serif;
+  font-size: 13.5px; line-height: 1.55;
+  color: var(--ink-dim); margin: 0; flex: 1;
+}
+.contact-page .track-specs {
+  display: flex; flex-direction: column; gap: 4px; margin-top: 4px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px; letter-spacing: .08em;
+  color: var(--ink-dim); text-transform: uppercase;
+}
+.contact-page .track-specs .r { display: flex; justify-content: space-between; gap: 10px; }
+.contact-page .track-specs .r b { color: var(--ink); font-weight: 500; }
+.contact-page .track-cta {
+  margin-top: 8px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .1em; text-transform: uppercase;
+  color: var(--accent);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+
+/* Dispatch body — form + channels split */
+.contact-page .dispatch-body {
+  display: grid; grid-template-columns: 1.2fr 1fr; gap: 56px;
+  padding: 64px 0 96px; border-top: 1px solid var(--rule);
+}
+@media (max-width: 900px) {
+  .contact-page .dispatch-body { grid-template-columns: 1fr; gap: 40px; }
+}
+
+.contact-page .db-head {
+  display: flex; align-items: baseline; gap: 12px; margin-bottom: 24px;
+}
+.contact-page .db-head .num {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px; letter-spacing: .14em;
+  color: var(--accent); text-transform: uppercase;
+}
+.contact-page .db-head h3 {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 28px; font-weight: 500;
+  letter-spacing: -0.015em; color: var(--ink); margin: 0;
+}
+
+/* Form — editorial */
+.contact-page .ed-form { display: flex; flex-direction: column; gap: 22px; }
+.contact-page .ed-field { display: flex; flex-direction: column; gap: 8px; }
+.contact-page .ed-row { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+@media (max-width: 540px) { .contact-page .ed-row { grid-template-columns: 1fr; } }
+.contact-page .ed-label {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--ink-dim);
+  display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+}
+.contact-page .ed-label .num { color: var(--accent); }
+.contact-page .ed-input,
+.contact-page .ed-textarea,
+.contact-page .ed-select {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 18px;
+  color: var(--ink); background: transparent;
+  border: 0; border-bottom: 1px solid var(--rule-strong);
+  padding: 6px 0 10px;
+  width: 100%; box-sizing: border-box;
+  letter-spacing: -0.005em;
+  transition: border-color .15s ease;
+  border-radius: 0;
+  appearance: none;
+}
+.contact-page .ed-input::placeholder,
+.contact-page .ed-textarea::placeholder {
+  color: var(--fg-subtle); font-style: italic;
+}
+.contact-page .ed-input:focus,
+.contact-page .ed-textarea:focus,
+.contact-page .ed-select:focus {
+  outline: none; border-bottom-color: var(--accent);
+}
+.contact-page .ed-textarea { min-height: 112px; resize: vertical; font-size: 17px; line-height: 1.55; }
+.contact-page .ed-select {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 13px;
+  text-transform: uppercase; letter-spacing: .08em;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--ink-dim) 50%),
+    linear-gradient(135deg, var(--ink-dim) 50%, transparent 50%);
+  background-position: calc(100% - 12px) 16px, calc(100% - 6px) 16px;
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+  padding-right: 24px;
+}
+
+.contact-page .ed-seg {
+  display: flex; flex-wrap: wrap; gap: 0;
+  border: 1px solid var(--rule);
+}
+.contact-page .ed-seg label {
+  flex: 1 1 auto;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: .1em; text-transform: uppercase;
+  padding: 10px 14px; text-align: center;
+  color: var(--ink-dim); cursor: pointer;
+  border-right: 1px solid var(--rule);
+  transition: background .15s, color .15s;
+  white-space: nowrap;
+}
+.contact-page .ed-seg label:last-child { border-right: 0; }
+.contact-page .ed-seg input { display: none; }
+.contact-page .ed-seg label:has(input:checked) { background: var(--ink); color: var(--paper); }
+.dark .contact-page .ed-seg label:has(input:checked) { background: var(--accent); color: #1a1a2e; }
+
+.contact-page .ed-submit-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 20px; margin-top: 8px; flex-wrap: wrap;
+}
+.contact-page .ed-submit-row .fine {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .1em; text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.contact-page .ed-submit {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 12px;
+  letter-spacing: .14em; text-transform: uppercase; font-weight: 600;
+  padding: 14px 22px; background: var(--accent); color: #fff;
+  border: 0; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  transition: background .15s, transform .1s;
+  border-radius: 0;
+}
+.contact-page .ed-submit:hover { background: var(--accent-hover); transform: translateY(-1px); }
+.contact-page .ed-submit:disabled { opacity: .6; cursor: not-allowed; transform: none; }
+.dark .contact-page .ed-submit { color: #1a1a2e; }
+
+/* Channels column */
+.contact-page .channels { display: flex; flex-direction: column; gap: 0; }
+.contact-page .channel {
+  display: grid; grid-template-columns: 44px 1fr auto;
+  gap: 18px; align-items: center;
+  padding: 18px 0;
+  border-top: 1px solid var(--rule);
+  text-decoration: none; color: inherit;
+  transition: background .15s ease;
+  cursor: pointer;
+  background: transparent;
+  border-left: 0; border-right: 0; border-bottom: 0;
+  width: 100%; text-align: left;
+  font-family: inherit;
+}
+.contact-page .channel:first-child { border-top: 0; padding-top: 4px; }
+.contact-page .channel:last-child { border-bottom: 1px solid var(--rule); }
+.contact-page .channel:hover { background: var(--bg-secondary); }
+.contact-page .channel:hover .ch-title { color: var(--accent); }
+.contact-page .ch-icon {
+  width: 44px; height: 44px;
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--rule); background: var(--bg-elevated);
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 20px; color: var(--ink);
+}
+.contact-page .ch-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.contact-page .ch-title {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 18px; font-weight: 600;
+  color: var(--ink); letter-spacing: -0.005em;
+}
+.contact-page .ch-sub {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .06em; color: var(--ink-dim);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.contact-page .ch-go {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .1em; text-transform: uppercase; color: var(--ink-dim);
+}
+.contact-page .channel:hover .ch-go { color: var(--accent); }
+
+.contact-page .channels-foot {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--rule);
+  display: flex; justify-content: space-between;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .12em; text-transform: uppercase; color: var(--ink-dim);
+}
+
+/* FAQ */
+.contact-page .faq-wrap {
+  padding: 64px 0 96px;
+  border-top: 1px solid var(--rule);
+  background: var(--bg-secondary);
+}
+.contact-page .faq-inner { max-width: 820px; margin: 0 auto; padding: 0 24px; }
+.contact-page .faq-head {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--ink-dim);
+  padding-bottom: 18px; border-bottom: 2px solid var(--ink);
+  margin-bottom: 12px;
+  display: flex; justify-content: space-between;
+}
+.contact-page .faq-head strong { color: var(--ink); font-weight: 600; }
+.contact-page .faq details {
+  border-bottom: 1px solid var(--rule); padding: 22px 0;
+}
+.contact-page .faq summary {
+  cursor: pointer; list-style: none;
+  display: grid; grid-template-columns: 60px 1fr auto; gap: 20px;
+  align-items: baseline;
+}
+.contact-page .faq summary::-webkit-details-marker { display: none; }
+.contact-page .faq summary .num {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px; letter-spacing: .14em;
+  color: var(--accent); text-transform: uppercase;
+}
+.contact-page .faq summary .q {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 21px; font-weight: 500;
+  letter-spacing: -0.01em; color: var(--ink); text-wrap: balance;
+}
+.contact-page .faq summary .chev {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 18px; color: var(--ink-dim);
+  transition: transform .2s ease;
+}
+.contact-page .faq details[open] summary .chev { transform: rotate(45deg); color: var(--accent); }
+.contact-page .faq details[open] summary .q { color: var(--accent); }
+.contact-page .faq .a {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-size: 17px; line-height: 1.6;
+  color: var(--ink-dim); margin: 14px 0 0 80px; max-width: 62ch; text-wrap: pretty;
+}
+@media (max-width: 640px) {
+  .contact-page .faq summary { grid-template-columns: 40px 1fr; }
+  .contact-page .faq .a { margin-left: 0; }
+}
+
+/* Copy-to-clipboard toast */
+.contact-page .toast {
+  position: fixed; bottom: 90px; left: 50%; transform: translate(-50%, 20px);
+  background: var(--ink); color: var(--paper);
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px; letter-spacing: .14em;
+  text-transform: uppercase; padding: 10px 16px;
+  opacity: 0; transition: all .25s ease; z-index: 100;
+  pointer-events: none;
+}
+.contact-page .toast.visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+/* Form status strip */
+.contact-page .form-status {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .1em; text-transform: uppercase;
+  padding: 14px 16px;
+  border: 1px solid var(--rule-strong);
+  color: var(--ink);
+}
+.contact-page .form-status.ok {
+  border-color: var(--green-700);
+  color: var(--green-700);
+  background: rgb(34 197 94 / .05);
+}
+.dark .contact-page .form-status.ok { color: #86efac; }
+.contact-page .form-status.err {
+  border-color: #ef4444;
+  color: #b91c1c;
+  background: rgb(239 68 68 / .06);
+}
+.dark .contact-page .form-status.err { color: #fca5a5; }

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -71,7 +71,7 @@
 
 /* Hero chrome */
 .contact-page .c-hero {
-  padding: 80px 0 56px;
+  padding: 40px 0 32px;
   border-bottom: 1px solid var(--rule);
   position: relative;
 }
@@ -81,7 +81,7 @@
   letter-spacing: .14em;
   text-transform: uppercase;
   color: var(--ink-dim);
-  margin-bottom: 26px;
+  margin-bottom: 18px;
 }
 .contact-page .c-hero .kicker em { font-style: normal; color: var(--accent); }
 
@@ -105,10 +105,10 @@
   font-size: 11px;
   letter-spacing: .1em; text-transform: uppercase;
   color: var(--ink-dim);
-  padding: 14px 0;
+  padding: 12px 0;
   border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
-  margin-top: 48px;
+  margin-top: 28px;
 }
 .contact-page .avail-strip .slot { display: inline-flex; align-items: center; gap: 8px; }
 .contact-page .avail-strip .dot {
@@ -130,28 +130,29 @@
 /* Dispatch: monument + attribution */
 .contact-page .dispatch {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 340px;
-  gap: 80px;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 56px;
   align-items: end;
 }
 .contact-page .dispatch-display {
   font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
   font-weight: 400;
-  font-size: clamp(56px, 7.6vw, 112px);
-  line-height: 0.98;
-  letter-spacing: -0.035em;
+  font-size: clamp(40px, 4.6vw, 64px);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
   color: var(--ink);
-  margin: 0 0 0 -0.03em;
+  margin: 0;
   text-wrap: balance;
+  max-width: 22ch;
 }
 .contact-page .dispatch-display em { font-style: italic; color: var(--accent); font-weight: 400; }
 .contact-page .dispatch-lead {
   font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
-  font-size: 21px;
+  font-size: 18px;
   line-height: 1.5;
   color: var(--fg-muted);
   max-width: 52ch;
-  margin: 28px 0 0;
+  margin: 20px 0 0;
   text-wrap: pretty;
 }
 .contact-page .dispatch-side {

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -491,7 +491,7 @@
   color: var(--ink-dim); margin: 14px 0 0 80px; max-width: 62ch; text-wrap: pretty;
 }
 @media (max-width: 640px) {
-  .contact-page .faq summary { grid-template-columns: 40px 1fr; }
+  .contact-page .faq summary { grid-template-columns: 40px 1fr auto; }
   .contact-page .faq .a { margin-left: 0; }
 }
 


### PR DESCRIPTION
Answer to "what happened to the updated /contact page" — here it is, on its own branch.

The homepage-glowup PR (#1026) got squash-merged before I finished this work, so the contact page implementation lived in limbo. Porting it fresh off \`main\` with just the three files it actually needs.

## What's in it

Variation A **Dispatch** from the Claude Design handoff (\`h/oQUii-fr4tnfpjES0xAEnQ\`). B (Switchboard) and C (Correspondence) are intentionally skipped — the bundle defaulted to A and A fits the current conversion funnel best.

### Hero
- \`§ C · Contact · Consulting · Workshops · Speaking\` kicker with italic-accented *Contact*
- Giant Source Serif display: *"Send a dispatch. I'll write back when I've got something useful to say."* with italic accent on *write back*
- Signed-card aside with **ZP** monogram plate + "Applied AI · WorkOS"
- 4-slot availability strip: warn dot for Consulting (selective), green for Workshops / Speaking / Advisory

### § 01 Tracks
Four-column picker: Consulting · Workshops · Speaking · Press / Readers. Each card has a **T.NN** kicker, serif title, copy, mono specs (rate · availability · lead time), and CTA. Clicking a card scrolls to \`#form\` **and** selects the matching radio in the segmented Track group.

### § 02 Form → /api/consultation
- Editorial underlined fields (no rounded corners, serif values); mono labels with per-field numbers (01–06)
- Segmented Track radios, Name + Email row, Company + Budget/Timeline row, Message textarea
- Posts JSON to the existing \`/api/consultation\` Postmark endpoint (\`name\`, \`email\`, \`company\`, \`message\`)
- Track label + Budget line are prefixed into the \`message\` body so the existing email templates render them cleanly — no backend change
- Inline \`form-status.ok\` / \`form-status.err\` strip plumbed from the API response; submit disables while in-flight

### § 03 Channels
Direct-reach list: Email (copy-to-clipboard with toast), cal.com 30-min intro, LinkedIn, GitHub, X, Newsletter internal link to \`/newsletter\`. Foot: \`GMT−5 · PGP on request\`.

### § 04 FAQ
Six \`<details>\` with mono Q.NN numbers, serif questions, serif answers. First one open by default. \`+\` chev flips to \`×\` on open.

## Files
- \`src/styles/contact.css\` — new, scoped under \`.contact-page\` so none of the \`.tracks\` / \`.ed-*\` / \`.faq\` / \`.channels\` rules leak
- \`src/app/contact/ContactContent.jsx\` — full rewrite; drops \`RandomPortrait\` / \`SocialIcons\` / \`useTheme\` from the old version
- \`src/app/layout.tsx\` — adds \`contact.css\` import next to the other editorial stylesheets

## Test plan
- [ ] Submit with all fields → email arrives at zackproser@gmail.com with Track + Budget + Message
- [ ] Submit with just name/email/message → backend accepts (track defaults to Consulting)
- [ ] Click each Track card → #form scroll + matching radio selected
- [ ] Copy email channel → toast confirms, clipboard contains zack@workos.com
- [ ] Dark-mode pass on hero + form + channels + FAQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large rewrite of the `/contact` UI and client-side form submission logic could introduce regressions in lead capture (validation, track selection, and POSTing to `/api/consultation`). Backend change is minimal but affects how multi-line messages render in the outgoing email.
> 
> **Overview**
> Replaces the `/contact` page with a new editorial “Dispatch” layout that adds a track picker, a richer consultation form (track + optional budget/timeline prepended into the message), direct-reach channel links, copy-to-clipboard email with toast, and an FAQ section.
> 
> Adds a new route-scoped stylesheet `contact.css` and wires it into the global `layout.tsx`.
> 
> Tweaks the consultation email HTML template so the `Message` field preserves newlines via `white-space: pre-line`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c8352e47696f6ed9ab8f7bbb36d2565d5964723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->