### PR TITLE
blog: editorial glow-up for /blog index

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/blog/blog-client.tsx
+++ b/src/app/blog/blog-client.tsx
@@ -424,7 +424,7 @@ function Gallery({ posts, showLead }: { posts: ArticleWithSlug[]; showLead: bool
           <Link
             key={post.slug ?? `${post.title}-${i}`}
             className={`eb-card${isLead ? " is-lead" : ""}`}
-            href={`/blog/${post.slug}`}
+            href={post.slug as any}
           >
             <div className={`eb-thumb ${imgSrc ? "" : pattern}`}>
               {imgSrc ? (
@@ -488,7 +488,7 @@ function Ledger({ groups }: { groups: Array<{ year: string; posts: ArticleWithSl
                 <Link
                   key={post.slug ?? `${post.title}-${running}`}
                   className="eb-row"
-                  href={`/blog/${post.slug}`}
+                  href={post.slug as any}
                 >
                   <div className="eb-num">№ {pad2(running)}</div>
                   <div className="eb-mdate">

--- a/src/app/blog/blog-client.tsx
+++ b/src/app/blog/blog-client.tsx
@@ -12,7 +12,6 @@ type SortKey = "newest" | "oldest";
 
 interface BlogClientProps {
   articles: ArticleWithSlug[];
-  years: string[];
 }
 
 const KIND_LABEL: Record<string, string> = {
@@ -32,11 +31,11 @@ const MONTHS_SHORT = [
 const pad2 = (n: number) => String(n).padStart(2, "0");
 const fmtMonYear = (iso: string) => {
   const d = new Date(iso);
-  return `${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear()}`;
+  return `${MONTHS_SHORT[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
 };
 const fmtDayMon = (iso: string) => {
   const d = new Date(iso);
-  return { day: pad2(d.getDate()), mon: MONTHS_SHORT[d.getMonth()].toUpperCase() };
+  return { day: pad2(d.getUTCDate()), mon: MONTHS_SHORT[d.getUTCMonth()].toUpperCase() };
 };
 
 function toRomanNumeral(year: number): string {
@@ -173,7 +172,7 @@ export default function BlogClient({ articles }: BlogClientProps) {
   const ledgerGroups = useMemo(() => {
     const byYear: Record<string, ArticleWithSlug[]> = {};
     for (const a of filtered) {
-      const y = new Date(a.date).getFullYear().toString();
+      const y = new Date(a.date).getUTCFullYear().toString();
       (byYear[y] ||= []).push(a);
     }
     const keys = Object.keys(byYear).sort((a, b) => (sort === "oldest" ? +a - +b : +b - +a));

--- a/src/app/blog/blog-client.tsx
+++ b/src/app/blog/blog-client.tsx
@@ -1,173 +1,512 @@
-"use client"
+"use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { Search, Sparkles, ArrowRight } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ContentCard } from "@/components/ContentCard";
 import { track } from "@vercel/analytics";
 import debounce from "lodash.debounce";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ArticleWithSlug } from "@/types";
+
+type Variation = "A" | "B";
+type SortKey = "newest" | "oldest";
 
 interface BlogClientProps {
   articles: ArticleWithSlug[];
   years: string[];
 }
 
-const ALL_YEARS_OPTION = "All Years";
+const KIND_LABEL: Record<string, string> = {
+  blog: "Essay",
+  video: "Video",
+  demo: "Demo",
+  course: "Course",
+};
 
-export default function BlogClient({ articles, years }: BlogClientProps) {
-  const [searchTerm, setSearchTerm] = useState("");
-  const [selectedYear, setSelectedYear] = useState(ALL_YEARS_OPTION);
-  const [filteredArticles, setFilteredArticles] = useState<ArticleWithSlug[]>(articles);
+const THUMB_PATTERNS = ["t-grid", "t-dots", "t-rule", "t-diag"] as const;
+
+const MONTHS_SHORT = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+const fmtMonYear = (iso: string) => {
+  const d = new Date(iso);
+  return `${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear()}`;
+};
+const fmtDayMon = (iso: string) => {
+  const d = new Date(iso);
+  return { day: pad2(d.getDate()), mon: MONTHS_SHORT[d.getMonth()].toUpperCase() };
+};
+
+function toRomanNumeral(year: number): string {
+  const map: Array<[number, string]> = [
+    [1000, "M"], [900, "CM"], [500, "D"], [400, "CD"],
+    [100, "C"], [90, "XC"], [50, "L"], [40, "XL"],
+    [10, "X"], [9, "IX"], [5, "V"], [4, "IV"], [1, "I"],
+  ];
+  let out = "";
+  let n = year;
+  for (const [v, s] of map) {
+    while (n >= v) { out += s; n -= v; }
+  }
+  return out;
+}
+
+function firstGlyph(title: string): string {
+  const ch = title.trim().charAt(0).toUpperCase();
+  return /[A-Z0-9]/.test(ch) ? ch : "§";
+}
+
+function resolveImageSrc(image: ArticleWithSlug["image"]): string | null {
+  if (!image) return null;
+  if (typeof image === "string") return image;
+  if (typeof image === "object" && "src" in image && typeof image.src === "string") return image.src;
+  return null;
+}
+
+export default function BlogClient({ articles }: BlogClientProps) {
+  const [variation, setVariation] = useState<Variation>("A");
+  const [search, setSearch] = useState("");
+  const [kind, setKind] = useState<string>("All");
+  const [tag, setTag] = useState<string>("All");
+  const [sort, setSort] = useState<SortKey>("newest");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const debouncedTrack = useMemo(
     () =>
-      debounce((query: string) => {
-        if (query.trim()) {
-          track("blog-search", { term: query });
-        }
+      debounce((q: string) => {
+        if (q.trim()) track("blog-search", { term: q });
       }, 600),
     []
   );
+  useEffect(() => () => debouncedTrack.cancel(), [debouncedTrack]);
 
   useEffect(() => {
-    return () => {
-      debouncedTrack.cancel();
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      }
     };
-  }, [debouncedTrack]);
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
 
-  useEffect(() => {
-    let filtered = [...articles];
-
-    if (searchTerm.trim()) {
-      const term = searchTerm.trim().toLowerCase();
-      filtered = filtered.filter(
-        (article) =>
-          article.title.toLowerCase().includes(term) ||
-          article.description.toLowerCase().includes(term)
-      );
+  const { kindCounts, tagCounts } = useMemo(() => {
+    const kindCounts: Record<string, number> = {};
+    const tagCounts: Record<string, number> = {};
+    for (const a of articles) {
+      const k = a.type || "blog";
+      kindCounts[k] = (kindCounts[k] || 0) + 1;
+      for (const t of a.tags || []) tagCounts[t] = (tagCounts[t] || 0) + 1;
     }
+    return { kindCounts, tagCounts };
+  }, [articles]);
 
-    if (selectedYear !== ALL_YEARS_OPTION) {
-      filtered = filtered.filter(
-        (article) => new Date(article.date).getFullYear().toString() === selectedYear
-      );
-    }
+  const topTags = useMemo(
+    () => Object.keys(tagCounts).sort((a, b) => tagCounts[b] - tagCounts[a]).slice(0, 10),
+    [tagCounts]
+  );
+  const kindOrder = useMemo(
+    () => Object.keys(kindCounts).sort((a, b) => kindCounts[b] - kindCounts[a]),
+    [kindCounts]
+  );
 
-    filtered.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const out = articles.filter((a) => {
+      if (kind !== "All" && (a.type || "blog") !== kind) return false;
+      if (tag !== "All" && !(a.tags || []).includes(tag)) return false;
+      if (q) {
+        const hay = `${a.title} ${a.description} ${(a.tags || []).join(" ")} ${a.type || ""}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+    out.sort((a, b) => {
+      const da = new Date(a.date).getTime();
+      const db = new Date(b.date).getTime();
+      return sort === "oldest" ? da - db : db - da;
+    });
+    return out;
+  }, [articles, search, kind, tag, sort]);
 
-    setFilteredArticles(filtered);
-  }, [articles, searchTerm, selectedYear]);
+  const totalCount = articles.length;
+  const thisYearCount = useMemo(() => {
+    const y = new Date().getFullYear();
+    return articles.filter((a) => new Date(a.date).getFullYear() === y).length;
+  }, [articles]);
+  const earliestYear = useMemo(() => {
+    if (!articles.length) return new Date().getFullYear();
+    return articles.reduce((min, a) => Math.min(min, new Date(a.date).getFullYear()), Number.POSITIVE_INFINITY);
+  }, [articles]);
+  const latestDate = useMemo(() => {
+    if (!articles.length) return null;
+    const latest = articles.reduce((m, a) => (new Date(a.date) > new Date(m.date) ? a : m), articles[0]);
+    return latest.date;
+  }, [articles]);
 
-  const handleSearchChange = (value: string) => {
-    setSearchTerm(value);
-    debouncedTrack(value);
+  const activeFilterCount =
+    (kind !== "All" ? 1 : 0) + (tag !== "All" ? 1 : 0) + (sort !== "newest" ? 1 : 0);
+
+  const handleSearch = (v: string) => {
+    setSearch(v);
+    debouncedTrack(v);
   };
 
-  const resetFilters = () => {
-    setSearchTerm("");
-    setSelectedYear(ALL_YEARS_OPTION);
+  const clearAll = () => {
+    setSearch("");
+    setKind("All");
+    setTag("All");
+    setSort("newest");
     debouncedTrack.cancel();
   };
 
+  const chooseVariation = (v: Variation) => {
+    setVariation(v);
+    track("blog-view-toggle", { variation: v });
+  };
+
+  const ledgerGroups = useMemo(() => {
+    const byYear: Record<string, ArticleWithSlug[]> = {};
+    for (const a of filtered) {
+      const y = new Date(a.date).getFullYear().toString();
+      (byYear[y] ||= []).push(a);
+    }
+    const keys = Object.keys(byYear).sort((a, b) => (sort === "oldest" ? +a - +b : +b - +a));
+    return keys.map((y) => ({ year: y, posts: byYear[y] }));
+  }, [filtered, sort]);
+
   return (
-    <div className="w-full">
-      <div className="container mx-auto px-4 py-16">
-        <div className="text-center mb-12">
-          <h1 className="text-5xl font-bold text-burnt-400 dark:text-amber-400 mb-4">
-            I write to learn, and publish to share
+    <div className="editorial-blog">
+      <section className="eb-header">
+        <div className="eb-container">
+          <div className="eb-eyebrow">Writing · Essays · Field notes</div>
+          <h1 className="eb-title">
+            I write to learn, and <em>publish to share</em>.
           </h1>
-          <p className="text-xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto">
-            All of my technical tutorials, musings and developer rants
+          <p className="eb-dek">
+            Technical tutorials, field notes on applied AI, and developer
+            writing from a long stretch shipping production systems. Updated
+            most weeks.
           </p>
-        </div>
-
-        {/* Featured: AI Tools for Small Business */}
-        <Link
-          href="/best-ai-tools"
-          className="block mb-8 max-w-4xl mx-auto group"
-        >
-          <div className="bg-gradient-to-r from-amber-500/10 via-burnt-400/15 to-amber-500/10 dark:from-amber-900/30 dark:via-amber-800/30 dark:to-amber-900/30 rounded-xl p-4 border border-amber-500/30 dark:border-amber-600/40 hover:border-amber-500/50 dark:hover:border-amber-500/60 transition-all hover:shadow-lg">
-            <div className="flex items-center gap-4">
-              <div className="flex-shrink-0 w-10 h-10 bg-amber-500/20 dark:bg-amber-500/30 rounded-lg flex items-center justify-center">
-                <Sparkles className="w-5 h-5 text-amber-600 dark:text-amber-400" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <p className="font-semibold text-charcoal-50 dark:text-white">
-                  Playing catch-up on AI?
-                </p>
-                <p className="text-sm text-parchment-600 dark:text-slate-400">
-                  Skip the research—here are the 4 AI tools I actually use to run my business
-                </p>
-              </div>
-              <ArrowRight className="w-5 h-5 text-amber-600 dark:text-amber-400 group-hover:translate-x-1 transition-transform" />
-            </div>
-          </div>
-        </Link>
-
-        <div className="bg-white dark:bg-slate-900 rounded-xl shadow-sm border border-slate-200 dark:border-slate-800 p-4 mb-8 max-w-4xl mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400" size={18} />
-              <Input
-                placeholder="Search articles..."
-                className="pl-10"
-                value={searchTerm}
-                onChange={(e) => handleSearchChange(e.target.value)}
-              />
-            </div>
-
-            <Select value={selectedYear} onValueChange={setSelectedYear}>
-              <SelectTrigger className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
-                <SelectValue placeholder="Year">
-                  {selectedYear}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent className="bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
-                <SelectItem value={ALL_YEARS_OPTION}>{ALL_YEARS_OPTION}</SelectItem>
-                {years.map((year) => (
-                  <SelectItem key={year} value={year}>
-                    {year}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="flex justify-between items-center mt-4">
-            <Button variant="outline" size="sm" onClick={resetFilters} className="text-slate-600 dark:text-slate-400">
-              Reset Filters
-            </Button>
-            <span className="text-sm text-slate-500 dark:text-slate-400">
-              {filteredArticles.length} {filteredArticles.length === 1 ? "article" : "articles"} found
+          <div className="eb-rule">
+            <span><b>{totalCount}</b> posts</span>
+            <span>
+              Since <span className="eb-dotted">{toRomanNumeral(earliestYear)}</span>
+              {latestDate ? <> · Archive complete through <b>{fmtMonYear(latestDate)}</b></> : null}
+            </span>
+            <span>{thisYearCount} this year</span>
+            <span>
+              <Link href="/rss/feed.xml">RSS ↗</Link>
             </span>
           </div>
         </div>
+      </section>
 
-        <div className="space-y-8">
-          <section>
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white mb-6 text-center">All Articles</h2>
+      <section className="eb-filter-bar">
+        <div className="eb-container">
+          <div className="eb-filter-row">
+            <div className="eb-search">
+              <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <circle cx={11} cy={11} r={8} />
+                <path d="m21 21-4.3-4.3" />
+              </svg>
+              <input
+                ref={searchInputRef}
+                type="search"
+                placeholder="Search…"
+                aria-label="Search writing"
+                value={search}
+                onChange={(e) => handleSearch(e.target.value)}
+              />
+              <span className="eb-kbd">⌘K</span>
+            </div>
 
-            <div className="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
-              <div className="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-                {filteredArticles.map((article) => (
-                  <ContentCard key={article.slug} article={article} />
-                ))}
+            <button
+              type="button"
+              className="eb-filters-toggle"
+              aria-expanded={drawerOpen}
+              onClick={() => setDrawerOpen((v) => !v)}
+            >
+              <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1={4} y1={21} x2={4} y2={14} />
+                <line x1={4} y1={10} x2={4} y2={3} />
+                <line x1={12} y1={21} x2={12} y2={12} />
+                <line x1={12} y1={8} x2={12} y2={3} />
+                <line x1={20} y1={21} x2={20} y2={16} />
+                <line x1={20} y1={12} x2={20} y2={3} />
+                <line x1={1} y1={14} x2={7} y2={14} />
+                <line x1={9} y1={8} x2={15} y2={8} />
+                <line x1={17} y1={16} x2={23} y2={16} />
+              </svg>
+              Filter
+              {activeFilterCount > 0 && (
+                <span className="eb-filter-badge">{activeFilterCount}</span>
+              )}
+            </button>
+
+            <span className="eb-results-count">
+              <b>{filtered.length}</b>{" "}
+              {filtered.length === totalCount
+                ? `post${filtered.length === 1 ? "" : "s"}`
+                : `of ${totalCount} posts`}
+            </span>
+
+            <div className="eb-view-toggle" role="tablist" aria-label="Layout">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={variation === "A"}
+                aria-label="Gallery"
+                title="Gallery"
+                className={variation === "A" ? "is-active" : ""}
+                onClick={() => chooseVariation("A")}
+              >
+                <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <rect x={3} y={3} width={7} height={7} />
+                  <rect x={14} y={3} width={7} height={7} />
+                  <rect x={3} y={14} width={7} height={7} />
+                  <rect x={14} y={14} width={7} height={7} />
+                </svg>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={variation === "B"}
+                aria-label="List"
+                title="List"
+                className={variation === "B" ? "is-active" : ""}
+                onClick={() => chooseVariation("B")}
+              >
+                <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <line x1={3} y1={6} x2={21} y2={6} />
+                  <line x1={3} y1={12} x2={21} y2={12} />
+                  <line x1={3} y1={18} x2={21} y2={18} />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          {drawerOpen && (
+            <div className="eb-filter-drawer">
+              <div className="eb-drawer-row">
+                <span className="eb-drawer-label">Kind</span>
+                <div className="eb-chip-group">
+                  <button
+                    type="button"
+                    className={`eb-chip ${kind === "All" ? "is-active" : ""}`}
+                    onClick={() => setKind("All")}
+                  >
+                    All<span className="eb-count">{totalCount}</span>
+                  </button>
+                  {kindOrder.map((k) => (
+                    <button
+                      key={k}
+                      type="button"
+                      className={`eb-chip ${kind === k ? "is-active" : ""}`}
+                      onClick={() => setKind(k)}
+                    >
+                      {KIND_LABEL[k] ?? k}
+                      <span className="eb-count">{kindCounts[k]}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {topTags.length > 0 && (
+                <div className="eb-drawer-row">
+                  <span className="eb-drawer-label">Tag</span>
+                  <div className="eb-chip-group">
+                    <button
+                      type="button"
+                      className={`eb-chip ${tag === "All" ? "is-active" : ""}`}
+                      onClick={() => setTag("All")}
+                    >
+                      All tags<span className="eb-count">{totalCount}</span>
+                    </button>
+                    {topTags.map((t) => (
+                      <button
+                        key={t}
+                        type="button"
+                        className={`eb-chip ${tag === t ? "is-active" : ""}`}
+                        onClick={() => setTag(t)}
+                      >
+                        #{t}
+                        <span className="eb-count">{tagCounts[t]}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <div className="eb-drawer-row">
+                <span className="eb-drawer-label">Sort</span>
+                <select
+                  className="eb-sort-select"
+                  aria-label="Sort"
+                  value={sort}
+                  onChange={(e) => setSort(e.target.value as SortKey)}
+                >
+                  <option value="newest">Newest first</option>
+                  <option value="oldest">Oldest first</option>
+                </select>
+                <button type="button" className="eb-clear" onClick={clearAll}>
+                  Clear all
+                </button>
               </div>
             </div>
-          </section>
+          )}
         </div>
-      </div>
+      </section>
+
+      <main>
+        <div className="eb-container">
+          {filtered.length === 0 ? (
+            <div className="eb-empty">
+              <h3>No matches.</h3>
+              <p>Try clearing a filter or searching with a different term.</p>
+            </div>
+          ) : variation === "A" ? (
+            <Gallery
+              posts={filtered}
+              showLead={search === "" && kind === "All" && tag === "All" && sort === "newest"}
+            />
+          ) : (
+            <Ledger groups={ledgerGroups} />
+          )}
+
+          <div className="eb-newsletter">
+            <div>
+              <h3>The Modern Coding letter.</h3>
+              <p>
+                Monthly. One essay on applied AI. No marketing, no spam.
+              </p>
+            </div>
+            <form
+              className="eb-newsletter-form"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const fd = new FormData(e.currentTarget);
+                const email = String(fd.get("email") || "");
+                if (!email) return;
+                track("newsletter_subscribe_submit", { location: "blog-index" });
+                window.location.href = `/subscribe?email=${encodeURIComponent(email)}`;
+              }}
+            >
+              <input
+                type="email"
+                name="email"
+                required
+                placeholder="you@company.com"
+                aria-label="Email"
+              />
+              <button type="submit" className="eb-btn-primary">
+                Subscribe →
+              </button>
+            </form>
+          </div>
+        </div>
+      </main>
     </div>
   );
 }
 
+function Gallery({ posts, showLead }: { posts: ArticleWithSlug[]; showLead: boolean }) {
+  return (
+    <div className="eb-grid">
+      {posts.map((post, i) => {
+        const isLead = showLead && i === 0;
+        const pattern = THUMB_PATTERNS[i % THUMB_PATTERNS.length];
+        const kindKey = post.type || "blog";
+        const imgSrc = resolveImageSrc(post.image);
+        return (
+          <Link
+            key={post.slug ?? `${post.title}-${i}`}
+            className={`eb-card${isLead ? " is-lead" : ""}`}
+            href={`/blog/${post.slug}`}
+          >
+            <div className={`eb-thumb ${imgSrc ? "" : pattern}`}>
+              {imgSrc ? (
+                <Image
+                  src={imgSrc}
+                  alt=""
+                  fill
+                  sizes={isLead ? "(min-width:1000px) 520px, 100vw" : "(min-width:1000px) 380px, 100vw"}
+                  style={{ objectFit: "cover" }}
+                  unoptimized
+                />
+              ) : null}
+              <span className="eb-thumb-num">
+                {pad2(i + 1)} · {KIND_LABEL[kindKey] ?? kindKey}
+              </span>
+              {!imgSrc && <span className="eb-thumb-glyph">{firstGlyph(post.title)}</span>}
+            </div>
+            <div className="eb-card-body">
+              <div className="eb-card-meta">
+                <span className="eb-kind-pill">{KIND_LABEL[kindKey] ?? kindKey}</span>
+                <span>{fmtMonYear(post.date)}</span>
+              </div>
+              <h3 className="eb-card-title">{post.title}</h3>
+              <p className="eb-card-dek">{post.description}</p>
+              <div className="eb-card-footer">
+                <div className="eb-card-tags">
+                  {(post.tags || []).slice(0, 3).map((t) => (
+                    <span key={t}>#{t}</span>
+                  ))}
+                </div>
+                <span>Read →</span>
+              </div>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+function Ledger({ groups }: { groups: Array<{ year: string; posts: ArticleWithSlug[] }> }) {
+  let running = 0;
+  return (
+    <div className="eb-ledger">
+      {groups.map(({ year, posts }) => {
+        const tagSet = new Set<string>();
+        posts.forEach((p) => (p.tags || []).forEach((t) => tagSet.add(t)));
+        return (
+          <div key={year}>
+            <header className="eb-year">
+              <div className="eb-year-label">{year}</div>
+              <div className="eb-year-meta">
+                <b>{posts.length}</b> posts · {tagSet.size} tag{tagSet.size === 1 ? "" : "s"}
+              </div>
+            </header>
+            {posts.map((post) => {
+              running += 1;
+              const { day, mon } = fmtDayMon(post.date);
+              const kindKey = post.type || "blog";
+              return (
+                <Link
+                  key={post.slug ?? `${post.title}-${running}`}
+                  className="eb-row"
+                  href={`/blog/${post.slug}`}
+                >
+                  <div className="eb-num">№ {pad2(running)}</div>
+                  <div className="eb-mdate">
+                    <span className="eb-day">{day}</span> {mon}
+                  </div>
+                  <div className="eb-title-wrap">
+                    <h3 className="eb-row-title">{post.title}</h3>
+                    <p className="eb-row-dek">{post.description}</p>
+                  </div>
+                  <div className="eb-kind">{KIND_LABEL[kindKey] ?? kindKey}</div>
+                  <div className="eb-arrow">→</div>
+                </Link>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -23,8 +23,6 @@ export default async function ArticlesIndex() {
     !a.hiddenFromIndex  // Exclude SEO/affiliate articles from main listing
   ) as Blog[];
 
-  const years = [...new Set(articles.map((a) => new Date(a.date).getFullYear().toString()))].sort((a, b) => parseInt(b) - parseInt(a));
-
-  return <BlogClient articles={articles} years={years} />;
+  return <BlogClient articles={articles} />;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Toaster } from '@/components/ui/toaster';
 import '@/styles/tailwind.css';
 import '@/styles/global.css';
 import '@/styles/editorial-home.css';
+import '@/styles/editorial-blog.css';
 import '@/styles/blog-post.css';
 import '@/styles/testimonials.css';
 import '@/styles/contact.css';

--- a/src/app/videos/VideosTheaterClient.tsx
+++ b/src/app/videos/VideosTheaterClient.tsx
@@ -27,6 +27,11 @@ export type TheaterVideo = {
 
 type Props = { videos: TheaterVideo[] }
 
+const MONTHS_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
 const pad2 = (n: number) => String(n).padStart(2, '0')
 const fmtDur = (s: number) => {
   if (s == null || isNaN(s)) return '—'
@@ -34,7 +39,10 @@ const fmtDur = (s: number) => {
   return h ? `${h}:${pad2(m)}:${pad2(sec)}` : `${m}:${pad2(sec)}`
 }
 const fmtMon = (iso: string) => {
-  try { return new Date(iso).toLocaleDateString('en-US', { month: 'short', year: 'numeric' }) }
+  try {
+    const d = new Date(iso)
+    return `${MONTHS_SHORT[d.getUTCMonth()]} ${d.getUTCFullYear()}`
+  }
   catch { return iso }
 }
 const fmtViews = (n: number) => {

--- a/src/app/videos/VideosTheaterClient.tsx
+++ b/src/app/videos/VideosTheaterClient.tsx
@@ -107,8 +107,8 @@ export default function VideosTheaterClient({ videos }: Props) {
       }
       return true
     }).sort((a, b) => {
-      if (sort === 'newest') return a.date < b.date ? 1 : -1
-      if (sort === 'oldest') return a.date > b.date ? 1 : -1
+      if (sort === 'newest') return new Date(b.date).getTime() - new Date(a.date).getTime()
+      if (sort === 'oldest') return new Date(a.date).getTime() - new Date(b.date).getTime()
       if (sort === 'popular') return b.views - a.views
       if (sort === 'longest') return b.durSec - a.durSec
       if (sort === 'shortest') return a.durSec - b.durSec
@@ -137,7 +137,7 @@ export default function VideosTheaterClient({ videos }: Props) {
   const totalSec = useMemo(() => videos.reduce((s, v) => s + v.durSec, 0), [videos])
   const totalViews = useMemo(() => videos.reduce((s, v) => s + v.views, 0), [videos])
   const lastDate = useMemo(() => {
-    const sorted = [...videos].sort((a, b) => (a.date < b.date ? 1 : -1))
+    const sorted = [...videos].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     return sorted[0]?.date ? fmtMon(sorted[0].date) : ''
   }, [videos])
 

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -86,7 +86,7 @@ export default async function VideosIndex() {
 
   const payload: TheaterVideo[] = videos
     .filter(v => !v.hiddenFromIndex)
-    .sort((a, b) => (a.date < b.date ? 1 : -1))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     .map((v, i) => {
       const kind = kindOf(v)
       const { series, part } = seriesOf(v)

--- a/src/lib/content-handlers.ts
+++ b/src/lib/content-handlers.ts
@@ -159,7 +159,9 @@ function _processContentMetadata(contentType: string, directorySlug: string, raw
     ...(processedMetadata.landing && { landing: processedMetadata.landing }),
     ...(processedMetadata.tags && { tags: processedMetadata.tags }),
     ...(typeof processedMetadata.hiddenFromIndex !== 'undefined' && { hiddenFromIndex: processedMetadata.hiddenFromIndex }),
-    ...(typeof processedMetadata.hideNewsletter !== 'undefined' && { hideNewsletter: processedMetadata.hideNewsletter })
+    ...(typeof processedMetadata.hideNewsletter !== 'undefined' && { hideNewsletter: processedMetadata.hideNewsletter }),
+    ...(typeof processedMetadata.durSec !== 'undefined' && { durSec: processedMetadata.durSec }),
+    ...(typeof processedMetadata.views !== 'undefined' && { views: processedMetadata.views })
   };
 
   logger.debug(`Processed metadata for ${contentType}/${directorySlug}`, content);

--- a/src/styles/editorial-blog.css
+++ b/src/styles/editorial-blog.css
@@ -1,0 +1,503 @@
+/* Editorial /blog index — glow-up port of the design-system Blog Index.
+ * Scoped under .editorial-blog to avoid leaking into the rest of the site.
+ * Relies on --font-serif / --font-sans / --font-mono registered in layout.tsx.
+ */
+
+.editorial-blog {
+  /* Light tokens */
+  --eb-bg: #fbf7f0;               /* parchment-100 */
+  --eb-bg-secondary: #f5f0e6;     /* parchment-200 */
+  --eb-bg-elevated: #fefdfb;      /* parchment-50 */
+  --eb-fg: #2c3e50;               /* charcoal-50 */
+  --eb-fg-muted: #8b7355;         /* parchment-600 */
+  --eb-fg-subtle: #b8a88f;        /* parchment-500 */
+  --eb-border: #e8e0d0;           /* parchment-300 */
+  --eb-border-strong: #d1c7b7;    /* parchment-400 */
+  --eb-accent: #e67e22;           /* burnt-400 */
+  --eb-accent-hover: #d35400;     /* burnt-500 */
+  --eb-accent-soft: rgb(230 126 34 / .10);
+  --eb-accent-ring: rgb(230 126 34 / .40);
+  --eb-shadow-sm: 0 1px 2px 0 rgb(24 24 40 / .04);
+  --eb-shadow-md: 0 4px 10px -2px rgb(24 24 40 / .08), 0 2px 4px -2px rgb(24 24 40 / .05);
+  --eb-shadow-lg: 0 12px 28px -8px rgb(24 24 40 / .14), 0 4px 8px -4px rgb(24 24 40 / .08);
+
+  position: relative;
+  isolation: isolate;
+  background-color: var(--eb-bg);
+  color: var(--eb-fg);
+  font-family: var(--font-sans, Inter, system-ui, sans-serif);
+  padding-bottom: 0;
+}
+
+.editorial-blog::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(139, 115, 85, .05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139, 115, 85, .05) 1px, transparent 1px),
+    radial-gradient(ellipse at top left, rgba(230, 126, 34, .025), transparent 60%);
+  background-size: 120px 120px, 120px 120px, 100% 100%;
+}
+
+/* Dark tokens */
+.dark .editorial-blog {
+  --eb-bg: #1a1a2e;               /* charcoal-400 */
+  --eb-bg-secondary: #141428;     /* charcoal-500 */
+  --eb-bg-elevated: #1e293b;      /* slate-800 */
+  --eb-fg: #fbf7f0;               /* parchment-100 */
+  --eb-fg-muted: #cbd5e1;         /* slate-300 */
+  --eb-fg-subtle: #94a3b8;        /* slate-400 */
+  --eb-border: #334155;           /* slate-700 */
+  --eb-border-strong: #475569;    /* slate-600 */
+  --eb-accent: #f39c12;           /* amber-400 */
+  --eb-accent-hover: #fcd34d;     /* amber-300 */
+  --eb-accent-soft: rgb(243 156 18 / .20);
+  --eb-accent-ring: rgb(243 156 18 / .40);
+  --eb-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / .4);
+  --eb-shadow-md: 0 4px 10px -2px rgb(0 0 0 / .5);
+  --eb-shadow-lg: 0 12px 28px -8px rgb(0 0 0 / .6);
+}
+.dark .editorial-blog::before {
+  background-image:
+    linear-gradient(rgba(148, 163, 184, .03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, .03) 1px, transparent 1px);
+  background-size: 120px 120px, 120px 120px;
+}
+
+.editorial-blog *,
+.editorial-blog *::before,
+.editorial-blog *::after { box-sizing: border-box; }
+
+.editorial-blog .eb-container { max-width: 1200px; margin: 0 auto; padding: 0 32px; }
+.editorial-blog .eb-hide { display: none !important; }
+
+/* ---------------- Header ---------------- */
+.editorial-blog .eb-header { padding: 56px 0 28px; }
+.editorial-blog .eb-eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px; font-weight: 600; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--eb-fg-subtle);
+}
+.editorial-blog .eb-eyebrow::before {
+  content: ''; width: 24px; height: 1px; background: var(--eb-accent);
+}
+.editorial-blog .eb-title {
+  margin: 14px 0 0;
+  font-family: var(--font-serif, Georgia, serif); font-weight: 800;
+  font-size: clamp(44px, 5.2vw, 68px); line-height: 1.04; letter-spacing: -.028em;
+  color: var(--eb-fg); text-wrap: balance;
+}
+.editorial-blog .eb-title em { font-style: italic; color: var(--eb-accent); font-weight: 800; }
+.editorial-blog .eb-dek {
+  margin: 20px 0 0; max-width: 62ch;
+  font-size: 19px; line-height: 1.6; color: var(--eb-fg-muted); text-wrap: pretty;
+}
+.editorial-blog .eb-rule {
+  display: grid; grid-template-columns: auto 1fr auto auto; gap: 24px;
+  align-items: center; margin-top: 36px; padding-top: 14px;
+  border-top: 1px solid var(--eb-border);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: var(--eb-fg-subtle);
+}
+.editorial-blog .eb-rule b { color: var(--eb-fg); font-weight: 600; letter-spacing: .1em; }
+.editorial-blog .eb-rule .eb-dotted { border-bottom: 1px dotted var(--eb-border-strong); padding-bottom: 3px; }
+.editorial-blog .eb-rule a {
+  color: var(--eb-fg-subtle); text-decoration: none;
+  transition: color .15s;
+}
+.editorial-blog .eb-rule a:hover { color: var(--eb-accent); }
+@media (max-width: 720px) {
+  .editorial-blog .eb-rule { grid-template-columns: 1fr 1fr; gap: 10px; }
+}
+
+/* ---------------- Filter bar ---------------- */
+.editorial-blog .eb-filter-bar {
+  position: sticky; top: 0; z-index: 30;
+  background: color-mix(in oklab, var(--eb-bg) 94%, transparent);
+  backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+  border-top: 1px solid var(--eb-border);
+  border-bottom: 1px solid var(--eb-border);
+  padding: 12px 0;
+}
+.editorial-blog .eb-filter-row {
+  display: grid; grid-template-columns: 1fr auto auto auto; gap: 10px;
+  align-items: center;
+}
+.editorial-blog .eb-search {
+  position: relative; display: flex; align-items: center; gap: 10px;
+  border: 1px solid var(--eb-border); border-radius: 6px;
+  padding: 8px 12px; background: var(--eb-bg-elevated);
+  transition: border-color .15s, box-shadow .15s;
+  max-width: 420px;
+}
+.editorial-blog .eb-search:focus-within {
+  border-color: var(--eb-accent);
+  box-shadow: 0 0 0 3px var(--eb-accent-ring);
+}
+.editorial-blog .eb-search svg { flex-shrink: 0; color: var(--eb-fg-subtle); }
+.editorial-blog .eb-search input {
+  flex: 1; border: 0; background: transparent; outline: none;
+  font-family: var(--font-sans, Inter, sans-serif); font-size: 14px;
+  color: var(--eb-fg); min-width: 0;
+}
+.editorial-blog .eb-search input::placeholder { color: var(--eb-fg-subtle); }
+.editorial-blog .eb-kbd {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: .08em;
+  color: var(--eb-fg-subtle); border: 1px solid var(--eb-border);
+  padding: 2px 6px; border-radius: 4px; background: var(--eb-bg);
+}
+.editorial-blog .eb-filters-toggle {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--font-sans, Inter, sans-serif); font-size: 13px; font-weight: 500;
+  color: var(--eb-fg); background: transparent; border: 1px solid var(--eb-border);
+  border-radius: 6px; padding: 8px 14px; cursor: pointer;
+  transition: border-color .15s, color .15s;
+}
+.editorial-blog .eb-filters-toggle:hover { border-color: var(--eb-border-strong); }
+.editorial-blog .eb-filters-toggle[aria-expanded="true"] { border-color: var(--eb-accent); color: var(--eb-accent); }
+.editorial-blog .eb-filters-toggle svg { color: var(--eb-fg-subtle); }
+.editorial-blog .eb-filters-toggle[aria-expanded="true"] svg { color: var(--eb-accent); }
+.editorial-blog .eb-filter-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 18px; height: 18px; padding: 0 5px;
+  background: var(--eb-accent); color: #fff;
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; font-weight: 600;
+  border-radius: 999px;
+}
+.dark .editorial-blog .eb-filter-badge { color: #1a1a2e; }
+.editorial-blog .eb-results-count {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; letter-spacing: .06em;
+  color: var(--eb-fg-subtle); white-space: nowrap;
+}
+.editorial-blog .eb-results-count b { color: var(--eb-fg); font-weight: 600; }
+
+.editorial-blog .eb-view-toggle {
+  display: inline-flex; border: 1px solid var(--eb-border); border-radius: 6px; overflow: hidden;
+}
+.editorial-blog .eb-view-toggle button {
+  background: transparent; border: 0; cursor: pointer;
+  width: 34px; height: 34px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--eb-fg-muted);
+}
+.editorial-blog .eb-view-toggle button:hover { color: var(--eb-fg); }
+.editorial-blog .eb-view-toggle button.is-active { background: var(--eb-accent); color: #fff; }
+.dark .editorial-blog .eb-view-toggle button.is-active { color: #1a1a2e; }
+
+/* Drawer */
+.editorial-blog .eb-filter-drawer {
+  margin-top: 12px; padding-top: 14px;
+  border-top: 1px dashed var(--eb-border);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.editorial-blog .eb-drawer-row {
+  display: grid; grid-template-columns: 60px 1fr auto; gap: 14px;
+  align-items: center;
+}
+.editorial-blog .eb-drawer-label {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--eb-fg-subtle); font-weight: 600;
+}
+.editorial-blog .eb-chip-group { display: flex; gap: 4px; flex-wrap: wrap; }
+.editorial-blog .eb-chip {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--eb-fg-muted);
+  padding: 6px 10px; border: 1px solid var(--eb-border); border-radius: 999px;
+  background: transparent; cursor: pointer;
+  transition: color .15s, border-color .15s, background .15s;
+}
+.editorial-blog .eb-chip:hover { color: var(--eb-fg); border-color: var(--eb-border-strong); }
+.editorial-blog .eb-chip.is-active {
+  color: var(--eb-accent); border-color: var(--eb-accent); background: var(--eb-accent-soft);
+}
+.editorial-blog .eb-chip .eb-count { opacity: .5; margin-left: 6px; }
+.editorial-blog .eb-sort-select {
+  font-family: var(--font-sans, Inter, sans-serif); font-size: 13px; color: var(--eb-fg);
+  background: var(--eb-bg-elevated); border: 1px solid var(--eb-border); border-radius: 6px;
+  padding: 6px 10px; cursor: pointer;
+}
+.editorial-blog .eb-clear {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--eb-fg-muted);
+  background: transparent; border: 0; cursor: pointer; padding: 4px 8px;
+}
+.editorial-blog .eb-clear:hover { color: var(--eb-accent); }
+
+@media (max-width: 720px) {
+  .editorial-blog .eb-filter-row { grid-template-columns: 1fr auto; }
+  .editorial-blog .eb-filters-toggle { grid-column: 1; grid-row: 2; justify-self: start; }
+  .editorial-blog .eb-results-count { display: none; }
+  .editorial-blog .eb-drawer-row { grid-template-columns: 1fr; gap: 8px; }
+  .editorial-blog .eb-chip-group { overflow-x: auto; flex-wrap: nowrap; }
+}
+
+/* ---------------- Gallery (variation A) ---------------- */
+.editorial-blog .eb-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px;
+  padding: 40px 0 40px;
+}
+@media (max-width: 1000px) { .editorial-blog .eb-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 640px)  { .editorial-blog .eb-grid { grid-template-columns: 1fr; } }
+
+.editorial-blog .eb-card {
+  background: var(--eb-bg-elevated);
+  border: 1px solid var(--eb-border); border-radius: 8px;
+  overflow: hidden; display: flex; flex-direction: column;
+  text-decoration: none; color: inherit;
+  box-shadow: var(--eb-shadow-sm);
+  transition: transform .2s, box-shadow .2s, border-color .2s;
+}
+.editorial-blog .eb-card:hover {
+  transform: translateY(-2px); box-shadow: var(--eb-shadow-md);
+  border-color: var(--eb-border-strong);
+}
+.editorial-blog .eb-thumb {
+  position: relative; aspect-ratio: 16/9;
+  background: var(--eb-bg-secondary); border-bottom: 1px solid var(--eb-border);
+  overflow: hidden;
+}
+.editorial-blog .eb-thumb img {
+  position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;
+}
+.editorial-blog .eb-thumb.t-grid::before {
+  content: ''; position: absolute; inset: 0;
+  background-image:
+    linear-gradient(rgba(139,115,85,.14) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139,115,85,.14) 1px, transparent 1px);
+  background-size: 18px 18px;
+}
+.dark .editorial-blog .eb-thumb.t-grid::before {
+  background-image:
+    linear-gradient(rgba(148,163,184,.14) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148,163,184,.14) 1px, transparent 1px);
+}
+.editorial-blog .eb-thumb.t-dots::before {
+  content: ''; position: absolute; inset: 0;
+  background-image: radial-gradient(rgba(139,115,85,.22) 1px, transparent 1.5px);
+  background-size: 10px 10px;
+}
+.dark .editorial-blog .eb-thumb.t-dots::before {
+  background-image: radial-gradient(rgba(148,163,184,.22) 1px, transparent 1.5px);
+}
+.editorial-blog .eb-thumb.t-rule::before {
+  content: ''; position: absolute; inset: 0;
+  background: repeating-linear-gradient(90deg, var(--eb-border) 0 1px, transparent 1px 14px);
+  opacity: .7;
+}
+.editorial-blog .eb-thumb.t-diag::before {
+  content: ''; position: absolute; inset: 0;
+  background-image: repeating-linear-gradient(45deg, rgba(139,115,85,.12) 0 1px, transparent 1px 10px);
+}
+.dark .editorial-blog .eb-thumb.t-diag::before {
+  background-image: repeating-linear-gradient(45deg, rgba(148,163,184,.14) 0 1px, transparent 1px 10px);
+}
+.editorial-blog .eb-thumb::after {
+  content: ''; position: absolute; left: 0; bottom: 0; height: 3px; width: 38%;
+  background: var(--eb-accent);
+}
+.editorial-blog .eb-thumb-num {
+  position: absolute; top: 12px; left: 14px; z-index: 2;
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: .12em;
+  color: var(--eb-fg-subtle); text-transform: uppercase;
+}
+.editorial-blog .eb-card .eb-thumb img + .eb-thumb-num,
+.editorial-blog .eb-card .eb-thumb img ~ .eb-thumb-num { color: rgba(255,255,255,.85); }
+.editorial-blog .eb-thumb-glyph {
+  position: absolute; right: 14px; bottom: 10px; z-index: 2;
+  font-family: var(--font-serif, Georgia, serif); font-weight: 800;
+  font-size: 44px; line-height: 1; color: var(--eb-accent);
+  opacity: .9; letter-spacing: -.03em;
+}
+.editorial-blog .eb-card-body {
+  padding: 18px 20px 20px; display: flex; flex-direction: column; gap: 8px; flex: 1;
+}
+.editorial-blog .eb-card-meta {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--eb-fg-subtle);
+}
+.editorial-blog .eb-kind-pill {
+  color: var(--eb-accent); border: 1px solid var(--eb-accent-ring); border-radius: 3px;
+  padding: 2px 6px; font-weight: 600;
+}
+.editorial-blog .eb-card-title {
+  margin: 0; font-family: var(--font-serif, Georgia, serif); font-weight: 700;
+  font-size: 22px; line-height: 1.22; color: var(--eb-fg); letter-spacing: -.008em;
+  text-wrap: pretty;
+}
+.editorial-blog .eb-card:hover .eb-card-title { color: var(--eb-accent); }
+.editorial-blog .eb-card-dek {
+  margin: 0; font-family: var(--font-sans, Inter, sans-serif); font-size: 14px; line-height: 1.55;
+  color: var(--eb-fg-muted); text-wrap: pretty;
+}
+.editorial-blog .eb-card-footer {
+  margin-top: auto; padding-top: 10px;
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--eb-fg-subtle);
+}
+.editorial-blog .eb-card-tags { display: flex; gap: 6px; flex-wrap: wrap; }
+.editorial-blog .eb-card-tags span { opacity: .7; }
+
+/* Lead card (first card, spans 2 cols + horizontal layout) */
+.editorial-blog .eb-grid .eb-card.is-lead {
+  grid-column: span 2; flex-direction: row;
+}
+.editorial-blog .eb-grid .eb-card.is-lead .eb-thumb {
+  aspect-ratio: auto; width: 46%;
+  border-right: 1px solid var(--eb-border); border-bottom: 0;
+}
+.editorial-blog .eb-grid .eb-card.is-lead .eb-card-body {
+  padding: 30px 36px; gap: 12px;
+}
+.editorial-blog .eb-grid .eb-card.is-lead .eb-card-title {
+  font-size: 32px; line-height: 1.1; font-weight: 800; letter-spacing: -.015em;
+}
+.editorial-blog .eb-grid .eb-card.is-lead .eb-card-dek {
+  font-size: 16px; max-width: 48ch;
+}
+.editorial-blog .eb-grid .eb-card.is-lead .eb-thumb-glyph {
+  font-size: 96px; right: 24px; bottom: 18px;
+}
+@media (max-width: 1000px) {
+  .editorial-blog .eb-grid .eb-card.is-lead { flex-direction: column; }
+  .editorial-blog .eb-grid .eb-card.is-lead .eb-thumb {
+    width: 100%; aspect-ratio: 16/9;
+    border-right: 0; border-bottom: 1px solid var(--eb-border);
+  }
+}
+@media (max-width: 640px) {
+  .editorial-blog .eb-grid .eb-card.is-lead { grid-column: span 1; }
+}
+
+/* ---------------- Ledger (variation B) ---------------- */
+.editorial-blog .eb-ledger { padding: 40px 0 40px; }
+.editorial-blog .eb-year {
+  display: grid; grid-template-columns: 120px 1fr; gap: 32px;
+  padding: 28px 0 12px;
+  border-top: 2px solid var(--eb-border-strong);
+  position: sticky; top: 64px; background: var(--eb-bg); z-index: 2;
+}
+.editorial-blog .eb-year-label {
+  font-family: var(--font-serif, Georgia, serif); font-weight: 800;
+  font-size: 56px; line-height: 1; letter-spacing: -.03em; color: var(--eb-accent);
+}
+.editorial-blog .eb-year-meta {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--eb-fg-subtle); align-self: end;
+  padding-bottom: 10px;
+}
+.editorial-blog .eb-year-meta b { color: var(--eb-fg); font-weight: 600; }
+
+.editorial-blog .eb-row {
+  display: grid; grid-template-columns: 120px 70px 1fr 160px 80px;
+  gap: 28px; align-items: baseline;
+  padding: 20px 0; border-bottom: 1px solid var(--eb-border);
+  text-decoration: none; color: inherit;
+  transition: background .15s, padding-left .2s;
+}
+.editorial-blog .eb-row:hover { background: var(--eb-bg-secondary); padding-left: 12px; }
+.editorial-blog .eb-row .eb-num {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; letter-spacing: .12em;
+  color: var(--eb-fg-subtle); font-weight: 600;
+}
+.editorial-blog .eb-row .eb-mdate {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; letter-spacing: .06em;
+  color: var(--eb-fg-muted);
+}
+.editorial-blog .eb-row .eb-mdate .eb-day { color: var(--eb-accent); font-weight: 600; }
+.editorial-blog .eb-row .eb-title-wrap { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.editorial-blog .eb-row .eb-row-title {
+  margin: 0; font-family: var(--font-serif, Georgia, serif); font-weight: 700;
+  font-size: 20px; line-height: 1.25; color: var(--eb-fg); letter-spacing: -.008em;
+  text-wrap: pretty;
+}
+.editorial-blog .eb-row:hover .eb-row-title { color: var(--eb-accent); }
+.editorial-blog .eb-row .eb-row-dek {
+  margin: 0; font-family: var(--font-sans, Inter, sans-serif); font-size: 13px; line-height: 1.5;
+  color: var(--eb-fg-muted);
+}
+.editorial-blog .eb-row .eb-kind {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10px; letter-spacing: .1em;
+  color: var(--eb-fg-muted); text-transform: uppercase;
+}
+.editorial-blog .eb-row .eb-arrow {
+  font-family: var(--font-mono, ui-monospace, monospace); color: var(--eb-fg-subtle);
+  text-align: right; transition: color .15s, transform .15s;
+}
+.editorial-blog .eb-row:hover .eb-arrow { color: var(--eb-accent); transform: translateX(3px); }
+@media (max-width: 1000px) {
+  .editorial-blog .eb-row { grid-template-columns: 60px 1fr auto; gap: 14px; }
+  .editorial-blog .eb-row .eb-mdate,
+  .editorial-blog .eb-row .eb-kind { grid-column: 2; font-size: 10px; }
+  .editorial-blog .eb-row .eb-arrow { grid-row: 1; grid-column: 3; align-self: center; }
+  .editorial-blog .eb-year { grid-template-columns: 1fr; gap: 4px; position: static; }
+  .editorial-blog .eb-year-label { font-size: 40px; }
+}
+
+/* ---------------- Newsletter strip ---------------- */
+.editorial-blog .eb-newsletter {
+  margin: 40px 0 80px;
+  border: 1px solid var(--eb-border-strong);
+  background: var(--eb-bg-elevated);
+  border-radius: 10px; padding: 36px 40px;
+  display: grid; grid-template-columns: 1.4fr 1fr; gap: 28px; align-items: center;
+  position: relative; overflow: hidden;
+}
+.editorial-blog .eb-newsletter::before {
+  content: ''; position: absolute; inset: 0; pointer-events: none;
+  background-image:
+    linear-gradient(rgba(139,115,85,.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139,115,85,.06) 1px, transparent 1px);
+  background-size: 28px 28px;
+  opacity: .7;
+}
+.dark .editorial-blog .eb-newsletter::before {
+  background-image:
+    linear-gradient(rgba(148,163,184,.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148,163,184,.04) 1px, transparent 1px);
+}
+.editorial-blog .eb-newsletter > * { position: relative; }
+.editorial-blog .eb-newsletter h3 {
+  margin: 0 0 8px; font-family: var(--font-serif, Georgia, serif);
+  font-size: 26px; font-weight: 700; letter-spacing: -.01em; color: var(--eb-fg);
+}
+.editorial-blog .eb-newsletter p {
+  margin: 0; color: var(--eb-fg-muted); font-size: 14px; line-height: 1.55;
+}
+.editorial-blog .eb-newsletter-form { display: flex; gap: 8px; }
+.editorial-blog .eb-newsletter-form input {
+  flex: 1; font-family: var(--font-sans, Inter, sans-serif); font-size: 14px; color: var(--eb-fg);
+  background: var(--eb-bg); border: 1px solid var(--eb-border-strong); border-radius: 6px;
+  padding: 12px 14px;
+}
+.editorial-blog .eb-newsletter-form input:focus {
+  outline: none; border-color: var(--eb-accent);
+  box-shadow: 0 0 0 3px var(--eb-accent-ring);
+}
+.editorial-blog .eb-btn-primary {
+  font-family: var(--font-sans, Inter, sans-serif); font-weight: 600; font-size: 14px;
+  padding: 12px 20px; border-radius: 6px; border: 0; cursor: pointer;
+  background: var(--eb-accent); color: #fff;
+  transition: background .15s, transform .15s;
+}
+.editorial-blog .eb-btn-primary:hover {
+  background: var(--eb-accent-hover); transform: translateY(-1px);
+}
+.dark .editorial-blog .eb-btn-primary { color: #1a1a2e; }
+@media (max-width: 720px) {
+  .editorial-blog .eb-newsletter { grid-template-columns: 1fr; padding: 28px; }
+}
+
+/* ---------------- Empty state ---------------- */
+.editorial-blog .eb-empty {
+  text-align: center; padding: 80px 20px; color: var(--eb-fg-muted);
+}
+.editorial-blog .eb-empty h3 {
+  font-family: var(--font-serif, Georgia, serif); font-size: 24px; margin: 0 0 8px; color: var(--eb-fg);
+}
+.editorial-blog .eb-empty p { margin: 0; font-size: 14px; }

--- a/src/styles/editorial-blog.css
+++ b/src/styles/editorial-blog.css
@@ -430,13 +430,46 @@
   text-align: right; transition: color .15s, transform .15s;
 }
 .editorial-blog .eb-row:hover .eb-arrow { color: var(--eb-accent); transform: translateX(3px); }
+/* Tablet: collapse the date+kind columns, keep a single content column + arrow. */
 @media (max-width: 1000px) {
-  .editorial-blog .eb-row { grid-template-columns: 60px 1fr auto; gap: 14px; }
+  .editorial-blog .eb-row {
+    grid-template-columns: 60px 1fr auto;
+    grid-template-areas:
+      "num   title arrow"
+      ".     meta  meta";
+    gap: 6px 14px;
+  }
+  .editorial-blog .eb-row .eb-num        { grid-area: num; }
+  .editorial-blog .eb-row .eb-title-wrap { grid-area: title; min-width: 0; }
+  .editorial-blog .eb-row .eb-arrow      { grid-area: arrow; align-self: center; }
   .editorial-blog .eb-row .eb-mdate,
-  .editorial-blog .eb-row .eb-kind { grid-column: 2; font-size: 10px; }
-  .editorial-blog .eb-row .eb-arrow { grid-row: 1; grid-column: 3; align-self: center; }
+  .editorial-blog .eb-row .eb-kind {
+    grid-area: meta; display: inline;
+    font-size: 10px; color: var(--eb-fg-subtle);
+  }
+  .editorial-blog .eb-row .eb-mdate::after { content: " · "; opacity: .5; }
   .editorial-blog .eb-year { grid-template-columns: 1fr; gap: 4px; position: static; }
   .editorial-blog .eb-year-label { font-size: 40px; }
+}
+
+/* Phone: ditch the grid, stack meta / title / dek; drop the arrow. */
+@media (max-width: 640px) {
+  .editorial-blog .eb-row {
+    display: block; padding: 18px 0; gap: 0;
+  }
+  .editorial-blog .eb-row:hover { padding-left: 0; }
+  .editorial-blog .eb-row .eb-num,
+  .editorial-blog .eb-row .eb-mdate,
+  .editorial-blog .eb-row .eb-kind {
+    display: inline; font-size: 10px; margin-right: 10px;
+  }
+  .editorial-blog .eb-row .eb-mdate::after { content: none; }
+  .editorial-blog .eb-row .eb-title-wrap {
+    display: block; margin-top: 8px; min-width: 0;
+  }
+  .editorial-blog .eb-row .eb-row-title { font-size: 18px; }
+  .editorial-blog .eb-row .eb-row-dek { margin-top: 4px; }
+  .editorial-blog .eb-row .eb-arrow { display: none; }
 }
 
 /* ---------------- Newsletter strip ---------------- */


### PR DESCRIPTION
## Summary
- Port the Blog Index design from the zackproser.com design-system handoff into a real Next.js client component.
- Gallery (A) grid with a featured lead card + Ledger (B) year-grouped list, toggled from the filter bar.
- Collapsible filter drawer (kind / tag chips / sort / clear), debounced search with ⌘K focus, editorial header with archive stats, newsletter strip handing off to `/subscribe`.
- Styles scoped under `.editorial-blog` in `src/styles/editorial-blog.css` — no global token leakage; dark-mode variant included.

## What I dropped vs. the prototype
- Tweaks panel, density toggle, thumbs toggle, read-time toggle, accent swatch, hero verbose/terse — design-tool chrome, not real site features.
- Magazine variation (C) — design chat confirmed this was cut.
- Inline theme switcher + nav/footer — site has `ConsultancyNav` already.

## Data mapping (existing `ArticleWithSlug` fields)
- `type` → kind (Essay / Video / Demo)
- `description` → dek
- Read time omitted (not in metadata)
- Glyph synthesized from first letter of title when no image is present

## Test plan
- [ ] `/blog` renders in Gallery view with lead card on first post
- [ ] Toggle to List view — year rails render, rows link to posts
- [ ] ⌘K focuses the search input; typing filters both views
- [ ] Filter drawer opens; Kind + Tag chips and Sort select work; Clear all resets
- [ ] Active filter badge appears on the Filter button when non-default filters are set
- [ ] Dark mode swaps tokens (charcoal background, amber accent)
- [ ] Newsletter form submits and redirects to `/subscribe?email=…`
- [ ] Mobile (<720px): filter row collapses, chips scroll horizontally, ledger rows stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces the `/blog` index UI and client-side filtering/sorting logic, which could affect navigation, performance, and analytics events. Also tweaks content metadata shaping (`durSec`/`views`) and date sorting in video pages, which can change ordering and display.
> 
> **Overview**
> **Replaces the `/blog` index experience** with a new editorial client component: sticky search (with ⌘K focus), collapsible filter drawer (kind/tag/sort + clear), and a layout toggle between a *Gallery* card grid (with a lead card) and a *Ledger* year-grouped list.
> 
> Adds a scoped stylesheet `editorial-blog.css` (including dark-mode tokens) and wires it into the root layout, removes the old `years` prop plumbing from `blog/page.tsx`, and adds a newsletter subscribe handoff to `/subscribe` with new analytics events.
> 
> Also standardizes date formatting/sorting in the videos theater/index pages and extends `content-handlers` metadata shaping to include optional `durSec` and `views` fields; updates `next-env.d.ts` to reference Next route types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 421a1bc6994da280ba0960209f5a74dc1b9518ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->