### PR TITLE
affiliate: 5 WisprFlow vertical articles (academic researchers, mobile devs, life coaches, chiropractors, EMTs)

### DIFF
--- a/src/content/blog/granola-for-compliance-officers-2026/metadata.json
+++ b/src/content/blog/granola-for-compliance-officers-2026/metadata.json
@@ -1,0 +1,10 @@
+{
+  "title": "Granola for Compliance Officers: Audit-Ready Meeting Documentation",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Compliance officers need accurate, searchable records of every policy discussion, audit finding, and remediation meeting. Granola provides the documentation trail that auditors expect.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "imageAlt": "Granola AI meeting notes showing a compliance officer's regulatory review meeting with structured action items and decisions captured",
+  "tags": ["compliance", "regulatory", "risk", "meetings", "productivity", "granola"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/granola-for-compliance-officers-2026/page.mdx
+++ b/src/content/blog/granola-for-compliance-officers-2026/page.mdx
@@ -1,0 +1,77 @@
+import { AffiliateLink, InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+
+export const campaign = 'granola-for-compliance-officers-2026'
+
+# Granola for Compliance Officers: Audit-Ready Meeting Documentation
+
+Compliance work runs on documentation. Policies need evidence of review. Audit findings need remediation plans with owners and deadlines. Training sessions need attendance records and completion logs. And when a regulator asks what happened in a particular meeting three months ago, "I think we discussed it" is not an acceptable answer.
+
+Compliance officers spend a significant portion of their week in meetings — audit prep sessions, risk committee reviews, policy reviews with legal, vendor risk assessments, regulatory response discussions. The documentation burden from those meetings falls disproportionately on the compliance team, and the standard approaches (whoever takes notes, whatever format they use) produce inconsistent results under exactly the conditions where consistency matters most.
+
+Granola generates structured, accurate meeting summaries automatically. Compliance teams get better documentation without adding to anyone's workload.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## What compliance meetings require from documentation
+
+A compliance meeting record has to do more than remind attendees what was discussed. It has to be legible to someone who wasn't in the room — including an examiner or auditor who is reading it twelve months later looking for evidence that a control was properly reviewed.
+
+That means capturing:
+
+- What was discussed and what context was provided
+- What decisions were made and who made them
+- What issues or concerns were raised (including ones that were discussed and dismissed)
+- What action items were assigned, to whom, and by when
+- Whether there was any disagreement or dissent
+
+This level of detail requires either a dedicated note-taker whose only job is documentation, or AI assistance. Granola provides the latter.
+
+## Specific use cases
+
+**Audit preparation sessions.** When you're preparing for an internal audit or regulatory examination, the prep meetings themselves generate important records. What scope was agreed on, what evidence was identified, what concerns were flagged — all of that belongs in the file. Granola captures it without requiring a separate documentation step.
+
+**Risk committee and board committee meetings.** Risk and compliance committee meetings often have formal documentation requirements. Board-level meeting minutes are legal documents. Granola's AI summaries aren't a replacement for formal board minutes, but they provide an accurate record of the discussion that supports whoever is drafting the formal documentation.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+**Vendor risk assessments and due diligence calls.** Third-party risk management requires documentation of what vendors said about their controls, their certifications, and their practices. Granola gives you an accurate record of the vendor call to include in the due diligence file alongside questionnaire responses and documentation provided.
+
+**Policy review meetings.** When you're walking a policy through legal review or business unit approval, those conversations often include substantive edits, concerns, and agreements that don't make it into the formal document track. Granola captures the discussion so you have a record of what was considered, not just what was adopted.
+
+**Incident response and remediation meetings.** When something goes wrong — a data incident, a control failure, a regulatory finding — the remediation process generates meetings. Who was notified, when, what was discussed, what remediation steps were committed to, who owns them. This is exactly the kind of documentation that gets scrutinized in enforcement actions and post-incident reviews.
+
+**Training delivery sessions.** Live compliance training sessions have attendance and content documentation requirements. Granola captures what was actually covered in training, which supplements the attendance roster.
+
+## The consistency problem at scale
+
+Large compliance programs involve many people running many meetings across different business units and geographies. Notes taken by different people in different formats create inconsistent records that are hard to search, consolidate, or present coherently to an auditor.
+
+Granola's AI summaries produce consistent structured output regardless of who ran the meeting. Action items, decisions, and discussion points get captured in the same format every time. For programs that need to demonstrate process consistency to regulators, this matters.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Working alongside formal minutes
+
+Granola summaries and formal meeting minutes serve different purposes. Board and committee minutes are legal documents prepared by a secretary or counsel, reviewed and approved according to governance procedures. Granola summaries are working records for the compliance team.
+
+The two can coexist usefully. Granola summaries capture the substantive content of the discussion in real time. Formal minutes, prepared from the transcript and summary, become more accurate and easier to draft. The underlying Granola record provides contemporaneous documentation of the meeting content that can be retained in the compliance file.
+
+## Privacy and security
+
+Granola runs locally on your Mac. Audio is processed on-device, not streamed through external servers. For compliance teams in regulated industries with data residency and data handling requirements, the local processing model is an important characteristic.
+
+Your organization's policies on meeting recording and AI tools apply. As with any AI tool in a compliance context, get appropriate approvals and document the tool's use as part of your compliance program itself — a compliance officer whose meeting notes are AI-assisted is not exempt from the documentation requirements that apply to everyone else.
+
+## Getting started
+
+The free plan gives you enough meetings to evaluate Granola's output quality before committing. For compliance officers, the clearest test is running it on a few internal meetings — a policy review, a vendor call, a risk discussion — and comparing the AI summary to whatever notes you would have taken. If the summary captures what you'd have written and adds structure you'd have had to create manually, it's worth keeping.
+
+---
+
+Compliance programs are only as good as their documentation. Granola helps compliance teams produce better records from every meeting, without making documentation someone's second job.
+
+<AffiliateLink product="granola" campaign={campaign}>Try Granola free</AffiliateLink>

--- a/src/content/blog/granola-for-data-scientists-2026/metadata.json
+++ b/src/content/blog/granola-for-data-scientists-2026/metadata.json
@@ -1,0 +1,10 @@
+{
+  "title": "Granola for Data Scientists: Meeting Notes That Keep Up With Technical Discussions",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Data scientists lose hours every week to poorly documented meetings. Granola captures model reviews, experiment postmortems, and stakeholder alignment calls with technical precision.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "imageAlt": "Granola AI meeting notes interface showing a data science model review transcript with technical terms accurately captured",
+  "tags": ["ai", "data-science", "machine-learning", "meetings", "productivity", "granola"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/granola-for-data-scientists-2026/page.mdx
+++ b/src/content/blog/granola-for-data-scientists-2026/page.mdx
@@ -1,0 +1,67 @@
+import { AffiliateLink, InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+
+export const campaign = 'granola-for-data-scientists-2026'
+
+# Granola for Data Scientists: Meeting Notes That Keep Up With Technical Discussions
+
+The worst part of a model review isn't presenting results. It's realizing two weeks later that you can't remember why the team decided to drop a feature, or what the business stakeholder actually said about the acceptable false positive rate.
+
+Data science work is intensely collaborative. You're in meetings constantly — requirements sessions with product, model review standups with engineering, experiment postmortems, data governance reviews, vendor evaluations. And every one of those conversations generates information that needs to be captured accurately or it disappears.
+
+Granola records, transcribes, and summarizes your meetings with AI, so you can actually pay attention to the conversation instead of racing to capture everything in a notebook.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## The documentation problem in data science teams
+
+Data scientists deal with a specific flavor of meeting documentation pain. The technical vocabulary is dense — AUC-ROC, feature drift, p-values, embedding dimensions, hyperparameter schedules — and most generic transcription tools butcher it. You end up with transcripts full of phonetic guesses that are more confusing than helpful.
+
+Beyond vocabulary, data science discussions have a particular structure. The important content is often buried in the middle of a discussion: "Yeah, we could do that, but actually the reason we're not is..." followed by a nuanced explanation of a constraint that will determine everything that happens next. If you're writing notes and miss that sentence, you lose the context that makes all the downstream decisions make sense.
+
+Standard meeting notes don't capture the reasoning chain. They capture conclusions. Granola's summaries pull out both — what was decided and, when it comes up in discussion, why.
+
+## Where Granola fits in a data science workflow
+
+**Experiment design reviews.** When you're planning an experiment, the decisions you make about holdout sets, evaluation metrics, and success criteria need to be documented. These discussions can go in several directions, and having a searchable record of the final design and the alternatives considered is genuinely useful when you're writing up results six weeks later.
+
+**Stakeholder requirements meetings.** Translating business requirements into modeling objectives is hard enough without also trying to take accurate notes. Granola handles the documentation while you focus on asking good questions and probing the actual constraints. The summary afterward tells you what success criteria the stakeholder committed to — not what you thought you heard.
+
+**Model review sessions.** Code reviews have pull requests. Model reviews often have nothing. Granola gives model reviews a structured record: what metrics were presented, what concerns were raised, what follow-up was requested, and who owns it.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+**Cross-functional syncs with engineering.** When data scientists and engineers discuss deployment architecture, feature pipeline changes, or serving infrastructure, the technical specifics matter. Granola captures the full conversation so you can refer back to what was actually agreed about latency requirements or batch versus real-time serving.
+
+**Vendor and tool evaluations.** If you're evaluating ML platforms, data providers, or annotation services, the discussions get detailed fast. Granola's notes give you something to share with your team that goes beyond "here's what I remember from the demo."
+
+## Technical vocabulary handling
+
+One of the reasons data scientists tend to distrust transcription tools is the vocabulary problem. Granola handles technical language well — it's trained to recognize ML terminology, statistical concepts, and the kind of compound phrases that appear in data science discussions.
+
+It won't be perfect on proprietary internal terminology (your company's internal model names, codenames for products, team-specific jargon). But for standard ML vocabulary, it performs significantly better than generic transcription. And you can always add notes inline to the Granola summary before sending it to teammates.
+
+## The async use case
+
+Data science teams are often distributed. Granola's summaries solve the async problem: teammates who couldn't make a meeting get a clear record of what was discussed and decided, not just "notes from the call" that require context they don't have.
+
+The AI summary isn't a replacement for attending the meeting when presence matters. But for recurring syncs, status updates, and informational sessions, Granola gives absentees something genuinely useful.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Setup
+
+Granola works on Mac. It runs in the background during meetings and picks up audio from your system and microphone. There's no bot that joins your Zoom or Google Meet — Granola is local software that processes what's happening on your computer.
+
+The free plan covers a set number of meetings per month. For most data scientists who want to try it on their highest-value meetings, the trial is plenty of runway to evaluate whether it's worth adding to your workflow.
+
+If your team runs a lot of high-stakes technical meetings — model reviews, architecture discussions, stakeholder alignment — the paid plan pays for itself quickly in reduced meeting overhead and better documentation.
+
+---
+
+Data science is a discipline where the difference between a good outcome and a wasted quarter often comes down to whether the right information was captured and shared. Granola is one of the cheapest ways to close that gap.
+
+<AffiliateLink product="granola" campaign={campaign}>Try Granola free</AffiliateLink>

--- a/src/content/blog/granola-for-immigration-lawyers-2026/metadata.json
+++ b/src/content/blog/granola-for-immigration-lawyers-2026/metadata.json
@@ -1,0 +1,10 @@
+{
+  "title": "Granola for Immigration Lawyers: Client Consultations Without Missing Critical Details",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Immigration lawyers handle complex client situations where missing a date or misremembering a fact can derail a case. Granola keeps a precise record of every consultation.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "imageAlt": "Granola AI meeting notes for an immigration attorney conducting a client intake consultation with detailed summary",
+  "tags": ["immigration-law", "legal", "meetings", "productivity", "granola"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/granola-for-immigration-lawyers-2026/page.mdx
+++ b/src/content/blog/granola-for-immigration-lawyers-2026/page.mdx
@@ -1,0 +1,69 @@
+import { AffiliateLink, InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+
+export const campaign = 'granola-for-immigration-lawyers-2026'
+
+# Granola for Immigration Lawyers: Client Consultations Without Missing Critical Details
+
+Immigration law is a discipline where the details are the case. An entry date misremembered by six days. A prior visa category the client mentioned in passing but didn't think was important. A gap in employment history the client glossed over. Any of these can derail an application that looked solid on paper.
+
+Immigration lawyers run a lot of consultations, especially in high-volume practices handling employment visas, asylum, DACA renewals, and family petitions. Each client brings a complex, often emotionally charged narrative with dates, relationships, employment history, and immigration history that has to be captured accurately to do the legal work correctly.
+
+Granola records and summarizes your client meetings so you capture everything that matters, even when the conversation goes in unexpected directions.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## What immigration consultations require
+
+An initial immigration consultation covers a lot of ground in a short time. You're gathering entry history, visa history, current status, employment history, family relationships, criminal history, and the client's current situation and goals — while also assessing what pathways exist and what risks apply.
+
+Clients often don't know which details are legally significant. They might not mention a brief unauthorized entry because they don't realize it matters. They might not connect a prior visa denial to the petition you're planning. Part of your job is asking the right questions. But you can't ask the right follow-up questions if you're writing notes and miss what the client just said.
+
+Granola handles the transcription. You stay in the conversation.
+
+## Specific use cases
+
+**Initial intake consultations.** The first meeting with a client determines the entire shape of the representation. Granola gives you a complete record of what the client said — every date they mentioned, every visa they referenced, every employer they listed — without requiring you to interrupt the conversation to write it down.
+
+**Case strategy discussions.** When you're explaining the options to a client and walking through the risks and requirements of each path, what you said and what the client understood and agreed to is important documentation. Granola creates a record of that conversation.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+**Document review sessions.** When you're going through a client's documents with them — reviewing prior applications, old passports, employment records — those conversations surface details that belong in your case notes. The client will explain discrepancies, provide context for gaps, and share information that only emerges when they're looking at the documents. Granola captures all of it.
+
+**Interview preparation sessions.** Preparing a client for a USCIS interview or an immigration court hearing involves detailed coaching. What to say, what not to say, how to answer specific likely questions. Having a record of what you covered and what the client said in preparation is useful if the interview goes unexpectedly.
+
+**Coordination with corporate clients.** Employment-based immigration work often means coordinating with HR departments and in-house counsel. Those conversations involve data about multiple employees, timeline requirements, and policy constraints. Granola's summaries give you a clean record of what was agreed without requiring a follow-up email chain to confirm who said what.
+
+## The language factor
+
+Immigration clients often have limited English proficiency, and consultations may involve interpreters. If you're working with an interpreter on a video call, Granola will capture the full conversation — both the original language portions and the English interpretation. The transcript may require more careful review than a monolingual meeting, but you'll have a record of the complete exchange rather than just your notes on what the interpreter conveyed.
+
+## Privacy and confidentiality
+
+Immigration clients are often in sensitive situations — undocumented status, asylum seekers with credible fear claims, clients with criminal history that affects their immigration case. Confidentiality is critical.
+
+Granola processes audio locally on your Mac. Recordings don't stream through external servers in a way that would compromise attorney-client privilege. Review your local bar rules on recording client communications and get appropriate consent, as you would for any recording.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Volume practices
+
+Immigration practices that handle high case volume — H-1B season, DACA renewals, family petition mills — run a lot of consultations. The documentation burden at scale is significant. Consistent Granola summaries across all consultations means every case file has the same quality of intake documentation, regardless of who ran the meeting.
+
+For solo practitioners and small firms especially, this kind of systematic documentation can make a significant difference in practice quality without requiring more time.
+
+## Getting started
+
+Granola works on Mac. It runs in the background, picks up your meeting audio, and generates a structured summary when the meeting ends. You review, edit if needed, and save it to the client file.
+
+The free plan gives you enough meetings to evaluate whether it fits your practice before committing. For immigration attorneys doing regular client consultations, it's worth testing on a few lower-stakes intake calls to see how it handles the specific vocabulary and conversation patterns of immigration work.
+
+---
+
+Immigration law is demanding work. Getting the details right from the first conversation is the foundation of a good case. Granola makes it easier to do that without sacrificing your attention to the client in front of you.
+
+<AffiliateLink product="granola" campaign={campaign}>Try Granola free</AffiliateLink>

--- a/src/content/blog/granola-for-patent-attorneys-2026/metadata.json
+++ b/src/content/blog/granola-for-patent-attorneys-2026/metadata.json
@@ -1,0 +1,10 @@
+{
+  "title": "Granola for Patent Attorneys: Accurate Notes for Technical Inventor Disclosures",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Patent attorneys sit through dense inventor disclosure meetings filled with technical specifics. Granola captures the details accurately so attorneys can focus on legal strategy instead of furious note-taking.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "imageAlt": "Granola AI meeting notes interface showing a patent attorney's inventor disclosure meeting with technical terminology captured accurately",
+  "tags": ["patent-law", "legal", "ip", "meetings", "productivity", "granola"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/granola-for-patent-attorneys-2026/page.mdx
+++ b/src/content/blog/granola-for-patent-attorneys-2026/page.mdx
@@ -1,0 +1,71 @@
+import { AffiliateLink, InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+
+export const campaign = 'granola-for-patent-attorneys-2026'
+
+# Granola for Patent Attorneys: Accurate Notes for Technical Inventor Disclosures
+
+Inventor disclosure meetings are unlike most legal consultations. You're sitting across from an engineer or scientist who has spent months or years developing something, and you need to understand it well enough to draft claims that actually protect what's novel — in a single meeting, with someone who may have limited experience explaining their work to a non-technical audience.
+
+The technical details matter enormously. A missed claim element, a misremembered technical constraint, or an inaccurate description of the prior art the inventor mentioned can mean the difference between a patent that holds up and one that gets challenged successfully.
+
+Most patent attorneys take detailed notes during these meetings. Granola means you can take fewer notes and pay more attention to the inventor.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## The inventor disclosure problem
+
+Engineers are not natural communicators of patent concepts. They think about their inventions in implementation terms, not claim terms. During a disclosure meeting, a significant part of your job is asking the right questions to draw out what's actually novel, what alternatives were considered, what problem the invention solves that existing approaches don't.
+
+That's hard to do while simultaneously writing detailed notes. Something always suffers — either you're writing and miss the thread of what the inventor is saying, or you're engaged and your notes are incomplete.
+
+Granola handles the transcription so you can stay in the conversation. You can probe the technical details, ask follow-up questions, and make sure you actually understand the invention — knowing that the full conversation is being captured.
+
+## Where Granola fits in patent practice
+
+**Initial inventor disclosure sessions.** The foundational meeting where the inventor explains the technology, the problem it solves, and what makes it different. The accuracy of your notes from this meeting determines the quality of the application you file.
+
+**Claim development meetings.** As you work through claim scope with the inventor, you're iterating on language and testing the boundaries of what the invention covers. These iterative conversations benefit from a record — both so you can reconstruct the logic later and so you can send the inventor a summary to confirm alignment before you draft.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+**Prior art review discussions.** When you walk an inventor through relevant prior art, their reactions and explanations are legally significant. Their explanation of why their invention is different from a particular reference belongs in your file. Granola captures those explanations verbatim.
+
+**Client counseling on prosecution strategy.** When you're advising a client on office action responses, continuation strategy, or whether to appeal, those conversations are substantive. Having a record means you can document what advice you gave and what the client decided — useful for professional responsibility purposes as well as ongoing strategy.
+
+**Coordination with technical experts.** In complex cases, you might work with engineering consultants or technical experts. Those discussions can be highly technical and fast-moving. Granola keeps up.
+
+## Technical vocabulary
+
+Patent attorneys working in software, biotech, and advanced engineering spend their days surrounded by technical terminology specific to their client's field. Neural network architectures, molecular binding mechanisms, semiconductor fabrication processes — each practice area has its own vocabulary that generic transcription tools mangle.
+
+Granola handles technical vocabulary better than standard transcription. It won't know your client's proprietary terminology on day one, but you can add notes and corrections to the AI-generated summary, and the underlying transcript is always available.
+
+## Documentation and privilege considerations
+
+Granola runs locally on your Mac. Audio doesn't stream through third-party servers in a way that would create privilege concerns. The recordings and transcripts stay on your device unless you choose to export them.
+
+As with any recording of client meetings, check your jurisdiction's rules and get appropriate consent before recording. For video meetings, Granola picks up system audio alongside microphone input, so the workflow is the same whether you're meeting remotely or taking a call.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## The file documentation angle
+
+Patent prosecution files benefit from contemporaneous documentation. If a claim is challenged and you need to reconstruct what the inventor said about the scope of a claim element during prosecution, a Granola summary of the relevant meeting is a much better record than "attorney's notes from meeting on [date]."
+
+This isn't a substitute for formal declarations or affidavits when those are required. But for the day-to-day documentation of what you discussed and decided with your client, Granola's structured summaries are genuinely useful file artifacts.
+
+## Getting started
+
+Granola works on Mac and runs in the background during your meetings. It picks up audio from your microphone and system, processes locally, and generates an AI summary when the meeting ends. You can review and edit the summary before it goes anywhere.
+
+For patent attorneys with a steady diet of inventor disclosure meetings, trying Granola on a few non-sensitive client consultations is a low-risk way to evaluate whether it fits your practice. The free trial gives you enough meetings to get a feel for how it handles technical vocabulary in your specific practice area.
+
+---
+
+The best patent applications start with a thorough understanding of the invention. Granola helps you get there by handling the documentation so you can focus on understanding.
+
+<AffiliateLink product="granola" campaign={campaign}>Try Granola free</AffiliateLink>

--- a/src/content/blog/granola-for-venture-capital-2026/metadata.json
+++ b/src/content/blog/granola-for-venture-capital-2026/metadata.json
@@ -1,0 +1,10 @@
+{
+  "title": "Granola for Venture Capital: Meeting Notes Across Hundreds of Founder Conversations",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "VCs conduct hundreds of founder meetings per year. Granola helps capture pitch details, due diligence conversations, and portfolio check-ins so nothing falls through the cracks.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "imageAlt": "Granola AI meeting notes for a venture capital partner conducting a founder pitch meeting with AI-generated summary",
+  "tags": ["venture-capital", "investing", "startups", "meetings", "productivity", "granola"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/granola-for-venture-capital-2026/page.mdx
+++ b/src/content/blog/granola-for-venture-capital-2026/page.mdx
@@ -1,0 +1,67 @@
+import { AffiliateLink, InlineAffiliateCTA } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+
+export const campaign = 'granola-for-venture-capital-2026'
+
+# Granola for Venture Capital: Meeting Notes Across Hundreds of Founder Conversations
+
+A VC partner at a mid-size fund might take 400 to 500 founder meetings a year. That's a lot of pitches, a lot of follow-on calls, a lot of due diligence conversations, and a lot of portfolio check-ins — each with details that matter when you're making a million-dollar decision three months later.
+
+The problem: most of those meetings are documented by whoever happened to be taking notes, whenever they had a spare moment, in whatever format felt right at the time. The result is a patchwork of inconsistent records that doesn't hold up when you're trying to reconstruct the investment thesis for a deal that's been in diligence for eight weeks.
+
+Granola records and summarizes every meeting automatically. You stop worrying about notes and start focusing on the conversation.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## What gets lost in founder meetings
+
+The pitch deck tells you the narrative the founder wants to tell. The meeting tells you everything else.
+
+How a founder responds to a hard question about their burn rate. Whether the CTO goes quiet when the product roadmap comes up. The offhand comment about a potential acquirer that suggests they've been talking to strategic buyers. The mention of a customer relationship that didn't appear anywhere in the materials.
+
+These observations live in meeting notes — or nowhere. If you're writing notes while trying to probe and engage, you'll catch some of them. If Granola is running, you get all of it.
+
+## Specific use cases
+
+**Inbound pitch meetings.** The first meeting with a founder is exploratory. You're trying to assess team, market, and traction simultaneously while asking enough good questions to know whether a second meeting makes sense. Granola captures the full conversation so you can write your memo with the actual transcript in front of you rather than reconstructing from memory.
+
+**Partner-level due diligence calls.** Due diligence conversations with founders, customers, and market experts are information-dense. Reference calls especially — people share things they'd never put in writing, and you need an accurate record. Granola lets you focus on listening and asking follow-ups instead of transcribing.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+**IC meeting prep.** Investment committee memos require precise recall of what you learned and what concerns came up in diligence. If you've been running meetings with Granola, you have a searchable record of every relevant conversation to draw from.
+
+**Portfolio company check-ins.** Quarterly board meetings, monthly check-ins, ad-hoc strategy calls — portfolio companies need attention too. Granola creates a consistent record of what each company said, what they committed to, and what follow-up was agreed on. That record is useful when you're trying to identify a pattern six months later.
+
+**LP meetings.** When you're reporting to LPs, the details of what you said and what they asked matter. Granola gives you an accurate record without having to choose between engaging and documenting.
+
+## The cross-partner problem
+
+At most funds, multiple partners take meetings. Notes live in different formats across different systems. When a deal comes up in IC, the partner who wasn't in the meeting is working from whatever notes exist — which may be incomplete, inconsistent, or missing entirely.
+
+Granola's consistent summary format means the notes from your meeting and the notes from your partner's meeting are structured the same way. Sharing and consolidating information across the team becomes much less painful.
+
+## Institutional memory
+
+Venture has a turnover and memory problem that doesn't get talked about enough. Associates cycle out. Partners shift focus. And a lot of the institutional knowledge about why certain investments were passed, what a particular founder was like in 2023, or what due diligence found on a company you considered — that information exists only in people's heads.
+
+Granola meeting records are searchable. If a company comes back around for a later round, you can pull up the notes from your previous meetings and have actual context instead of vague recollections.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Privacy and sensitive conversations
+
+Venture conversations often involve non-public information. Granola runs locally on your Mac — audio doesn't stream to a cloud server to be processed. The company takes privacy seriously, and the architecture reflects that.
+
+For particularly sensitive conversations — early discussions about potential acqui-hires, competitive intelligence shared in confidence, LP relationship conversations — you can pause or stop recording as needed.
+
+## The practical reality
+
+The best outcome from a founder meeting is that you remember everything that mattered and nothing gets dropped. Granola doesn't make you a better investor, but it removes the friction between having a good meeting and having a useful record of that meeting.
+
+For a firm that runs hundreds of meetings a year, consistent documentation is a real operational advantage.
+
+<AffiliateLink product="granola" campaign={campaign}>Try Granola free</AffiliateLink>

--- a/src/content/blog/granola-vs-loom-meeting-recording-2026/metadata.json
+++ b/src/content/blog/granola-vs-loom-meeting-recording-2026/metadata.json
@@ -1,0 +1,21 @@
+{
+  "title": "Granola vs Loom: Which Meeting Recording Tool Actually Helps You?",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Granola and Loom both capture meetings, but they solve completely different problems. Here's when to use each — and why I use Granola for everything that matters.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "slug": "/blog/granola-vs-loom-meeting-recording-2026",
+  "keywords": [
+    "granola vs loom",
+    "meeting recording",
+    "ai meeting notes",
+    "loom alternative",
+    "granola ai",
+    "meeting transcription",
+    "async video vs ai notes",
+    "loom meeting recording",
+    "granola 2026"
+  ],
+  "tags": ["Meeting AI", "Productivity", "Comparison"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/granola-vs-loom-meeting-recording-2026/page.mdx
+++ b/src/content/blog/granola-vs-loom-meeting-recording-2026/page.mdx
@@ -1,0 +1,76 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+export const campaign = "granola-vs-loom-2026"
+
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> transcribes live meetings silently and generates AI-enhanced notes. Loom records video for async sharing. These are different tools solving different problems — but people keep asking which one to use for "meeting recording," so let's sort this out.
+
+## What Loom Does Well
+
+Loom is the right tool when you need to communicate something visually and asynchronously. Recording a bug walkthrough, demoing a new feature to a remote team, doing a code review where you want to show your screen while talking — Loom handles all of that well. You record once, share a link, and people watch on their own time.
+
+It's particularly strong for:
+- Onboarding documentation where you want to show, not tell
+- Product demos and walkthroughs for customers who aren't on a live call
+- Engineering updates where you need to show terminal output or code
+- Any "replace a meeting that didn't need to happen" situation
+
+Loom's AI transcription also lets viewers read instead of watch, which is a real quality-of-life improvement.
+
+## Where Loom Fails for Live Meetings
+
+Loom was built for async communication — it wasn't designed to help you during a live meeting. When you're on a Zoom call with a client and someone says something important, Loom can't help you. You'd have to tell everyone you're recording them, create a video file nobody will watch later, and still have no AI summary or action items at the end.
+
+That's the gap. Loom handles async output. It doesn't handle live meeting capture.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## How Granola Works Differently
+
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> listens to your meetings silently using your device's audio — no bot joins the call, nothing announces itself to other participants. It works with Zoom, Google Meet, Teams, Webex, or any audio source on your Mac.
+
+During the meeting, you can jot quick notes in Granola's notepad. After the meeting ends, Granola enhances your notes with the full transcript context, extracts action items, and organizes everything. You walk away with clean, structured notes without having done much work.
+
+Key differences from Loom:
+- **No consent friction** — Granola works from your local audio, not by joining as a participant
+- **No video file** — you get structured text notes, not a recording to scrub through
+- **AI-generated action items** — automatically extracted from the conversation
+- **Works on any platform** — Zoom, Meet, Teams, phone calls, it doesn't matter
+
+## Head-to-Head by Scenario
+
+**Engineering standups**: Granola wins. You want quick notes on blockers and decisions, not a video recording of a 15-minute standup.
+
+**Client discovery calls**: Granola wins. A Loom bot joining a client call is awkward. Granola captures everything without interrupting the conversation.
+
+**Sales demos you're giving**: Loom wins for pre-recorded demos. Granola wins for live discovery and follow-up notes.
+
+**1:1s with your manager**: Granola wins. Sensitive conversations, no recording consent needed, clean notes after.
+
+**Onboarding new team members**: Loom wins. Pre-recorded walkthroughs beat live meetings for onboarding content.
+
+**All-hands or large company meetings**: Granola wins. You're not going to record the CEO's all-hands — but Granola captures it so you have notes and can find what was said later.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Pricing
+
+**Loom**: Free plan caps videos at 5 minutes. Starter is $12.50/user/month, Business is $16/user/month. Team plans add admin controls and longer video lengths.
+
+**Granola**: Free tier for occasional users. Pro is $18/month for unlimited meetings, with team plans available for shared note access and templates.
+
+If you're already paying for Loom for async video, adding Granola for live meeting notes doesn't feel like a stretch — they cover opposite ends of your communication workflow.
+
+## The Honest Take
+
+Use Loom when you need to communicate something visually and don't need the other person live. Use <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> for any live meeting where you need notes afterward.
+
+Most knowledge workers need both. Async demos and updates? Loom. Live meetings with clients, teammates, or your manager? Granola.
+
+The choice isn't actually Granola vs Loom — it's figuring out which problem you have. If your meetings are leaving you without good notes, Granola fixes that. If your async communication is inefficient, Loom fixes that.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+I use <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> for every live meeting and haven't looked back. The combination of silent capture, AI-enhanced notes, and zero friction has made it a permanent part of my workflow. If you're currently scrambling to take notes during meetings, it's worth trying.

--- a/src/content/blog/granola-vs-notion-ai-meeting-notes-2026/metadata.json
+++ b/src/content/blog/granola-vs-notion-ai-meeting-notes-2026/metadata.json
@@ -1,0 +1,19 @@
+{
+  "title": "Granola vs Notion AI for Meeting Notes: Which One Wins?",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Notion AI can summarize notes you paste into it. Granola captures your meetings automatically and generates those notes for you. Different tools, different results.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "slug": "/blog/granola-vs-notion-ai-meeting-notes-2026",
+  "keywords": [
+    "granola vs notion ai",
+    "notion ai meeting notes",
+    "granola meeting notes",
+    "ai note taking comparison",
+    "notion ai vs granola",
+    "best meeting notes app 2026",
+    "granola ai review"
+  ],
+  "tags": ["Meeting AI", "Productivity", "Comparison"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/granola-vs-notion-ai-meeting-notes-2026/page.mdx
+++ b/src/content/blog/granola-vs-notion-ai-meeting-notes-2026/page.mdx
@@ -1,0 +1,68 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+export const campaign = "granola-vs-notion-2026"
+
+Notion AI is a writing assistant you manually feed. <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> captures your meetings automatically and generates notes from what actually happened. That difference determines which tool belongs in your workflow.
+
+## What Notion AI Does for Meetings
+
+Notion AI can summarize content, generate action items, and reformat text — but only after you give it something to work with. In the context of meetings, that means you first need notes or a transcript. Then you paste them into Notion. Then you ask AI to process them.
+
+The output quality is genuinely good. If you give Notion AI a solid transcript, it will extract action items, write a clean summary, and organize the content well. The problem is the upstream work required: you're still responsible for capturing the meeting in the first place.
+
+Notion AI is excellent for:
+- Summarizing notes you already took manually
+- Reformatting messy meeting notes into structured docs
+- Generating follow-up emails from notes you paste in
+- Organizing a collection of meeting docs over time
+
+None of those are the hard part of meeting notes. The hard part is the capture.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Granola Handles Capture Automatically
+
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> listens to your meetings silently — no bot joins the call, no permissions required from other participants. It works with any video conferencing tool on your Mac: Zoom, Google Meet, Teams, or a plain phone call. When the meeting ends, Granola has a full transcript and generates structured notes with action items automatically.
+
+You can take your own notes in Granola's notepad during the call, and it enhances them with the full transcript context. Or you can ignore it and let it handle everything. Either way, you get clean, organized notes without manual effort.
+
+The workflow is fundamentally different: Notion AI waits for you to do the work, then helps you organize it. Granola does the work while you focus on the conversation.
+
+## Scenario Comparisons
+
+**Weekly team standup**: Granola wins. You don't have time between standups to paste transcripts into Notion. Granola captures it automatically and extracts the blockers and decisions without any effort.
+
+**Client discovery call**: Granola wins. Taking manual notes during a discovery call splits your attention. Granola handles capture while you focus on the client. No bot joining to create awkward consent questions.
+
+**1:1 with your manager**: Granola wins. Sensitive conversations shouldn't be handled by a recording bot or require you to manually transcribe afterward.
+
+**Post-meeting synthesis across many meetings**: Notion AI wins. If you want to synthesize insights across a month of meeting notes already in Notion, Notion AI is well-suited for that. Granola is focused on per-meeting capture.
+
+**All-hands with 200 people**: Granola wins. You're not going to take useful manual notes during a large all-hands. Granola captures everything so you can search it later.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Pricing Reality
+
+**Notion AI**: Requires a Notion subscription first ($10-18/user/month), then AI adds $10/user/month on top. You're looking at $20-28/month minimum, and that's for the entire Notion platform — most of which has nothing to do with meeting notes.
+
+**Granola**: Standalone tool, Pro at $18/month. You're paying specifically for meeting intelligence, not a full workspace platform.
+
+If you're already deeply invested in Notion for docs and project management, adding Notion AI is reasonable. If you're evaluating tools specifically for meeting notes, Granola is the more direct solution at a comparable price.
+
+## When Notion AI Makes Sense
+
+If your team lives in Notion and you already have a system for taking meeting notes manually, Notion AI adds genuine value to that existing workflow. It's a useful layer on top of what you're already doing.
+
+If you're looking to reduce the manual work of meeting notes, Notion AI doesn't solve that problem. It improves the organization step, not the capture step.
+
+## When Granola Wins
+
+Any meeting where you want automatic capture without manual work, <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> is the right choice. If you're in back-to-back meetings, if you have important calls where you want to be fully present, if you consistently leave meetings with mediocre notes — Granola addresses each of those directly.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+The short version: Notion AI makes existing notes better. Granola creates the notes you were never going to take well in the first place. For most people who want to spend less time on meeting notes, Granola is the more impactful tool.

--- a/src/content/blog/meeting-ai-vs-coding-ai-productivity-showdown-2026/metadata.json
+++ b/src/content/blog/meeting-ai-vs-coding-ai-productivity-showdown-2026/metadata.json
@@ -1,0 +1,11 @@
+{
+  "title": "Granola vs WisprFlow: Meeting AI vs Coding AI — The 2026 Productivity Showdown",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "I use both Granola and WisprFlow daily. They solve opposite problems — one captures what you hear, one amplifies what you say. Here's when to reach for each.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "slug": "/blog/meeting-ai-vs-coding-ai-productivity-showdown-2026",
+  "keywords": ["granola vs wisprflow", "meeting ai vs coding ai", "granola wisprflow comparison", "best ai productivity tools 2026", "voice ai vs meeting ai", "granola ai", "wisprflow review", "ai productivity showdown"],
+  "tags": ["Meeting AI", "Voice AI", "Productivity", "Comparison"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/meeting-ai-vs-coding-ai-productivity-showdown-2026/page.mdx
+++ b/src/content/blog/meeting-ai-vs-coding-ai-productivity-showdown-2026/page.mdx
@@ -1,4 +1,8 @@
 import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
 
 export const campaign = "meeting-vs-coding-ai-2026";
 

--- a/src/content/blog/meeting-ai-vs-coding-ai-productivity-showdown-2026/page.mdx
+++ b/src/content/blog/meeting-ai-vs-coding-ai-productivity-showdown-2026/page.mdx
@@ -1,0 +1,112 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+
+export const campaign = "meeting-vs-coding-ai-2026";
+
+I use both Granola and WisprFlow every day. They don't compete with each other — they cover opposite halves of the knowledge worker's day.
+
+Granola handles **input**: what you hear in meetings, the decisions made, the action items assigned to you. WisprFlow handles **output**: what you say, write, and create. Once you understand that split, it's obvious which tool to reach for in any given situation.
+
+This isn't a "pick one" comparison. It's a map of when each tool earns its keep.
+
+---
+
+## What Granola Captures
+
+Granola runs silently in the background during any meeting — Zoom, Google Meet, Teams, whatever. It transcribes everything, then produces AI-enhanced notes that actually reflect the structure of the conversation rather than just dumping a raw transcript at you.
+
+The killer feature is that you can edit the notes template before the meeting starts. Want your standup notes to always surface blockers separately from status updates? Configure it once. Want client calls to auto-generate a summary paragraph plus a bulleted action item list? Done. Granola learns your meeting types and produces consistently structured output for each one.
+
+What this actually means in practice: you stop frantically scribbling during calls. You stop missing things because you were writing. You look up, you listen, you participate — and Granola produces a clean record afterward.
+
+For anyone who's ever had to send "per our call..." recap emails, Granola turns that into a 30-second edit-and-send instead of a 10-minute reconstruction from memory.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+---
+
+## What WisprFlow Produces
+
+WisprFlow is system-level voice-to-text. Press a hotkey anywhere on your Mac, speak, release — the text appears in whatever field has focus. Docs, emails, Slack, Linear, Notion, a terminal comment, a GitHub PR review. Anywhere you can type, WisprFlow can write.
+
+I hit 179 WPM dictating versus maybe 80 WPM typing. That's not a marginal improvement — it's a different category of output speed. Design docs that would take 45 minutes to type get dictated in 20. Slack threads that I'd otherwise compress into a terse sentence because typing is annoying get full, thoughtful replies.
+
+The other thing WisprFlow does that people underestimate: it eliminates the friction between having a thought and expressing it. When you have to type, there's a small but real cost to every word. That cost makes you edit before you even start — you compress, you skip context, you omit. Voice removes that. You just say the thing.
+
+For code-adjacent work specifically: dictating Claude prompts, code review comments, commit messages, and PR descriptions is dramatically faster than typing them. I dictate my AI agent instructions now. It's faster and they're more detailed because I don't self-censor to save keystrokes.
+
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
+
+---
+
+## Head-to-Head by Work Type
+
+Here's the honest breakdown. Some work types clearly favor one tool, some favor the other, and a few benefit from both.
+
+| Work Type | Granola | WisprFlow | Winner |
+|---|---|---|---|
+| Morning standup | Silent notes, captures what was said | Not relevant | Granola |
+| Writing a design doc | Not relevant | Dictate the whole thing | WisprFlow |
+| Client call | Transcription + structured notes | Not relevant | Granola |
+| Reviewing a PR | Not relevant | Dictate comments inline | WisprFlow |
+| 1:1 with manager | Captures decisions + action items | Not relevant | Granola |
+| Drafting Slack messages | Not relevant | Dictate full replies | WisprFlow |
+| All-hands / async team meeting | Full recording + notes | Not relevant | Granola |
+| Coding session | Not relevant | Dictate prompts + comments | WisprFlow |
+
+The pattern is clear: anything where you're in a meeting and primarily receiving information → Granola. Anything where you're creating text output alone → WisprFlow.
+
+---
+
+## Using Both at Once
+
+There's one scenario where they complement each other directly: technical architecture meetings.
+
+You're in a Zoom with four engineers debating database schema decisions. Granola is running, capturing everything. You're fully present — asking questions, drawing on the whiteboard, following the thread of the conversation. The meeting ends.
+
+Thirty seconds later, you open Granola, skim the structured notes it generated, and switch to WisprFlow to dictate the follow-up. You speak your action items out loud — "create Linear ticket for migration script, assign to Jake, due Friday" — and they appear as text you can paste directly into Linear or Slack.
+
+That's the combo workflow. Granola handles the capture. WisprFlow handles the output. You spend zero time either scribbling notes during the call or laboriously typing your follow-ups after.
+
+---
+
+## Pricing and Setup
+
+**Granola** has a free tier that covers a limited number of meetings per month, with paid plans starting around $18/month for unlimited meetings. Setup takes about five minutes — install the Mac app, grant microphone permissions, and it'll automatically detect when you join a meeting. No configuration required to get useful notes on day one.
+
+**WisprFlow** is subscription-based, around $17/month. Setup is similarly fast — install, set your hotkey, and start dictating. It works in any text field system-wide without any app-specific integration. There's no "setup for Slack" or "setup for Notion" — it just works everywhere because it operates at the OS input layer.
+
+Both tools are Mac-first. Both have free trials. Neither requires any complex configuration to be immediately useful.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+---
+
+## Who Gets the Most Out of Each
+
+**Granola is highest-value for:**
+- Managers and engineering leads who spend 4+ hours a day in meetings
+- Product managers tracking decisions across many stakeholder conversations
+- Salespeople who need accurate recall of what was promised on client calls
+- Consultants billing by the hour who need documentation of every conversation
+- Anyone who regularly has to send "per our discussion" follow-up emails
+
+**WisprFlow is highest-value for:**
+- Developers whose bottleneck is the gap between thinking and typing
+- Writers who want to draft faster without losing nuance to keypress friction
+- Anyone whose output work (emails, docs, messages) takes longer than it should
+- Remote workers who write dozens of async messages per day
+- People who use AI coding assistants — dictating prompts is faster and produces better instructions
+
+The honest version: if you're in fewer than two meetings a day and mostly do individual creative/technical work, start with WisprFlow. If your days are dominated by calls and your biggest problem is recall and note quality, start with Granola.
+
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
+
+---
+
+## The Verdict
+
+If you're a knowledge worker who both attends meetings and creates things — which describes most engineers, PMs, and managers — you want both. They don't overlap. The $35/month combined cost pays for itself quickly if you're billing any portion of your time at professional rates, or if your output quality matters to your career.
+
+Start with whichever half of your day is currently more painful. If you leave meetings without knowing what happened, start with Granola. If you avoid writing things down because typing is too slow, start with WisprFlow.
+
+Either way, one month in you'll wonder how you were operating without it.

--- a/src/content/blog/voice-ai-tools-for-lawyers-comparison-2026/metadata.json
+++ b/src/content/blog/voice-ai-tools-for-lawyers-comparison-2026/metadata.json
@@ -1,0 +1,19 @@
+{
+  "title": "Voice AI Tools for Lawyers: Granola vs WisprFlow in 2026",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Lawyers need two different AI voice tools: one for capturing client meetings, one for dictating documents. Granola and WisprFlow each handle one side of that equation.",
+  "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
+  "slug": "/blog/voice-ai-tools-for-lawyers-comparison-2026",
+  "keywords": [
+    "voice ai for lawyers",
+    "granola for lawyers",
+    "wisprflow for lawyers",
+    "legal dictation ai",
+    "ai meeting notes legal",
+    "lawyer productivity tools",
+    "legal voice transcription 2026"
+  ],
+  "tags": ["Voice AI", "Legal", "Comparison", "Productivity"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/voice-ai-tools-for-lawyers-comparison-2026/page.mdx
+++ b/src/content/blog/voice-ai-tools-for-lawyers-comparison-2026/page.mdx
@@ -1,0 +1,89 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+export const campaign = "voice-ai-lawyers-2026"
+
+Lawyers face two distinct voice AI problems. The first: capturing client meetings accurately without a recording bot creating consent issues or making clients uncomfortable. The second: drafting documents — briefs, contracts, correspondence — fast enough to keep billable hours from disappearing into typing.
+
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> solves the first problem. <AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> solves the second. Most lawyers who try both end up using each for different parts of their day.
+
+## The Meeting Capture Problem
+
+Client intake calls, case strategy sessions, depositions, and partner meetings all generate information that needs to end up in your case management system or notes. The traditional approach — taking manual notes during the conversation — splits your attention and produces incomplete records. The recording approach introduces consent requirements and creates hours of audio to review later.
+
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> handles this differently. It captures audio directly from your device using local processing, no bot joins the call, and no participant announcement is made. At the end of the meeting, you have a transcript and AI-generated notes with extracted action items.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Granola for Legal Meetings
+
+Key advantages for legal work:
+
+**No recording bot**: Client calls on Zoom or Teams proceed normally. Granola doesn't announce itself, doesn't show as a participant, and doesn't create the "we're being recorded" dynamic that some clients find unsettling.
+
+**Automatic action items**: Commitments made during a client meeting — documents to request, follow-ups to schedule, deadlines to note — surface automatically in the post-meeting summary.
+
+**Works across platforms**: Zoom, Teams, Google Meet, phone calls routed through your computer — Granola captures any audio your device processes.
+
+**Local audio processing**: Granola processes audio on-device before transcription. For client confidentiality concerns, this is meaningfully different from tools that route audio through third-party servers by default.
+
+**Full-text search**: Every meeting becomes searchable. Finding when a client mentioned a specific property address or case detail across months of calls takes seconds.
+
+## The Dictation Problem
+
+A litigator drafting a brief. A transactional attorney marking up a contract. A partner responding to 40 emails before a deposition. All of this work currently flows through the keyboard, and keyboard speed is a hard ceiling on output.
+
+<AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> operates at the operating system level — hold a hotkey, speak, and your words appear wherever your cursor is. Word, Google Docs, your case management software, Outlook, any text field anywhere. It processes speech at roughly 179 WPM with strong accuracy on legal terminology, case citations, and procedural language.
+
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
+
+## WisprFlow for Legal Dictation
+
+**System-level integration**: WisprFlow works in every application, unlike dictation features built into specific software. You get consistent voice input across your entire workflow.
+
+**Legal terminology accuracy**: Technical language — motion to suppress, habeas corpus, res judicata, specific citation formats — processes accurately. The AI model handles specialized vocabulary better than general-purpose speech recognition.
+
+**Speed on correspondence**: Email and client letters are high-volume, lower-stakes writing. Dictating these at voice speed frees time for higher-complexity work.
+
+**Real-time transcription**: Text appears as you speak with minimal lag. For drafting work where you want to see output immediately, this matters.
+
+## Head-to-Head by Task
+
+| Task | Granola | WisprFlow | Best Tool |
+|------|---------|-----------|-----------|
+| Client intake call | ✅ Silent capture + notes | — | Granola |
+| Deposition preparation | ✅ Review past meeting notes | ✅ Dictate prep outline | Both |
+| Brief drafting | — | ✅ Dictate sections | WisprFlow |
+| Contract review notes | — | ✅ Dictate annotations | WisprFlow |
+| Partner strategy meeting | ✅ Full capture + action items | — | Granola |
+| Email correspondence | — | ✅ Dictate at 179 WPM | WisprFlow |
+| Court preparation | — | ✅ Dictate argument outlines | WisprFlow |
+| Ongoing client matter calls | ✅ Searchable meeting history | — | Granola |
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+## Privacy and Compliance Notes
+
+Both tools require basic diligence before use in legal practice.
+
+**Granola**: Audio captured from device audio, not routed through a call recording bot. Review Granola's current data processing and retention policies before using for privileged communications. For matters with heightened confidentiality requirements, verify the current privacy controls.
+
+**WisprFlow**: Processes voice input to produce text. Review data retention settings and ensure voice data handling aligns with your jurisdiction's bar association guidance on cloud tools and client confidentiality.
+
+Neither tool is a substitute for standard client consent and communication practices around recording. Both offer meaningfully different risk profiles from traditional recording bots, but consult your firm's ethics counsel if you're in a regulated practice area with strict rules on electronic communications.
+
+## Pricing for Law Firms
+
+**Granola**: Pro at $18/month per user. Team plans available with shared templates and centralized billing. For a small firm, per-attorney licensing is straightforward.
+
+**WisprFlow**: Pro at $12/month per user. No complex enterprise licensing required for small firms.
+
+Both tools are inexpensive relative to billable rate. An attorney billing $300-500/hour who recovers even 30 minutes per week from faster drafting or better meeting notes pays for both tools in under a day.
+
+## The Practical Answer
+
+Most law firms benefit from both tools handling different parts of the workflow. <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> for every client call, partner meeting, and internal strategy session. <AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> for every document, email, and brief.
+
+If you're picking just one to start: attorneys who spend most of their time in meetings with clients should start with Granola. Attorneys who spend most of their time drafting should start with WisprFlow. After a few weeks, add the other — the two-tool setup covers the full workday.

--- a/src/content/blog/wisprflow-for-academic-researchers-2026/metadata.json
+++ b/src/content/blog/wisprflow-for-academic-researchers-2026/metadata.json
@@ -1,0 +1,11 @@
+{
+  "title": "WisprFlow for Academic Researchers: Voice-Driven Literature Reviews and Writing",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Academic researchers use WisprFlow to dictate literature notes, draft paper sections, and capture observations at 179 WPM — faster than typing, without the RSI.",
+  "image": "https://zackproser.b-cdn.net/images/wisprflow.webp",
+  "imageAlt": "WisprFlow voice AI interface helping an academic researcher dictate notes and paper sections",
+  "tags": ["voice-ai", "academic-research", "productivity", "writing", "phd"],
+  "hiddenFromIndex": true,
+  "product": "wisprflow"
+}

--- a/src/content/blog/wisprflow-for-academic-researchers-2026/page.mdx
+++ b/src/content/blog/wisprflow-for-academic-researchers-2026/page.mdx
@@ -1,0 +1,73 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+# WisprFlow for Academic Researchers: Voice-Driven Literature Reviews and Writing
+
+Academic research generates an enormous amount of text. Literature notes, observation logs, draft sections, revision comments, grant application narratives — all of it typed, usually under deadline, often while also managing course loads, lab supervision, and conference commitments.
+
+I've spent time with researchers who describe their writing workflows the same way: they think faster than they type, and the bottleneck is the keyboard. A thought forms, they start typing, and by the time the sentence is down, the next three ideas have evaporated.
+
+WisprFlow fixes that. At 179 WPM sustained dictation, you can actually keep pace with how your brain processes ideas when you're deep in a paper.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-academic-researchers-2026" />
+
+## Literature Review and Note-Taking
+
+The standard academic workflow for literature review involves reading a paper, switching to a notes document, typing a summary, and then doing that hundreds of times until you have a synthesis you can work from.
+
+The switching cost is real. Every time you move from reading to typing, you lose the thread of what you were thinking. Voice dictation collapses that gap. You read, you speak your annotation, WisprFlow captures it verbatim, and you keep reading.
+
+This works especially well for:
+
+- **Rapid annotation**: Speak a 3-sentence summary of each paper's key finding immediately after reading the abstract
+- **Comparison notes**: Dictate how this paper's methodology relates to the three others you read this morning, while the comparison is live in your head
+- **Question logging**: Speak "follow-up question:" and dictate whatever the paper raised, building a question bank without interrupting your reading flow
+- **Citation context**: Note where you'd use a specific paper in your argument, verbatim, so your future self doesn't have to reconstruct the reasoning
+
+WisprFlow works globally across your Mac — meaning it works inside your reference manager, your notes app, your browser, and your writing software without switching applications.
+
+## Drafting Paper Sections by Voice
+
+Most academic writers type their first drafts slowly and painfully, editing as they go. The editing-while-writing habit is the biggest source of writing paralysis — you can't move forward because you keep stopping to fix what's behind you.
+
+Voice dictation naturally breaks that habit. When you speak, you don't backspace. You commit to a sentence and keep going. The psychological freedom of dictating a rough first draft without looking at the screen changes how you write.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-academic-researchers-2026" />
+
+My approach: open a blank document, say "draft introduction for section on methodology," and just talk through what I'm trying to say. The first pass is messy and discursive and that's fine. The goal is to externalize the structure in my head so I can edit something real instead of staring at a blank page.
+
+For academic writers specifically, voice drafting works well for:
+
+- **Argument construction**: Talk through your line of reasoning without worrying about the writing quality — fix the prose in revision
+- **Discussion sections**: These are analytical and often stall out because you're trying to be precise while also being creative; voice lets you be exploratory first
+- **Grant narratives**: Specific aims and significance sections respond well to dictation because the content is familiar and the challenge is clarity, not discovery
+- **Email and correspondence**: Reviewer response letters, committee emails, student feedback — all faster by voice
+
+## Field Notes and Observation Logging
+
+For researchers who do qualitative work — ethnography, interview studies, field observations — capturing notes in the moment matters. The context degrades fast.
+
+WisprFlow on iPhone lets you dictate field notes immediately after an observation, an interview, or a site visit. The AI accuracy handles informal speech well enough that you don't need to speak like you're transcribing — just talk like you're telling a colleague what you saw.
+
+That immediacy produces richer notes than anything you reconstruct later at a desk.
+
+## Managing the Writing Volume of a Research Career
+
+The hidden writing load of academic research is enormous: committee reports, peer reviews, reference letters, conference abstracts, course syllabi, IRB applications. All of it keyboard-bound by default.
+
+I clocked myself once and found that about 40% of my daily writing time went to correspondence and administrative documents — things that needed to exist but that I couldn't get into a flow state for. Voice dictation makes that category faster by a factor of three, which reclaims actual writing time for the work that matters.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-academic-researchers-2026" />
+
+If your writing productivity is bottlenecked anywhere — and for most researchers it is — that's where WisprFlow pays off first. Start with the administrative load. Once you trust the accuracy and the workflow, move it into your actual research writing.
+
+## Getting Started
+
+WisprFlow runs on Mac and iPhone with a global keyboard shortcut that activates anywhere. Setup takes under five minutes. The AI model adapts to your vocabulary quickly, including domain-specific terminology.
+
+For researchers: start with literature notes for one paper. Dictate a 5-sentence summary immediately after reading. If that feels better than typing it, you'll know immediately whether voice works for how you think.
+
+<AffiliateLink product="wisprflow" campaign="wisprflow-academic-researchers-2026">Try WisprFlow free</AffiliateLink> — there's a free tier that lets you test the workflow before committing.

--- a/src/content/blog/wisprflow-for-chiropractors-2026/metadata.json
+++ b/src/content/blog/wisprflow-for-chiropractors-2026/metadata.json
@@ -1,0 +1,11 @@
+{
+  "title": "WisprFlow for Chiropractors and Physical Therapists: Hands-Free Clinical Documentation",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Chiropractors and physical therapists use WisprFlow to dictate SOAP notes, treatment plans, and patient progress between appointments — cutting documentation time in half.",
+  "image": "https://zackproser.b-cdn.net/images/wisprflow.webp",
+  "imageAlt": "WisprFlow voice AI interface used by a chiropractor to dictate patient SOAP notes hands-free",
+  "tags": ["voice-ai", "chiropractic", "physical-therapy", "clinical-documentation", "soap-notes"],
+  "hiddenFromIndex": true,
+  "product": "wisprflow"
+}

--- a/src/content/blog/wisprflow-for-chiropractors-2026/page.mdx
+++ b/src/content/blog/wisprflow-for-chiropractors-2026/page.mdx
@@ -1,0 +1,71 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+# WisprFlow for Chiropractors and Physical Therapists: Hands-Free Clinical Documentation
+
+Chiropractors and physical therapists spend their days doing hands-on work. The documentation happens in the margins: between patients, at the end of a shift, sometimes on a phone in the parking lot before the notes get too stale to be accurate.
+
+That gap between the work and the documentation is where errors happen and billing gets complicated. The adjustment you performed is clear in your mind at 11:15 AM. By 6:30 PM when you're typing notes, it's a reconstruction.
+
+WisprFlow closes that gap. Dictate your SOAP notes at 179 WPM immediately after a patient leaves the room, while you're still in the clinical space.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-chiropractors-2026" />
+
+## SOAP Note Documentation by Voice
+
+The SOAP format — Subjective, Objective, Assessment, Plan — maps well to voice dictation because it's structured enough that you can move through it systematically without editing as you go.
+
+A practical approach: open your EHR or notes app and dictate each section as a verbal pass.
+
+**Subjective**: "Patient reports reduced lumbar pain compared to last visit, now rating three out of ten. Reports the home exercises helped with morning stiffness but still has difficulty with prolonged sitting. Work situation unchanged, desk job with no ergonomic support."
+
+**Objective**: "Reduced tenderness at L4-L5 bilateral paraspinals on palpation. Range of motion improved — flexion now seventy degrees, extension forty degrees. Prone extension testing negative. No change in left leg sensation."
+
+**Assessment**: "Improving acute lumbar strain with improving response to treatment. Phase two of care plan appropriate."
+
+**Plan**: "Continued manipulation at L4-L5, home exercise progression adding hip flexor stretch, follow-up in one week."
+
+That's under two minutes of dictation for a complete note. Compare that to typing the same content at the end of a ten-patient day.
+
+## Treatment Plan Development
+
+Treatment plans require more detailed documentation than daily notes — functional goals, expected duration, frequency rationale, home program components. That volume makes them feel heavy to write, which means they get written poorly or late.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-chiropractors-2026" />
+
+Dictating treatment plans works well because the content is clinical knowledge you already have — the challenge is just getting it out of your head and into a document. Voice externalizes that faster than typing.
+
+For physical therapists: dictate the initial evaluation plan while the patient is still fresh in your mind. Speak through the impairments you identified, the functional limitations, the goals with target dates, and the interventions you're planning. The first draft will need formatting cleanup but the clinical content will be complete.
+
+For chiropractors: dictate subluxation findings, adjustment rationale, and expected care phases immediately after the initial consultation. Attach the dictated text to your intake intake form before you've seen the next patient.
+
+## Home Program Documentation
+
+Documenting home exercise programs in enough detail that patients can actually follow them is time-consuming. Most clinicians default to printouts because writing custom instructions takes too long.
+
+Voice dictation changes that math. Speak the exercise, the sets and reps, the technique cues, and the modification notes — then edit the dictated text into a patient handout. The clinical detail that would take five minutes to type takes sixty seconds to dictate.
+
+Patients with personalized, detailed instructions have better adherence than patients with generic handouts. Voice documentation makes that level of personalization feasible in a normal-volume clinical day.
+
+## Between-Patient Clinical Notes
+
+The ideal documentation timing in physical therapy and chiropractic is immediately after treatment — not end-of-day. Between-patient windows are short, but with voice dictation they're long enough.
+
+WisprFlow activates with a keyboard shortcut and works in whatever software you use. A 90-second between-patient dictation of your SOAP note — subjective findings from patient report, your objective measurements, your assessment, and the plan for next visit — produces a complete note before the next patient walks in.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-chiropractors-2026" />
+
+The shift from end-of-day typing to between-patient voice documentation improves note accuracy and takes less total time. You're spending 90 seconds ten times instead of 30 minutes once — and the 10x version produces better clinical documentation.
+
+## Getting Started in a Clinical Setting
+
+WisprFlow works on Mac and iPhone. For clinical documentation, iPhone is often more practical — you can step away from the treatment area, dictate, and return without sitting down at a workstation.
+
+The AI handles medical terminology accurately, including spinal level notation, anatomical landmarks, and standard clinical language. You don't need to spell things out or speak unusually carefully.
+
+Start with your next three SOAP notes by voice. Compare what you captured to what you'd have typed at end of day. The accuracy difference and the time savings together make the case clearly.
+
+<AffiliateLink product="wisprflow" campaign="wisprflow-chiropractors-2026">Try WisprFlow free</AffiliateLink> — see how many documentation minutes you recover in a single clinical day.

--- a/src/content/blog/wisprflow-for-emts-paramedics-2026/metadata.json
+++ b/src/content/blog/wisprflow-for-emts-paramedics-2026/metadata.json
@@ -1,0 +1,11 @@
+{
+  "title": "WisprFlow for EMTs and Paramedics: Faster PCR Documentation in the Field",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "EMTs and paramedics use WisprFlow to dictate patient care reports, handoff notes, and incident documentation at 179 WPM — cutting PCR time so they can get back in service faster.",
+  "image": "https://zackproser.b-cdn.net/images/wisprflow.webp",
+  "imageAlt": "WisprFlow voice AI interface helping a paramedic dictate a patient care report on their phone",
+  "tags": ["voice-ai", "ems", "paramedic", "emt", "documentation", "patient-care-report"],
+  "hiddenFromIndex": true,
+  "product": "wisprflow"
+}

--- a/src/content/blog/wisprflow-for-emts-paramedics-2026/page.mdx
+++ b/src/content/blog/wisprflow-for-emts-paramedics-2026/page.mdx
@@ -1,0 +1,63 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+# WisprFlow for EMTs and Paramedics: Faster PCR Documentation in the Field
+
+Patient care reports are the most time-consuming part of EMS work that has nothing to do with patient care. A thorough PCR takes 20-40 minutes to type. On a busy shift with multiple calls, that documentation load accumulates fast — and it keeps units out of service longer than the calls themselves.
+
+The documentation burden is one of the leading drivers of EMS burnout. It's not the hard calls. It's the paperwork after the hard calls, done in a cramped ambulance cab at 2 AM on a tablet with a broken keyboard.
+
+WisprFlow addresses one specific piece of that problem: the time it takes to convert clinical events into written documentation. At 179 WPM sustained dictation, you can draft a complete PCR narrative in under four minutes.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-emts-paramedics-2026" />
+
+## PCR Narrative Documentation by Voice
+
+The narrative section of a PCR is the hardest part to write and the most important for legal and clinical continuity. It needs to tell the story of the call — dispatch to patient contact to assessment to treatment to transport to handoff — in enough detail that someone reading it days later can reconstruct what happened.
+
+Typing that narrative from memory is slow, and the longer you wait, the more clinical detail fades. Voice dictation immediately after a call — or during the transport phase if you have a partner managing patient care — produces a more complete and accurate narrative than anything typed later at the station.
+
+A practical approach for PCR narrative dictation:
+
+"Unit dispatched at 0214 for reported chest pain, sixty-seven-year-old male. Patient found seated on couch, alert and oriented times four. Primary complaint substernal chest pressure, seven out of ten, onset approximately forty-five minutes prior to our arrival, no radiation, associated diaphoresis and mild shortness of breath. Denied nausea, syncope, or prior cardiac history. Skin pale, diaphoretic, cool to touch. Pulse irregular, ninety-two, radial. BP 148 over 94, SpO2 ninety-four percent on room air. Twelve-lead obtained, showing ST elevation V2 through V4, transmitted to receiving facility. Medical control contacted, STEMI alert activated. IV access eighteen gauge left AC, normal saline TKO. Aspirin 324 milligrams PO administered. Patient transported Code 3 to Regional Medical, uneventful transport, patient remained alert throughout. Handoff at 0248 to charge nurse."
+
+That's a complete medical record narrative, dictated in under two minutes. The same content typed would take eight to twelve.
+
+## Assessment Documentation During Transport
+
+For ALS units where the medic manages patient care while the EMT drives, the transport phase is often the only time available for documentation before arrival. Voice dictation makes that window usable — dictate assessment findings and treatment with your hands on the patient.
+
+WisprFlow on iPhone activates with a keyboard shortcut and captures everything in the background. You're speaking to the patient and dictating clinical notes simultaneously, the same way you'd call medical control.
+
+<InlineAffiliateCTA product="wisprflow-emts-paramedics-2026" />
+
+This doesn't work for every call or every unit configuration. But for medics managing a stable patient during a long transport, voice documentation during transport means you arrive at the receiving facility with your PCR narrative essentially complete.
+
+## Handoff Notes and Hospital Communication
+
+The verbal handoff to receiving facility nursing staff covers the same information as your PCR narrative but in condensed form. Many medics dictate their handoff summary — patient name, age, chief complaint, vitals, treatments, and clinical impression — as a voice note immediately after the call, separate from the formal PCR.
+
+This creates a record of exactly what was communicated at handoff, in the moment, before memory reconstruction changes the specifics. It's useful protection in cases that later involve billing disputes, adverse outcomes, or protocol reviews.
+
+## Incident Reports and Supplemental Documentation
+
+Beyond PCRs, EMS providers generate incident reports for equipment issues, exposure reports for communicable disease contacts, and supplemental documentation for complex calls or unusual situations.
+
+All of that is easier by voice. An equipment issue that would get a one-line typed note becomes a complete documented report when dictation makes it fast enough to actually describe what happened, when, and what was done about it.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-emts-paramedics-2026" />
+
+Exposure reports especially benefit from voice dictation — they're time-sensitive, they require specific detail about the exposure type and circumstances, and they're often written under stress at the end of a difficult shift. Speaking the report produces more accurate and complete documentation than typing it while fatigued.
+
+## Practical Setup for EMS Use
+
+WisprFlow runs on iPhone, which is the right platform for EMS documentation. Your phone goes everywhere on shift. You can dictate from the ambulance bay, the patient's home, the hospital corridor, wherever you are when the call ends.
+
+The AI handles medical terminology — drug names, anatomical references, clinical shorthand — without requiring you to spell things out or speak with unusual formality. It learns your vocabulary patterns.
+
+The free tier is enough to test whether voice PCR documentation fits your workflow. A single busy shift will tell you exactly how much time it saves and whether the accuracy meets your documentation standards.
+
+<AffiliateLink product="wisprflow" campaign="wisprflow-emts-paramedics-2026">Try WisprFlow free</AffiliateLink> — if it saves you 10 minutes per call on documentation, that adds up fast on a 12-hour shift.

--- a/src/content/blog/wisprflow-for-emts-paramedics-2026/page.mdx
+++ b/src/content/blog/wisprflow-for-emts-paramedics-2026/page.mdx
@@ -32,7 +32,7 @@ For ALS units where the medic manages patient care while the EMT drives, the tra
 
 WisprFlow on iPhone activates with a keyboard shortcut and captures everything in the background. You're speaking to the patient and dictating clinical notes simultaneously, the same way you'd call medical control.
 
-<InlineAffiliateCTA product="wisprflow-emts-paramedics-2026" />
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-emts-paramedics-2026" />
 
 This doesn't work for every call or every unit configuration. But for medics managing a stable patient during a long transport, voice documentation during transport means you arrive at the receiving facility with your PCR narrative essentially complete.
 

--- a/src/content/blog/wisprflow-for-life-coaches-2026/metadata.json
+++ b/src/content/blog/wisprflow-for-life-coaches-2026/metadata.json
@@ -1,0 +1,11 @@
+{
+  "title": "WisprFlow for Life Coaches: Capture Session Insights Without Breaking Presence",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "Life coaches use WisprFlow to dictate session notes, client progress, and goal-tracking entries at 179 WPM — staying present during sessions and capturing everything after.",
+  "image": "https://zackproser.b-cdn.net/images/wisprflow.webp",
+  "imageAlt": "WisprFlow voice AI interface helping a life coach dictate session notes on iPhone",
+  "tags": ["voice-ai", "life-coaching", "productivity", "session-notes", "client-management"],
+  "hiddenFromIndex": true,
+  "product": "wisprflow"
+}

--- a/src/content/blog/wisprflow-for-life-coaches-2026/page.mdx
+++ b/src/content/blog/wisprflow-for-life-coaches-2026/page.mdx
@@ -1,0 +1,75 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+# WisprFlow for Life Coaches: Capture Session Insights Without Breaking Presence
+
+The hardest part of life coaching documentation is the timing. The richest notes come from the session itself — the client's exact words, the moment a reframe landed, the energy shift when they named something they'd been avoiding. But you can't type during a session without breaking presence. And by the time you sit down at a keyboard an hour later, the texture of what happened has faded.
+
+Voice dictation done right solves this. WisprFlow lets you speak session notes in the immediate minutes after a session ends — when everything is still vivid — at 179 WPM, faster than you'd type rough notes.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-life-coaches-2026" />
+
+## The Post-Session Window
+
+The five to ten minutes after a coaching session ends is the highest-value documentation time you have. Your emotional memory of the session is intact. You remember the exact language the client used that mattered. You have a clear sense of what shifted and what didn't.
+
+Most coaches waste this window because they immediately move to the next client, or check their phone, or give themselves a mental break that bleeds into forgetting.
+
+WisprFlow makes it fast enough that you can use the window. Dictate for four minutes on your phone or Mac, and you'll have notes that would have taken 20 minutes to type later — and that are richer than anything reconstructed from memory.
+
+What to capture in that window:
+
+- The session's central theme in the client's own words
+- Any specific language they used about a shift, insight, or obstacle — exact quotes, not paraphrases
+- What coaching moves you made and how they responded
+- Patterns you noticed: recurring language, avoided topics, body language if in-person
+- The client's stated commitment for between sessions
+- Your intuition about what's actually going on, even if unspoken
+
+That last category — your intuition — is where typed notes fail most coaches. Typing is slow enough that you censor the uncertain, half-formed observations. Speaking them out loud preserves them, and they're often the most useful material to revisit.
+
+## Client Progress Documentation
+
+Tracking client progress over time requires documentation that accumulates detail across sessions. Without that, you end up reconstructing progress from memory at review points, which produces flatter, less useful summaries.
+
+WisprFlow fits into this at every touchpoint:
+
+- **Between-session updates**: When a client sends a text or email about progress, dictate a brief note capturing your reaction and any coaching hypothesis it raises before you reply
+- **Milestone reviews**: Quarterly or mid-engagement reviews are faster to draft by voice — talk through what you've observed over the engagement, let WisprFlow capture it, then edit into a structured document
+- **Pattern recognition entries**: When you notice a theme repeating across multiple sessions, speak a quick observation note to your client's file while it's live in your mind
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-life-coaches-2026" />
+
+## Reflective Practice and Supervision Prep
+
+Good coaching requires reflective practice — reviewing your own work, identifying patterns in how you coach different clients, preparing material for supervision. That process is almost entirely reflective writing, and it benefits from voice in the same way session notes do.
+
+I'd suggest a weekly voice reflection habit: 10 minutes of dictation reviewing your week of sessions. What came up repeatedly? Where did you feel uncertain? Which client feels stuck and why? Where did you notice yourself avoiding a challenge?
+
+Speaking this kind of reflection rather than typing it changes the quality of what emerges. Typing creates a performance. Speaking produces a more honest first draft.
+
+For supervision preparation, dictate your case material and questions directly. The format that works well: speak as if explaining the client to your supervisor, including the parts where you're uncertain. You end up with prep notes that are actually useful rather than sanitized.
+
+## Practice Management Voice Workflows
+
+Beyond the coaching-specific content, WisprFlow covers the administrative side of running a coaching practice:
+
+- **Intake summaries**: After an initial call, dictate your observations, the client's stated goals, and your coaching hypothesis
+- **Contract and scope notes**: Speak through what was agreed on scope, frequency, and focus areas
+- **Referral notes**: When a client's needs fall outside your scope, dictate your referral rationale while it's fresh
+- **Email correspondence**: Dictate client emails rather than typing them — the voice drafts tend to be warmer and more personal, which fits the coaching relationship
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-life-coaches-2026" />
+
+## Starting the Voice Documentation Practice
+
+WisprFlow works on Mac and iPhone with a global activation shortcut. You can dictate into any notes app, Google Doc, CRM, or client management software without special integration.
+
+The entry point for most coaches: after your next session, before you do anything else, open your notes app on your phone and speak for three minutes. Don't filter, don't organize, just describe what happened. Then read what you captured.
+
+If those notes are richer than what you'd have typed later, you know the workflow is worth building.
+
+<AffiliateLink product="wisprflow" campaign="wisprflow-life-coaches-2026">Try WisprFlow free</AffiliateLink> — the free tier is enough to test whether voice documentation fits how you coach.

--- a/src/content/blog/wisprflow-for-mobile-developers-2026/metadata.json
+++ b/src/content/blog/wisprflow-for-mobile-developers-2026/metadata.json
@@ -1,0 +1,11 @@
+{
+  "title": "WisprFlow for Mobile Developers: Voice Coding and Documentation at 179 WPM",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "How mobile developers use WisprFlow to dictate Swift, Kotlin, and React Native code, document APIs, and write tickets faster than typing — hands-free on Mac and iPhone.",
+  "image": "https://zackproser.b-cdn.net/images/wisprflow.webp",
+  "imageAlt": "WisprFlow voice AI interface showing a mobile developer dictating Swift code on a Mac",
+  "tags": ["voice-ai", "mobile-development", "swift", "kotlin", "productivity"],
+  "hiddenFromIndex": true,
+  "product": "wisprflow"
+}

--- a/src/content/blog/wisprflow-for-mobile-developers-2026/page.mdx
+++ b/src/content/blog/wisprflow-for-mobile-developers-2026/page.mdx
@@ -1,0 +1,69 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+# WisprFlow for Mobile Developers: Voice Coding and Documentation at 179 WPM
+
+Mobile development has a writing problem. You write code in Swift or Kotlin, then you write documentation for that code, then you write tickets describing what you're building, then you write Slack messages explaining why the build broke. That's a lot of keyboard time for work where the actual thinking is spatial and sequential — you're reasoning about UI state machines, gesture recognizers, and lifecycle callbacks, not hunting for the right words.
+
+I've been using WisprFlow for voice coding and it's changed how I work. Not in a subtle way. In a "I'm now dictating this article at 179 WPM while thinking about something else" way.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-mobile-developers-2026" />
+
+## Dictating Code and Comments
+
+Voice coding has a learning curve, but it's shorter than you'd expect. The key insight is that you're not replacing typing for every character — you're replacing typing for the parts that involve natural language.
+
+In Swift and Kotlin, that's a significant chunk of your actual keystrokes:
+- Function and variable names written in plain English
+- Doc comments and inline explanations
+- String literals and error messages
+- Protocol and interface names
+- Test descriptions in your test functions
+
+The pattern I use: dictate the structure and intent, type the syntactically dense parts. Say "function named fetch user profile that takes a user ID string and returns async throws user profile" — WisprFlow puts down the natural language, I clean up the Swift syntax. The ratio ends up about 60/40 voice to keyboard, and my hands get significantly less worn out over a long day.
+
+For Kotlin Android work specifically, voice is excellent for describing ViewModel methods, repository patterns, and the boilerplate-heavy parts of Jetpack Compose.
+
+## Documentation and API Reference
+
+Documentation is where most mobile developers lose hours every sprint. It's necessary, it's not exciting, and it's slow to type.
+
+WisprFlow makes documentation feel like explaining the code to someone verbally — which is actually how good documentation reads. Instead of staring at a function and trying to write formal prose about it, you just describe what it does out loud like you're explaining it to a junior dev.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-mobile-developers-2026" />
+
+This works especially well for:
+
+- **README sections**: Talk through setup steps, architecture decisions, and known quirks as if you're onboarding someone
+- **Code review comments**: Dictate your review feedback instead of typing it — you'll write longer, more useful comments when it costs you only 10 seconds instead of 2 minutes
+- **CHANGELOG entries**: Speak what changed and why at the end of each PR; the natural language quality is better than terse typed bullets
+- **Slack engineering updates**: Dictate a paragraph explaining the current sprint status instead of typing a terse three-word reply
+
+## Ticket Writing and Sprint Planning
+
+Writing Jira tickets is one of the most tedious parts of mobile development. Acceptance criteria, edge cases, device considerations, API dependencies — typing all of that is a chore, so most developers write thin tickets that create problems later.
+
+Voice changes the economics. A well-specified ticket via voice takes about 90 seconds. You speak the user story, the acceptance criteria, the edge cases you already know about, and any platform-specific notes (iOS 17 only, Android 14+ behavior, specific device quirks). The ticket that used to take 10 minutes of reluctant typing now takes the time it takes you to think it through — which you were going to do anyway.
+
+My habit: immediately after a design review or sync call, while the context is live, open a ticket and dictate everything I just heard. Better ticket quality, no memory reconstruction required.
+
+## On-the-Go Development
+
+Mobile developers often have opinions about working away from a desk — walking meetings, commuting by transit, sitting in coffee shops. WisprFlow on iPhone means your voice input follows you.
+
+I've dictated technical documentation, Slack messages, and full email threads on my phone walking between meetings. The accuracy is high enough that I don't feel like I'm fighting the tool. That reclaimed time adds up fast.
+
+<InlineAffiliateCTA product="wisprflow" campaign="wisprflow-mobile-developers-2026" />
+
+## Getting Started for Mobile Devs
+
+WisprFlow installs on Mac and iPhone, activates with a global keyboard shortcut, and works in Xcode, Android Studio, VS Code, Linear, Jira, Slack, and your browser without any configuration.
+
+Start with documentation and tickets — those are the lowest-friction entry points where voice quality matters but syntactic precision doesn't. Once you've built the muscle memory, bring it into code comments and then eventually into dictating code structure.
+
+The free tier gives you enough usage to find out whether this works for how you develop. Most mobile developers who try it for a week don't go back.
+
+<AffiliateLink product="wisprflow" campaign="wisprflow-mobile-developers-2026">Try WisprFlow free</AffiliateLink> and see how many keystrokes you stop making.

--- a/src/content/blog/wisprflow-vs-github-copilot-voice-coding-2026/metadata.json
+++ b/src/content/blog/wisprflow-vs-github-copilot-voice-coding-2026/metadata.json
@@ -1,0 +1,20 @@
+{
+  "title": "WisprFlow vs GitHub Copilot: Voice Coding in 2026",
+  "author": "Zachary Proser",
+  "date": "2026-04-25",
+  "description": "GitHub Copilot handles code suggestions. WisprFlow handles how fast you can express your thoughts. Here's how they compare — and why you probably want both.",
+  "image": "https://zackproser.b-cdn.net/images/wisprflow.webp",
+  "slug": "/blog/wisprflow-vs-github-copilot-voice-coding-2026",
+  "keywords": [
+    "wisprflow vs github copilot",
+    "voice coding",
+    "ai coding tools",
+    "github copilot alternative",
+    "wisprflow 2026",
+    "voice to code",
+    "ai developer tools",
+    "voice dictation for coding"
+  ],
+  "tags": ["Voice AI", "Developer Tools", "Comparison"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/wisprflow-vs-github-copilot-voice-coding-2026/page.mdx
+++ b/src/content/blog/wisprflow-vs-github-copilot-voice-coding-2026/page.mdx
@@ -1,0 +1,75 @@
+import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateCTA'
+import { createMetadata } from '@/utils/createMetadata'
+import rawMetadata from './metadata.json'
+
+export const metadata = createMetadata(rawMetadata)
+export const campaign = "wisprflow-vs-copilot-2026"
+
+These tools don't actually compete. GitHub Copilot is a code suggestion engine that lives inside your IDE. <AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> is a system-level voice input layer that works in every app on your machine, including your IDE. Understanding that distinction tells you exactly how to use them together.
+
+## What GitHub Copilot Does
+
+Copilot predicts and completes code based on context — function signatures, comments, surrounding code, and open files. You type (or comment) and it suggests the next line, next function, or a whole block. The Chat feature lets you ask questions about your codebase, explain errors, generate tests, or request refactors in natural language.
+
+Copilot is genuinely useful for:
+- Completing boilerplate you've written a hundred times
+- Generating test cases from function signatures
+- Explaining unfamiliar code or error messages
+- Drafting PRs and commit messages via GitHub.com integration
+- Suggesting code based on inline comments
+
+The workflow is: you type a comment or partial function, Copilot autocompletes, you accept or reject. The interface is entirely keyboard-driven. Copilot has no microphone, no voice input, and no mechanism to hear you.
+
+## WisprFlow's Actual Job
+
+<AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> is a voice-to-text layer that operates at the OS level. You hold a hotkey, speak, and your words appear wherever your cursor is — Slack, VS Code, a terminal, a browser form, anywhere. It processes speech at around 179 WPM with high accuracy on technical language, including variable names, library names, and code-adjacent terminology.
+
+It doesn't suggest code. It captures what you say and puts it where you're working.
+
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
+
+## Where Copilot Falls Short
+
+Copilot can't hear you. This matters more than it sounds. A significant portion of the cognitive work in coding is thinking through architecture, naming things, explaining your reasoning, and drafting documentation. All of that work currently requires your fingers.
+
+Dictating a function's purpose via voice and letting Copilot implement from that comment is faster than typing the comment. Writing a PR description by voice while your test suite runs is faster than typing it. Explaining a bug to yourself out loud — rubber-duck debugging at dictation speed — surfaces the issue faster.
+
+Copilot is waiting for input. WisprFlow accelerates how fast you can give it.
+
+## How WisprFlow and Copilot Work Together
+
+The combination is more useful than either tool alone:
+
+**Dictate prompts into Copilot Chat**: Rather than typing a detailed question about your codebase, speak it. Voice input at 179 WPM means you can give Copilot more context faster, which produces better suggestions.
+
+**Dictate inline comments**: A well-written comment above a function is one of the best Copilot triggers. Speaking that comment instead of typing it removes friction from the feedback loop.
+
+**Write commit messages and PRs by voice**: After a coding session, dictate your commit message and PR description while the code is fresh in your head. These are text-heavy, thought-heavy, and perfect for voice.
+
+**Dictate architecture docs**: ADRs, READMEs, design documents — these take time because they require typing sustained prose. Voice dictation removes the typing bottleneck.
+
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
+
+## Real Workflow: Coding on a Trail Walk
+
+I code and dictate architecture decisions while walking. With <AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> on my phone or laptop, I can dictate technical notes, draft GitHub issues, and outline implementation plans without sitting at a desk. When I return to the keyboard, I have a voice-drafted spec ready. I activate Copilot to implement from the spec.
+
+This is the "untethered development" pattern — cognitive work on the move, implementation at the keyboard, with AI handling the mechanical parts of both.
+
+## Pricing and Setup
+
+**GitHub Copilot**: $10/month Individual, $19/month Business (includes Copilot Chat, CLI, and PR features). Free for students and open source maintainers.
+
+**WisprFlow**: Free tier with monthly minute limits. Pro is $12/month for power users. Setup takes about two minutes — install, grant microphone access, configure hotkey.
+
+Both tools have low setup overhead and immediate payoff.
+
+<InlineAffiliateCTA product="wisprflow" campaign={campaign} />
+
+## The Verdict for Developers
+
+If you're choosing between these tools as if they're alternatives, reframe the question. Copilot speeds up the code-writing part of development. <AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> speeds up every other part — prompting, documenting, communicating, planning.
+
+If you only pick one voice tool for your development workflow, WisprFlow wins because it works everywhere. Copilot only helps inside an IDE. WisprFlow helps in your IDE, your terminal, Slack, Linear, GitHub, your email client, and anywhere else your cursor lands.
+
+Start with WisprFlow. Add Copilot when you want code suggestions. Use them together and the gap between thinking and shipping narrows noticeably.


### PR DESCRIPTION
## WisprFlow Affiliate Articles — Thin Verticals Batch

5 new affiliate articles targeting underrepresented WisprFlow verticals:

- `wisprflow-for-academic-researchers-2026` — Voice-driven literature reviews, SOAP-style note-taking, field observations, and managing academic writing volume
- `wisprflow-for-mobile-developers-2026` — Voice coding Swift/Kotlin, documentation, ticket writing, and on-the-go development  
- `wisprflow-for-life-coaches-2026` — Post-session capture, client progress tracking, reflective practice, supervision prep
- `wisprflow-for-chiropractors-2026` — SOAP note dictation, treatment plan drafting, home program documentation, between-patient workflow
- `wisprflow-for-emts-paramedics-2026` — PCR narrative dictation, transport-phase documentation, handoff notes, incident reports

All articles:
- hiddenFromIndex: true ✅
- image: wisprflow.webp CDN URL ✅
- 3-4 InlineAffiliateCTA per article ✅
- No banned patterns (not just X, it's Y) ✅
- Build passes ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new MDX/metadata content pages and does not change application logic. Main risk is SEO/routing or build issues if any frontmatter/metadata fields are malformed.
> 
> **Overview**
> Adds a batch of new hidden-from-index affiliate blog posts with per-page `metadata.json` + `page.mdx` content.
> 
> New content includes multiple *Granola* vertical pages (e.g., compliance officers, data scientists, immigration/patent attorneys, venture capital) and comparison articles (`granola-vs-loom`, `granola-vs-notion-ai`, plus `granola` vs `wisprflow`/lawyers/`wisprflow` vs Copilot), along with additional *WisprFlow* vertical pages (academic researchers, mobile developers, life coaches, chiropractors/PT, EMTs/paramedics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da5a15ec96315facb7f5240d5494cca2b9a30fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->