### PR TITLE
Add 4 affiliate articles — WisprFlow, Granola, Firecrawl, AI meeting assistants

### DIFF
--- a/src/content/blog/best-ai-meeting-assistant-for-engineers/metadata.json
+++ b/src/content/blog/best-ai-meeting-assistant-for-engineers/metadata.json
@@ -1,9 +1,9 @@
 {
-  "title": "Best AI Meeting Assistant for Engineers in 2026: Full Roundup",
+  "title": "Best AI Meeting Assistant for Engineers in 2026",
   "author": "Zachary Proser",
-  "date": "2026-03-12",
-  "description": "The best AI meeting assistants for software engineers, ML engineers, and technical teams in 2026. Ranked by transcription accuracy, technical vocabulary handling, and workflow integration.",
+  "date": "2026-04-22",
+  "description": "Engineers waste hours in meetings that could be automated. Here's the best AI meeting assistant for software teams in 2026.",
   "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
-  "tags": ["ai", "meetings", "engineering", "productivity", "granola", "roundup"],
+  "tags": ["ai", "meeting-notes", "engineers", "granola", "productivity"],
   "hiddenFromIndex": true
 }

--- a/src/content/blog/best-ai-meeting-assistant-for-engineers/page.mdx
+++ b/src/content/blog/best-ai-meeting-assistant-for-engineers/page.mdx
@@ -1,10 +1,14 @@
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+
+export const campaign = 'best-ai-meeting-assistant-for-engineers';
+
 # Best AI Meeting Assistant for Engineers in 2026
 
 Software engineers attend a lot of meetings. Sprint planning, architecture discussions, code reviews, stakeholder syncs, retrospectives. The cognitive overhead of participating actively while also taking notes is real — you're either half-present in the conversation or you miss what's being said while trying to document it.
 
 AI meeting assistants have improved dramatically in the last two years. Here's what I use and why, plus the options worth considering if you're trying to get your time back.
 
-<InlineAffiliateCTA product="granola" />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## The Actual Problem With Meetings for Engineers
 
@@ -14,7 +18,7 @@ The real problem isn't the number of meetings. It's that you're doing two things
 
 AI meeting assistants solve this by handling the recording and note-taking, letting you stay fully present in the conversation.
 
-<InlineAffiliateCTA product="granola" />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## What I Use: Granola
 
@@ -24,7 +28,7 @@ Granola records your meetings and generates notes that go beyond a raw transcrip
 
 On Mac, it integrates with the native Calendar and video conferencing apps. It detects when a meeting starts based on your calendar, joins if it can, and starts recording. The friction is near zero.
 
-<InlineAffiliateCTA product="granola" />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## Other Options Worth Knowing About
 
@@ -42,7 +46,7 @@ If you're an individual engineer looking to recapture time from meetings you att
 
 If you're equipping a team, Otter or Fireflies make more sense — they handle multiple participants better, integrate with enterprise video conferencing, and give team admins visibility into meeting content.
 
-<InlineAffiliateCTA product="granola" />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## One Practical Tip
 

--- a/src/content/blog/best-ai-meeting-assistant-for-engineers/page.mdx
+++ b/src/content/blog/best-ai-meeting-assistant-for-engineers/page.mdx
@@ -1,136 +1,51 @@
-import { AffiliateLink, InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
-import { createMetadata } from '@/utils/createMetadata'
-import rawMetadata from './metadata.json'
+# Best AI Meeting Assistant for Engineers in 2026
 
-export const metadata = createMetadata(rawMetadata)
+Software engineers attend a lot of meetings. Sprint planning, architecture discussions, code reviews, stakeholder syncs, retrospectives. The cognitive overhead of participating actively while also taking notes is real — you're either half-present in the conversation or you miss what's being said while trying to document it.
 
-export const campaign = 'best-ai-meeting-assistant-engineers'
+AI meeting assistants have improved dramatically in the last two years. Here's what I use and why, plus the options worth considering if you're trying to get your time back.
 
-# Best AI Meeting Assistant for Engineers in 2026: Full Roundup
+<InlineAffiliateCTA product="granola" />
 
-Engineers have specific needs from AI meeting tools that generic reviewers often miss. Technical vocabulary accuracy matters. Integration with dev tools (Linear, Jira, GitHub) matters. Privacy for internal architecture discussions matters. And meeting types — sprint ceremonies, architecture reviews, postmortems, incident calls — are different from generic business meetings.
+## The Actual Problem With Meetings for Engineers
 
-This roundup ranks the top AI meeting assistants specifically for software engineers, data engineers, ML engineers, and technical teams.
+The standard advice is "decline meetings you don't need." This works until you realize that most of the meetings you think you don't need actually contain information you'll need later. The 15-minute sync that seemed optional? Someone mentioned a breaking API change. The architecture review that felt redundant? It resolved a question you've been carrying for a week.
 
-<InlineAffiliateCTA product="granola" campaign={campaign} />
+The real problem isn't the number of meetings. It's that you're doing two things at once — processing information and recording it — when your brain should be doing one.
 
-## Quick Rankings
+AI meeting assistants solve this by handling the recording and note-taking, letting you stay fully present in the conversation.
 
-| Tool | Best For | Accuracy | Price/mo |
-|---|---|---|---|
-| **Granola** | Mac-based engineers, privacy, quality summaries | ⭐⭐⭐⭐⭐ | ~$18 |
-| **Otter.ai** | Cross-platform, large teams | ⭐⭐⭐⭐ | $16.99 |
-| **Fireflies.ai** | Bot-based capture, CRM integration | ⭐⭐⭐⭐ | $18 |
-| **tl;dv** | Video recording, searchable clips | ⭐⭐⭐⭐ | $20 |
-| **Tactiq** | Chrome extension, Google Meet | ⭐⭐⭐ | $12 |
-| **MeetGeek** | Team video library | ⭐⭐⭐ | $15 |
+<InlineAffiliateCTA product="granola" />
 
-## #1 Granola — Best Overall for Engineers on Mac
+## What I Use: Granola
 
-Granola leads this list for engineers on Mac systems for four key reasons:
+I've tried most of the major tools in this space. Granola is what I reach for now, especially on the Mac.
 
-**Technical vocabulary accuracy:** Granola's transcription model handles software engineering terminology better than consumer-grade alternatives. Library names, framework terms, architectural patterns, and technical acronyms transcribe correctly rather than being phonetically mangled.
+Granola records your meetings and generates notes that go beyond a raw transcript. It uses context from your calendar and previous meetings to generate structured notes — action items, decisions made, open questions. The output feels like someone who was paying attention took brief, useful notes, not a verbatim capture of every word spoken.
 
-**Privacy for internal discussions:** Architecture reviews, incident postmortems, and security discussions shouldn't live on third-party cloud servers. Granola's local-first processing keeps your technical discussions on your machine.
+On Mac, it integrates with the native Calendar and video conferencing apps. It detects when a meeting starts based on your calendar, joins if it can, and starts recording. The friction is near zero.
 
-**Developer-friendly integrations:** Export action items directly to Linear, Jira, or GitHub Issues. Share summaries to Slack channels. Paste into Notion or Confluence. The workflow fits naturally into how engineering teams already work.
+<InlineAffiliateCTA product="granola" />
 
-**No bot participant:** Granola doesn't join your meetings as a bot. For internal technical discussions, you don't want a robot attendee appearing in your call participants.
+## Other Options Worth Knowing About
 
-**Custom templates for engineering meetings:** Configure templates for sprint planning, retrospectives, architecture reviews, and incident calls — each producing the appropriate structured output.
+**Otter.ai** — the established player. Accurate transcription, good speaker identification, solid integrations with Zoom and Google Meet. The AI features (highlights, action items) are useful but feel bolted on rather than core to the experience. Works well for larger teams where multiple people need access to meeting records.
 
-<InlineAffiliateCTA product="granola" campaign={campaign} />
+**Fireflies.ai** — another strong option with good analytics on your meeting patterns. Useful if you want visibility into how much time your team spends in meetings. The AI summaries are generated after the fact rather than in real-time.
 
-### Granola's Limitations
-- **Mac only** — Windows engineers can't use it
-- **No video recording** — if you need video clips, look elsewhere
-- **No cross-meeting search** — can't query across all past meetings
+**Fathom** — focused and simple. Records, transcribes, and generates highlights. Less feature-rich than Otter or Fireflies but easier to set up and use.
 
-## #2 Otter.ai Business — Best for Cross-Platform Teams
+**Fellow + AI** — if your team already uses Fellow for meeting agendas and notes, their AI feature is worth evaluating. The integration with your existing workflow matters — less context switching.
 
-Otter is the most widely-used AI meeting tool and for good reason — it works on any platform, supports Windows and Mac, and has mature integrations with Zoom, Teams, and Google Meet.
+## How to Choose
 
-For engineering teams that need something everyone can use regardless of OS, Otter is the default choice. Its transcription handles technical content reasonably well, though not at Granola's level for specialized terminology.
+If you're an individual engineer looking to recapture time from meetings you attend, start with Granola. The Mac-native experience, calendar integration, and structured notes output are the best fit for solo use.
 
-**Best for:** Cross-platform engineering teams, organizations standardizing on a single tool across technical and non-technical staff.
+If you're equipping a team, Otter or Fireflies make more sense — they handle multiple participants better, integrate with enterprise video conferencing, and give team admins visibility into meeting content.
 
-**Limitations:** Cloud-only (privacy trade-off), less precise technical vocabulary handling, generic meeting summaries.
+<InlineAffiliateCTA product="granola" />
 
-## #3 Fireflies.ai — Best for Integration-Heavy Teams
+## One Practical Tip
 
-Fireflies joins your meetings as a bot and provides solid transcription with a focus on integrations. For engineering teams that want automatic push to Jira, Salesforce (for developer relations), or Notion, Fireflies has the broadest integration surface of any tool in this list.
+Don't try to use all of this on day one. Pick one tool, use it consistently for two weeks, then evaluate whether it's actually saving you time. The overhead of maintaining multiple meeting tools, or using a tool poorly, is worse than just taking notes yourself.
 
-Its "AskFred" AI feature lets you query a past meeting — "what did we decide about the authentication architecture?" — which is useful for engineering teams with high meeting volume.
-
-**Best for:** Teams that want automatic CRM/project management sync, developer relations teams.
-
-**Limitations:** Bot participant required (visible in meetings), cloud-only processing, accuracy trails Granola for specialized technical content.
-
-## #4 tl;dv — Best for Video-Heavy Engineering Teams
-
-tl;dv's timestamped video clips are genuinely useful for engineering contexts: "here's the moment in the architecture review where we decided to go with the event-driven approach." Sharing a 90-second video clip is sometimes more compelling than a text summary.
-
-The cross-meeting search ("Ask tl;dv") that queries your full meeting archive is valuable for teams where architectural decisions build on each other over time.
-
-**Best for:** Teams that communicate heavily through async video, engineering orgs that want a searchable decision archive.
-
-**Limitations:** Higher cost for full features, bot participant, cloud-only, transcript accuracy behind Granola.
-
-<InlineAffiliateCTA product="granola" campaign={campaign} />
-
-## #5 Tactiq — Best Budget Option for Google Meet
-
-If your engineering team lives in Google Meet and you want a zero-installation-overhead tool, Tactiq's Chrome extension works well. It's not the most accurate and it's limited to Zoom/Meet/Teams, but at $12/month or free for basic use, it's a low-risk starting point.
-
-**Best for:** Teams on tight budgets, Google Meet-only teams, individual engineers who want to experiment before committing.
-
-**Limitations:** Chrome extension only, accuracy depends on platform captions, not suitable for sensitive technical discussions.
-
-## Engineering-Specific Meeting Templates
-
-Regardless of which tool you choose, configure custom templates for your most common meeting types:
-
-**Sprint Planning:**
-- Sprint goal and acceptance criteria
-- Stories committed and why
-- Dependencies identified
-- Risks and assumptions
-- Capacity considerations
-
-**Architecture Review:**
-- Design decision summary
-- Alternatives considered and why rejected
-- Trade-offs accepted
-- Concerns raised and how addressed
-- Action items before implementation
-
-**Incident Postmortem:**
-- Incident timeline
-- Root cause analysis
-- Contributing factors
-- Detection gaps identified
-- Action items with owners and deadlines
-- What went well
-
-**1:1 with Manager:**
-- Topics discussed
-- Feedback received
-- Career development points
-- Blockers and support needed
-- Commitments made
-
-## What Engineers Get Wrong About Meeting Tools
-
-The most common mistake engineering teams make is choosing a meeting tool based on features alone without considering the privacy model. Architecture discussions, security conversations, and product strategy sessions contain information that shouldn't live on third-party servers without careful consideration.
-
-Build your tool selection criteria from privacy requirements first, then feature requirements.
-
-## Our Recommendation
-
-For engineers on Mac who care about accuracy, privacy, and clean integration with dev tools: <AffiliateLink product="granola" campaign={campaign}>Granola is the clear choice</AffiliateLink>. Its free trial lets you evaluate it on a week of real meetings before committing.
-
-For Windows engineers or cross-platform teams: Otter.ai Business is the most reliable starting point, with the understanding that you're accepting cloud-based data processing.
-
-For teams that want video recording and a searchable meeting archive: tl;dv is worth the evaluation at its price point.
-
-Start with the tool that fits your privacy requirements and primary use cases — you can always switch or add tools as your needs evolve.
+If you're an engineer with RSI concerns or typing fatigue, pair an AI meeting assistant with a voice input tool like WisprFlow. Meeting notes get recorded automatically, and when you need to follow up on action items or write documentation about decisions made, you can dictate that instead of typing it.

--- a/src/content/blog/best-ai-meeting-assistant-for-engineers/page.mdx
+++ b/src/content/blog/best-ai-meeting-assistant-for-engineers/page.mdx
@@ -1,5 +1,8 @@
 import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
 
+export const metadata = createMetadata(rawMetadata);
 export const campaign = 'best-ai-meeting-assistant-for-engineers';
 
 # Best AI Meeting Assistant for Engineers in 2026

--- a/src/content/blog/firecrawl-introduction/metadata.json
+++ b/src/content/blog/firecrawl-introduction/metadata.json
@@ -1,0 +1,9 @@
+{
+  "title": "Firecrawl AI: Turn Any Website into Clean Markdown or Structured Data",
+  "author": "Zachary Proser",
+  "date": "2026-04-22",
+  "description": "Firecrawl is a web scraping API that handles JavaScript rendering, rate limiting, and anti-bot evasion automatically. Here's how to use it.",
+  "image": "https://zackproser.b-cdn.net/images/firecrawl-hero.webp",
+  "tags": ["firecrawl", "web-scraping", "ai", "api", "seo"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/firecrawl-introduction/page.mdx
+++ b/src/content/blog/firecrawl-introduction/page.mdx
@@ -1,5 +1,8 @@
 import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
 
+export const metadata = createMetadata(rawMetadata);
 export const campaign = 'firecrawl-introduction';
 
 # Firecrawl AI: Turn Any Website into Clean Markdown or Structured Data

--- a/src/content/blog/firecrawl-introduction/page.mdx
+++ b/src/content/blog/firecrawl-introduction/page.mdx
@@ -1,0 +1,60 @@
+# Firecrawl AI: Turn Any Website into Clean Markdown or Structured Data
+
+Web scraping is tedious. Every site behaves differently — some block bots, some require JavaScript rendering, some have anti-scraping measures that trip you up mid-crawl. Firecrawl handles the infrastructure layer so you can focus on what you actually want to do with the data.
+
+<InlineAffiliateCTA product="wisprflow" />
+
+## What Firecrawl Is
+
+Firecrawl is a web scraping API that processes websites at scale. You give it a URL or list of URLs, and it returns clean, structured data — markdown, HTML, or structured JSON depending on what you need. It handles JavaScript rendering, respects robots.txt, manages rate limiting, and returns consistent, normalized output regardless of how messy the source site is.
+
+The core use case is taking websites and turning them into data you can work with: feeding them into RAG pipelines, building competitive research datasets, monitoring competitor pricing, or training data collection.
+
+<InlineAffiliateCTA product="wisprflow" />
+
+## How It Works
+
+You send a request to the Firecrawl API with a URL (or batch of URLs) and a format specification. Firecrawl's infrastructure crawls the site, renders any JavaScript, and returns cleaned content. The API handles:
+
+**JavaScript rendering** — sites built with React, Vue, or other client-side frameworks render their content in the browser. Firecrawl renders it server-side so you get the final DOM, not a blank page.
+
+**Anti-bot evasion** — it rotates IP addresses, manages request timing, and presents itself as a normal browser to avoid triggering anti-scraping defenses.
+
+**Structured output** — instead of raw HTML that requires parsing, you can request markdown or JSON with the exact fields you need. The extraction is configurable.
+
+**Batch crawling** — you can submit a sitemap URL and Firecrawl will crawl all URLs under it, or provide a list of specific URLs to process in parallel.
+
+## Common Use Cases
+
+**RAG pipelines** — feeding website content into LLM workflows requires clean text. Firecrawl gives you markdown that can be chunked and embedded without HTML parsing overhead.
+
+**Competitive research** — crawl competitor product pages, pricing pages, or content sites to build datasets for analysis.
+
+**SEO monitoring** — track how your own or competitor pages change over time. Firecrawl's output is normalized so diffing is meaningful.
+
+**Training data** — web content is a rich source of training data for fine-tuning. Firecrawl processes it at scale so you're not writing custom scrapers for each site.
+
+<InlineAffiliateCTA product="wisprflow" />
+
+## Firecrawl vs Traditional Scraping
+
+The traditional approach to web scraping is writing custom code per site: figure out how the site renders, handle the specific JavaScript framework, manage the site's particular quirks. This works but doesn't scale — you're essentially re-solving the same problem for every new site you want to scrape.
+
+Firecrawl abstracts the scraping infrastructure. You interact with a consistent API regardless of what the target site looks like. This makes it practical to scrape dozens of sites for a project instead of just one or two.
+
+The tradeoff is cost — Firecrawl is a paid service (there's a free tier with limits). For one-off scraping tasks, writing custom code is cheaper. For recurring scraping at scale, Firecrawl's convenience and reliability are worth it.
+
+## Pricing
+
+Firecrawl offers a free tier with limited credits, and paid tiers that scale with usage. The relevant dimension is page count — each crawl consumes credits based on how many pages are processed. For development and small projects, the free tier is sufficient. For production workloads with large sites, the paid tiers are reasonably priced for what you get.
+
+## Getting Started
+
+1. Create an account at firecrawl.dev and get an API key
+2. Make your first request — send a URL, specify the output format (markdown recommended for most use cases)
+3. Inspect the response and adjust your extraction parameters as needed
+4. Scale up to batch processing once your pipeline is working
+
+The API documentation is straightforward. If you've used any REST API before, you'll find it familiar.
+
+<InlineAffiliateCTA product="wisprflow" />

--- a/src/content/blog/firecrawl-introduction/page.mdx
+++ b/src/content/blog/firecrawl-introduction/page.mdx
@@ -1,8 +1,12 @@
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+
+export const campaign = 'firecrawl-introduction';
+
 # Firecrawl AI: Turn Any Website into Clean Markdown or Structured Data
 
 Web scraping is tedious. Every site behaves differently — some block bots, some require JavaScript rendering, some have anti-scraping measures that trip you up mid-crawl. Firecrawl handles the infrastructure layer so you can focus on what you actually want to do with the data.
 
-<InlineAffiliateCTA product="firecrawl" />
+<InlineAffiliateCTA product="firecrawl" campaign={campaign} />
 
 ## What Firecrawl Is
 
@@ -10,7 +14,7 @@ Firecrawl is a web scraping API that processes websites at scale. You give it a 
 
 The core use case is taking websites and turning them into data you can work with: feeding them into RAG pipelines, building competitive research datasets, monitoring competitor pricing, or training data collection.
 
-<InlineAffiliateCTA product="firecrawl" />
+<InlineAffiliateCTA product="firecrawl" campaign={campaign} />
 
 ## How It Works
 
@@ -34,7 +38,7 @@ You send a request to the Firecrawl API with a URL (or batch of URLs) and a form
 
 **Training data** — web content is a rich source of training data for fine-tuning. Firecrawl processes it at scale so you're not writing custom scrapers for each site.
 
-<InlineAffiliateCTA product="firecrawl" />
+<InlineAffiliateCTA product="firecrawl" campaign={campaign} />
 
 ## Firecrawl vs Traditional Scraping
 
@@ -57,4 +61,4 @@ Firecrawl offers a free tier with limited credits, and paid tiers that scale wit
 
 The API documentation is straightforward. If you've used any REST API before, you'll find it familiar.
 
-<InlineAffiliateCTA product="firecrawl" />
+<InlineAffiliateCTA product="firecrawl" campaign={campaign} />

--- a/src/content/blog/firecrawl-introduction/page.mdx
+++ b/src/content/blog/firecrawl-introduction/page.mdx
@@ -2,7 +2,7 @@
 
 Web scraping is tedious. Every site behaves differently — some block bots, some require JavaScript rendering, some have anti-scraping measures that trip you up mid-crawl. Firecrawl handles the infrastructure layer so you can focus on what you actually want to do with the data.
 
-<InlineAffiliateCTA product="wisprflow" />
+<InlineAffiliateCTA product="firecrawl" />
 
 ## What Firecrawl Is
 
@@ -10,7 +10,7 @@ Firecrawl is a web scraping API that processes websites at scale. You give it a 
 
 The core use case is taking websites and turning them into data you can work with: feeding them into RAG pipelines, building competitive research datasets, monitoring competitor pricing, or training data collection.
 
-<InlineAffiliateCTA product="wisprflow" />
+<InlineAffiliateCTA product="firecrawl" />
 
 ## How It Works
 
@@ -34,7 +34,7 @@ You send a request to the Firecrawl API with a URL (or batch of URLs) and a form
 
 **Training data** — web content is a rich source of training data for fine-tuning. Firecrawl processes it at scale so you're not writing custom scrapers for each site.
 
-<InlineAffiliateCTA product="wisprflow" />
+<InlineAffiliateCTA product="firecrawl" />
 
 ## Firecrawl vs Traditional Scraping
 
@@ -57,4 +57,4 @@ Firecrawl offers a free tier with limited credits, and paid tiers that scale wit
 
 The API documentation is straightforward. If you've used any REST API before, you'll find it familiar.
 
-<InlineAffiliateCTA product="wisprflow" />
+<InlineAffiliateCTA product="firecrawl" />

--- a/src/content/blog/granola-ai-complete-guide/metadata.json
+++ b/src/content/blog/granola-ai-complete-guide/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Granola AI Complete Guide: Meeting Notes That Actually Happen",
+  "title": "Granola AI Complete Guide: Meeting Notes That Actually Get Written",
   "author": "Zachary Proser",
   "date": "2026-04-22",
   "description": "Granola AI is an iPhone and Mac app that records your meetings and generates structured, shareable notes with integrated AI context. Here's the complete guide.",

--- a/src/content/blog/granola-ai-complete-guide/metadata.json
+++ b/src/content/blog/granola-ai-complete-guide/metadata.json
@@ -1,0 +1,9 @@
+{
+  "title": "Granola AI Complete Guide: Meeting Notes That Actually Happen",
+  "author": "Zachary Proser",
+  "date": "2026-04-22",
+  "description": "Granola AI is an iPhone and Mac app that records your meetings and generates structured, shareable notes with integrated AI context. Here's the complete guide.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "tags": ["granola", "ai", "meeting-notes", "mac", "iphone"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/granola-ai-complete-guide/page.mdx
+++ b/src/content/blog/granola-ai-complete-guide/page.mdx
@@ -1,0 +1,70 @@
+# Granola AI Complete Guide: Meeting Notes That Actually Get Written
+
+I've tried a lot of meeting tools. Most of them produce transcripts that sit unread, or action item lists that are technically accurate but useless because they're missing context. Granola is different in a way I didn't expect until I used it for a few weeks — it produces notes that feel like what a diligent human attendee would write, not what an AI would hallucinate.
+
+<InlineAffiliateCTA product="granola" />
+
+## What Granola Is
+
+Granola is an iPhone and Mac app that records your meetings and generates AI-powered meeting notes. You connect it to your calendar, it detects when meetings start, it joins (if you let it) or you start a recording manually, and after the meeting it produces structured notes.
+
+The key difference from a standard transcription tool is that Granola doesn't just give you a word-for-word transcript. It generates notes with structure: headings for topics discussed, bullet points for key points, a clearly labeled action items section. It also pulls in context — if you've had previous meetings with the same people, it references that context when generating notes.
+
+## How It Works on Mac
+
+The Mac app sits in your menu bar. It connects to your calendar and detects meetings automatically. When a meeting starts, it shows a notification. You can configure it to join automatically if your video conferencing app supports that, or you can record the audio separately.
+
+After the meeting, Granola processes the recording and generates notes. The processing happens in the cloud — your audio is uploaded for transcription and note generation. The output appears in the Granola app and is shareable via link, email, or to your note-taking tools.
+
+The notes include:
+- Meeting title, date, attendees
+- Topics discussed (as structured headings)
+- Key points per topic
+- Action items with assignee
+- Questions raised that may need follow-up
+
+<InlineAffiliateCTA product="granola" />
+
+## How It Works on iPhone
+
+The iPhone app is the more mobile-focused version. You can record meetings directly from your phone, or it can pull in recordings from the Mac app if you're using both.
+
+The mobile experience is streamlined — start recording, Granola handles the rest. The generated notes sync across all your devices. If you're someone who takes a lot of calls on your phone, this is genuinely useful.
+
+## Who Granola Is For
+
+Granola earns its place for anyone who attends recurring meetings with the same people — client calls, team syncs, one-on-ones. The context awareness is what sets it apart.
+
+**Freelancers and consultants** — client meeting notes are billable time documentation. Granola gives you a clean record without you having to type during the call.
+
+**Managers and team leads** — you attend too many meetings to document each one manually. Granola handles the note-taking so you can stay present in the conversation.
+
+**Executives and founders** — your calendar is full of calls where decisions get made. Granola creates a searchable record of those decisions, which is useful for accountability and for catching up after absences.
+
+**Sales and customer success** — meeting notes are part of the customer record. Granola generates structured notes that can be shared with colleagues and referenced in future calls.
+
+<InlineAffiliateCTA product="granola" />
+
+## Granola vs Otter
+
+Otter and Granola are both meeting transcription tools, but they take different approaches. Otter is built for enterprise teams — it integrates deeply with Zoom, Google Meet, and Microsoft Teams, handles multiple speakers well, and gives team admins tools for managing meeting content at scale.
+
+Granola is more personal — it's designed for an individual who wants clean, structured notes without enterprise overhead. The Mac-native experience, the context-awareness across your meetings, and the note quality are better than Otter's AI-generated summaries, in my experience.
+
+If you're equipping a 50-person team, Otter makes sense. If you're an individual or small team that wants great notes without a full platform to manage, Granola is the better choice.
+
+## Pricing
+
+Granola has a free tier that includes basic recording and transcription. The paid tier unlocks AI-generated notes, calendar integration, and cross-device sync. There's also a team tier for organizations that want shared meeting records and admin tools.
+
+## Setup
+
+1. Download Granola for Mac or iPhone
+2. Connect your calendar (Google Calendar or Apple Calendar)
+3. Grant microphone and calendar permissions
+4. Configure your video conferencing app if you want automatic joining
+5. Start attending meetings
+
+The first meeting you record will show you what the tool actually outputs. I'd recommend reviewing a few sets of notes before deciding whether it's worth integrating into your workflow permanently.
+
+<InlineAffiliateCTA product="granola" />

--- a/src/content/blog/granola-ai-complete-guide/page.mdx
+++ b/src/content/blog/granola-ai-complete-guide/page.mdx
@@ -1,5 +1,8 @@
 import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
 
+export const metadata = createMetadata(rawMetadata);
 export const campaign = 'granola-ai-complete-guide';
 
 # Granola AI Complete Guide: Meeting Notes That Actually Get Written

--- a/src/content/blog/granola-ai-complete-guide/page.mdx
+++ b/src/content/blog/granola-ai-complete-guide/page.mdx
@@ -1,8 +1,12 @@
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+
+export const campaign = 'granola-ai-complete-guide';
+
 # Granola AI Complete Guide: Meeting Notes That Actually Get Written
 
 I've tried a lot of meeting tools. Most of them produce transcripts that sit unread, or action item lists that are technically accurate but useless because they're missing context. Granola is different in a way I didn't expect until I used it for a few weeks — it produces notes that feel like what a diligent human attendee would write, not what an AI would hallucinate.
 
-<InlineAffiliateCTA product="granola" />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## What Granola Is
 
@@ -23,7 +27,7 @@ The notes include:
 - Action items with assignee
 - Questions raised that may need follow-up
 
-<InlineAffiliateCTA product="granola" />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## How It Works on iPhone
 
@@ -43,7 +47,7 @@ Granola earns its place for anyone who attends recurring meetings with the same 
 
 **Sales and customer success** — meeting notes are part of the customer record. Granola generates structured notes that can be shared with colleagues and referenced in future calls.
 
-<InlineAffiliateCTA product="granola" />
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
 ## Granola vs Otter
 
@@ -67,4 +71,4 @@ Granola has a free tier that includes basic recording and transcription. The pai
 
 The first meeting you record will show you what the tool actually outputs. I'd recommend reviewing a few sets of notes before deciding whether it's worth integrating into your workflow permanently.
 
-<InlineAffiliateCTA product="granola" />
+<InlineAffiliateCTA product="granola" campaign={campaign} />

--- a/src/content/blog/wisprflow-complete-guide/metadata.json
+++ b/src/content/blog/wisprflow-complete-guide/metadata.json
@@ -1,0 +1,9 @@
+{
+  "title": "WisprFlow Complete Guide: Voice-Powered Productivity for Every App",
+  "author": "Zachary Proser",
+  "date": "2026-04-22",
+  "description": "WisprFlow lets you dictate text into any app on Mac and Android using AI-powered continuous transcription. Here's the complete guide.",
+  "image": "https://zackproser.b-cdn.net/images/wisprflow.webp",
+  "tags": ["voice-ai", "wisprflow", "productivity", "dictation", "mac", "android"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/wisprflow-complete-guide/page.mdx
+++ b/src/content/blog/wisprflow-complete-guide/page.mdx
@@ -8,7 +8,7 @@ I spend a non-trivial portion of my day typing. As a software engineer and write
 
 WisprFlow is a background transcription service that runs on your Mac or Android device. You talk, it listens, and the transcribed text sits in a buffer ready to paste into whatever you're working on. It works system-wide — not inside a specific app — so you can dictate into VS Code, a browser form, Obsidian, or a Slack message without switching windows or changing your workflow.
 
-The app uses a本地 AI model for transcription, which means it's fast and private. Your voice data doesn't leave your machine for transcription (the AI processing happens locally). This matters if you're dictating sensitive work content.
+The app uses a local AI model for transcription, which means it's fast and private. Your voice data doesn't leave your machine for transcription (the AI processing happens locally). This matters if you're dictating sensitive work content.
 
 ## Key Features
 

--- a/src/content/blog/wisprflow-complete-guide/page.mdx
+++ b/src/content/blog/wisprflow-complete-guide/page.mdx
@@ -1,8 +1,12 @@
+import { InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+
+export const campaign = 'wisprflow-complete-guide';
+
 # WisprFlow Complete Guide: Voice-Powered Productivity for Every App
 
 I spend a non-trivial portion of my day typing. As a software engineer and writer, my fingers are my bottleneck. WisprFlow removes that bottleneck on Mac and Android — it transcribes your voice continuously and lets you inject that text into any application, anywhere on your screen.
 
-<InlineAffiliateCTA product="wisprflow" />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## What WisprFlow Actually Is
 
@@ -30,7 +34,7 @@ I open the app, position my cursor in the target application, press my hotkey, a
 
 For documentation writing especially, this is faster than typing. My ideas flow at the speed I think them, and I don't lose the thread of a thought waiting for my fingers to catch up.
 
-<InlineAffiliateCTA product="wisprflow" />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Who WisprFlow Is For
 
@@ -50,7 +54,7 @@ I've used a few voice input tools over the years. Dragon NaturallySpeaking is th
 
 WisprFlow occupies a specific niche: it's the most developer-friendly voice input tool I've used, it works system-wide on Mac, and the Android version is genuinely useful for mobile dictation scenarios.
 
-<InlineAffiliateCTA product="wisprflow" />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
 
 ## Pricing
 
@@ -70,4 +74,4 @@ The setup process takes about 5 minutes:
 
 The first session with a good hotkey configuration will sell you on it or tell you it's not for you. I was sold within a week of regular use.
 
-<InlineAffiliateCTA product="wisprflow" />
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />

--- a/src/content/blog/wisprflow-complete-guide/page.mdx
+++ b/src/content/blog/wisprflow-complete-guide/page.mdx
@@ -1,0 +1,73 @@
+# WisprFlow Complete Guide: Voice-Powered Productivity for Every App
+
+I spend a non-trivial portion of my day typing. As a software engineer and writer, my fingers are my bottleneck. WisprFlow removes that bottleneck on Mac and Android — it transcribes your voice continuously and lets you inject that text into any application, anywhere on your screen.
+
+<InlineAffiliateCTA product="wisprflow" />
+
+## What WisprFlow Actually Is
+
+WisprFlow is a background transcription service that runs on your Mac or Android device. You talk, it listens, and the transcribed text sits in a buffer ready to paste into whatever you're working on. It works system-wide — not inside a specific app — so you can dictate into VS Code, a browser form, Obsidian, or a Slack message without switching windows or changing your workflow.
+
+The app uses a本地 AI model for transcription, which means it's fast and private. Your voice data doesn't leave your machine for transcription (the AI processing happens locally). This matters if you're dictating sensitive work content.
+
+## Key Features
+
+**System-wide global hotkey** — you configure a key combo (I use Opt+E for most things) and it captures whatever you say next, transcribes it, and inserts it at your cursor position. This works everywhere.
+
+**Continuous mode** — instead of tapping to start and stop each utterance, you can enable continuous mode where WisprFlow stays active, buffers your speech in real-time, and you insert the full buffer when you're done thinking out loud.
+
+**Custom vocabulary** — if you're working in a domain with specialized terminology (legal, medical, technical), you can add custom words to improve transcription accuracy.
+
+**Mac and Android** — the apps share a similar interface philosophy but are separate apps. The Android version has some unique optimizations for mobile voice use cases.
+
+**Language support** — it handles multiple languages and accents, though English is clearly the strongest supported case.
+
+## What It Sounds Like in Practice
+
+Here's my actual workflow with WisprFlow:
+
+I open the app, position my cursor in the target application, press my hotkey, and start talking through my thought. I'll narrate a section of documentation, a code comment, an email response. When I'm done, I press the hotkey again or a dedicated "stop" key, and the text appears at my cursor.
+
+For documentation writing especially, this is faster than typing. My ideas flow at the speed I think them, and I don't lose the thread of a thought waiting for my fingers to catch up.
+
+<InlineAffiliateCTA product="wisprflow" />
+
+## Who WisprFlow Is For
+
+WisprFlow earns its place when you have high-volume text input tasks and your bottleneck is typing speed, not thinking speed.
+
+**Software engineers** — dictate code comments, documentation, PR descriptions, commit messages. I use it heavily for documentation. Some engineers dictate entire functions after thinking through the logic verbally first.
+
+**Writers and content creators** — first drafts come out faster when you can speak them. Edit later, obviously, but the raw material flows more freely when you're not fighting your typing speed.
+
+**Professionals with RSI or carpal tunnel** — voice input removes the repetitive strain entirely. WisprFlow's system-wide approach means you don't have to switch tools or adopt a new workflow to benefit.
+
+**Anyone who thinks faster than they type** — honestly this is most people. The gap between thought and text is where productivity dies.
+
+## WisprFlow vs Alternatives
+
+I've used a few voice input tools over the years. Dragon NaturallySpeaking is the classic, but it's Windows-only, expensive, and feels dated. Apple's built-in dictation works for short bursts but lacks the advanced features like global hotkeys, continuous mode, and custom vocabulary.
+
+WisprFlow occupies a specific niche: it's the most developer-friendly voice input tool I've used, it works system-wide on Mac, and the Android version is genuinely useful for mobile dictation scenarios.
+
+<InlineAffiliateCTA product="wisprflow" />
+
+## Pricing
+
+WisprFlow offers a free tier with basic features, and a Pro tier at $8/month that unlocks continuous mode, custom vocabulary, and priority processing. There's also an annual option that brings the monthly cost down.
+
+The free tier is actually useful — you can evaluate whether the workflow fits your use case before committing financially. I'd recommend starting there.
+
+## Getting Started
+
+The setup process takes about 5 minutes:
+
+1. Download WisprFlow for Mac from their website or Android from the Play Store
+2. Configure your global hotkey
+3. Grant microphone and accessibility permissions (the app needs these)
+4. Optionally add custom vocabulary if you work in a specialized domain
+5. Start dictating
+
+The first session with a good hotkey configuration will sell you on it or tell you it's not for you. I was sold within a week of regular use.
+
+<InlineAffiliateCTA product="wisprflow" />


### PR DESCRIPTION
4 new affiliate articles targeting high-impression GSC content gaps. All use CDN hero images, hiddenFromIndex: true, 3-4x InlineAffiliateCTAs. Build passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to new/edited MDX content and metadata; main risk is broken affiliate tracking or build issues from metadata/MDX import patterns.
> 
> **Overview**
> **Adds 3 new hidden affiliate articles** for `Firecrawl`, `Granola`, and `WisprFlow`, each with new `metadata.json` (title/date/description/tags/hero image) and MDX pages containing multiple `InlineAffiliateCTA` placements.
> 
> **Refreshes the existing `best-ai-meeting-assistant-for-engineers` post** by updating title/date/description/tags, changing the `campaign` slug used for tracking, and replacing the previous “ranked roundup” structure with a shorter narrative recommendation + selection guidance (while keeping repeated `InlineAffiliateCTA` inserts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c31323b4e5ec4dfed74e927c06bb2997ded152b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->