### PR TITLE
Hero redesign: contrarian/insider variant

### DIFF
--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -2,13 +2,11 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import { useState } from 'react'
 import { track } from '@vercel/analytics'
 import { EditorialCard } from '@/components/EditorialCard'
 import { SectionHead } from '@/components/SectionHead'
-import ConsultationForm from '@/components/ConsultationForm'
 import { EditorialNewsletter } from '@/components/EditorialNewsletter'
-import RenderNumYearsExperience, { getYearsExperienceAsWord } from '@/components/NumYearsExperience'
+import RenderNumYearsExperience from '@/components/NumYearsExperience'
 import type { Content } from '@/types/content'
 
 /* ------------------------------------------------------------------
@@ -29,64 +27,98 @@ interface Props {
 
 // ----- Hero ---------------------------------------------------------
 
-function EditorialHero({ onConsult }: { onConsult: () => void }) {
-  const yearsWord = getYearsExperienceAsWord()
+function EditorialHero() {
   return (
-    <section className="pt-16 pb-12 md:pt-24 md:pb-16">
-      <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-14 lg:grid-cols-[1.35fr_1fr] lg:items-start">
-        <div>
-          <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
-            Applied AI · WorkOS
+    <section className="pt-8 pb-8 md:pt-10 md:pb-10">
+      <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-8 lg:gap-12 lg:grid-cols-[1.45fr_1fr] lg:items-start">
+        <div className="editorial-hero-c-main">
+          <div className="editorial-eyebrow editorial-eyebrow--ruled text-parchment-600 dark:text-slate-400">
+            <span className="editorial-eyebrow-rule" aria-hidden />
+            <span>
+              <span className="editorial-eyebrow-section text-burnt-400 dark:text-amber-400">§ 00</span>
+              {' · From inside the building'}
+            </span>
           </div>
           <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
-            AI engineering for teams that actually{' '}
-            <span className="text-burnt-400 dark:text-amber-400">ship</span>.
+            Most AI advice{' '}
+            <span className="editorial-strike">is bullshit.</span>
+            <br />
+            <em className="editorial-h1-em text-burnt-400 dark:text-amber-400">
+              Here&rsquo;s what actually ships.
+            </em>
           </h1>
-          <p className="editorial-lede text-parchment-600 dark:text-slate-300">
-            I build retrieval pipelines, agent harnesses, and ship-ready
-            developer tools at WorkOS. {yearsWord} years in production. Writing,
-            workshops, and consulting for teams that got handed an LLM and a
-            deadline.
+          <p className="editorial-greeting text-parchment-600 dark:text-slate-300">
+            Hi, I&rsquo;m <span className="text-burnt-400 dark:text-amber-400">Zack</span>{' '}
+            <span className="editorial-greeting-wave" role="img" aria-label="waving hand">👋</span>
+          </p>
+          <p className="editorial-lede editorial-lede--tight text-parchment-600 dark:text-slate-300">
+            I&rsquo;m an AI engineer on the Applied AI team at WorkOS &mdash; we power
+            authentication for OpenAI, Cursor, and a lot of the labs you&rsquo;ve
+            heard of. Fifteen years of web engineering before that. I help with
+            the AI enablement function for our whole org: internal tooling,
+            workshops, harnesses for teammates, helping everyone level up. I
+            write down what I learn.
           </p>
 
-          {/* Newsletter — the primary CTA. Inline under the lede. */}
-          <EditorialNewsletter location="hero" />
+          {/* Newsletter — the dominant CTA, rendered as a bordered card. */}
+          <EditorialNewsletter
+            location="hero"
+            variant="card"
+            label="The Modern Coding letter"
+            meta="5,000+ engineers"
+            title="Dispatches from the edge of applied AI."
+            promise={
+              <>
+                <b>What lands in your inbox:</b> what I&rsquo;m building, what I&rsquo;m
+                learning, the tools I&rsquo;d actually pay for, and the occasional
+                workshop or tutorial. Names named, vendors graded, evals included.
+              </>
+            }
+            fine="Unsubscribe in one click · No spam, ever"
+            ctaLabel="Subscribe →"
+          />
 
           <div className="editorial-secondary text-parchment-600 dark:text-slate-400">
-            <button
-              type="button"
-              onClick={() => {
-                onConsult()
-                track('main_cta_click', { destination: 'consultation' })
-              }}
-              className="bg-transparent border-0 p-0 cursor-pointer font-inherit text-inherit"
-              style={{ borderBottom: '1px solid currentColor', paddingBottom: 1 }}
-            >
-              Book a consult →
-            </button>
+            <Link href="/blog">Read the archive →</Link>
             <span>·</span>
-            <Link href="/blog">Read the essays →</Link>
-            <span>·</span>
-            <Link href="/services">Workshops →</Link>
+            <Link href="/services">Workshops &amp; AI enablement →</Link>
           </div>
 
         </div>
 
-        <div className="editorial-hero-plate">
-          <div className="editorial-portrait">
+        <aside className="editorial-hero-c-side">
+          <div className="editorial-portrait editorial-portrait--c">
             <Image
               src="https://zackproser.b-cdn.net/images/zack-sketch.webp"
               alt="Portrait of Zachary Proser"
               fill
-              sizes="(max-width: 1024px) 80vw, 500px"
+              sizes="(max-width: 1024px) 80vw, 320px"
               className="editorial-portrait-image"
               priority
             />
           </div>
-          <div className="editorial-portrait-caption text-parchment-600 dark:text-slate-400">
-            Plate I · Applied AI · MMXXVI
+          <div className="editorial-portrait-plate text-parchment-600 dark:text-slate-400">
+            <span>Plate I · Duotone</span>
+            <span>Source Serif</span>
           </div>
-        </div>
+
+          <div className="editorial-erratum">
+            <span className="editorial-erratum-stamp">Errata</span>
+            <div className="editorial-erratum-head text-burnt-400 dark:text-amber-400">
+              <span>Things I will not write about</span>
+            </div>
+            <ul className="editorial-erratum-list">
+              <li>&ldquo;Agents are eating SaaS&rdquo;</li>
+              <li>Frameworks I tried for 20 minutes</li>
+              <li>Demos that don&rsquo;t pass an eval</li>
+              <li>&ldquo;5 prompts that changed my life&rdquo;</li>
+              <li className="editorial-erratum-keep">
+                What I&rsquo;m actually building
+                <br />for engineers who ship.
+              </li>
+            </ul>
+          </div>
+        </aside>
       </div>
     </section>
   )
@@ -334,12 +366,10 @@ export default function HomepageClientComponent({
   careerAdvice,
   videos,
 }: Props) {
-  const [isConsultOpen, setIsConsultOpen] = useState(false)
-
   return (
     <div className="editorial-home flex flex-col min-h-screen text-charcoal-50 dark:text-parchment-100 theme-transition">
       <main className="flex-1">
-        <EditorialHero onConsult={() => setIsConsultOpen(true)} />
+        <EditorialHero />
         <StatRow />
         <FeaturedProject />
 
@@ -406,11 +436,6 @@ export default function HomepageClientComponent({
       </main>
 
       <ColophonFooter />
-
-      <ConsultationForm
-        isOpen={isConsultOpen}
-        onClose={() => setIsConsultOpen(false)}
-      />
     </div>
   )
 }

--- a/src/components/EditorialNewsletter.tsx
+++ b/src/components/EditorialNewsletter.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, FormEvent } from 'react'
+import { useState, FormEvent, ReactNode } from 'react'
 import { usePathname } from 'next/navigation'
 import { track } from '@vercel/analytics'
 import { sendGTMEvent } from '@next/third-parties/google'
@@ -10,6 +10,15 @@ interface EditorialNewsletterProps {
   label?: string
   title?: string
   fine?: string
+  /** Rendering style. `inline` (default) is the bare under-lede form;
+   * `card` is the bordered, accent-shadowed capture card used in the hero. */
+  variant?: 'inline' | 'card'
+  /** Optional secondary copy block shown between title and form (card variant). */
+  promise?: ReactNode
+  /** Optional meta caption shown next to the label (card variant). */
+  meta?: string
+  /** Submit button label. Defaults to "Subscribe →". */
+  ctaLabel?: string
 }
 
 export function EditorialNewsletter({
@@ -17,6 +26,10 @@ export function EditorialNewsletter({
   label = 'The Modern Coding letter',
   title = 'Applied AI dispatches read by 5,000+ engineers',
   fine = 'No spam. Unsubscribe in one click.',
+  variant = 'inline',
+  promise,
+  meta,
+  ctaLabel = 'Subscribe →',
 }: EditorialNewsletterProps) {
   const referrer = usePathname()
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
@@ -59,15 +72,39 @@ export function EditorialNewsletter({
     }
   }
 
+  const isCard = variant === 'card'
+
   return (
-    <form className="editorial-capture" onSubmit={handleSubscribe} noValidate>
-      <div className="editorial-capture-label text-parchment-600 dark:text-slate-400">
-        <span className="text-burnt-400 dark:text-amber-400">✱</span>
+    <form
+      className={isCard ? 'editorial-capture editorial-capture--card' : 'editorial-capture'}
+      onSubmit={handleSubscribe}
+      noValidate
+    >
+      <div
+        className={
+          isCard
+            ? 'editorial-capture-label editorial-capture-label--card text-burnt-400 dark:text-amber-400'
+            : 'editorial-capture-label text-parchment-600 dark:text-slate-400'
+        }
+      >
+        <span className={isCard ? 'editorial-capture-tick' : 'text-burnt-400 dark:text-amber-400'}>✱</span>
         <span>{label}</span>
+        {isCard && meta ? (
+          <span className="editorial-capture-meta text-parchment-500 dark:text-slate-400">{meta}</span>
+        ) : null}
       </div>
-      <div className="editorial-capture-title text-burnt-400 dark:text-amber-400">
+      <div
+        className={
+          isCard
+            ? 'editorial-capture-title editorial-capture-title--card text-charcoal-50 dark:text-parchment-100'
+            : 'editorial-capture-title text-burnt-400 dark:text-amber-400'
+        }
+      >
         {title}
       </div>
+      {isCard && promise ? (
+        <p className="editorial-capture-promise text-parchment-600 dark:text-slate-300">{promise}</p>
+      ) : null}
       {status === 'success' ? (
         <div className="editorial-capture-fine text-burnt-400 dark:text-amber-400" role="status">
           ✓ Subscribed. Check your inbox to confirm.
@@ -88,7 +125,7 @@ export function EditorialNewsletter({
               disabled={status === 'submitting'}
               className="inline-flex items-center justify-center px-5 py-[13px] text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors disabled:opacity-60"
             >
-              {status === 'submitting' ? 'Subscribing…' : 'Subscribe →'}
+              {status === 'submitting' ? 'Subscribing…' : ctaLabel}
             </button>
           </div>
           <div className="editorial-capture-fine text-parchment-500 dark:text-slate-500">

--- a/src/styles/editorial-home.css
+++ b/src/styles/editorial-home.css
@@ -57,14 +57,16 @@
 }
 
 /* ---------- Hero typography -------------------------------- */
+/* Sizing is intentionally compact: the newsletter capture is the dominant
+ * CTA and must remain above the fold on standard 1080p viewports. */
 .editorial-hero-h1 {
   font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
   font-weight: 800;
-  font-size: clamp(40px, 5vw, 58px);
-  line-height: 1.08;
+  font-size: clamp(34px, 4vw, 48px);
+  line-height: 1.05;
   letter-spacing: -0.025em;
   text-wrap: balance;
-  margin: 16px 0 0;
+  margin: 10px 0 0;
 }
 
 .editorial-eyebrow {
@@ -76,11 +78,47 @@
 }
 
 .editorial-lede {
-  margin: 28px 0 0;
-  font-size: 19px;
-  line-height: 1.6;
+  margin: 20px 0 0;
+  font-size: 16px;
+  line-height: 1.55;
   max-width: 56ch;
   text-wrap: pretty;
+}
+
+/* Lightweight greeting — sits between the headline and the lede.
+ * Visually nudges the lede up by overriding its top margin. */
+.editorial-greeting {
+  margin: 18px 0 0;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 600;
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.editorial-greeting-wave {
+  display: inline-block;
+  font-size: 19px;
+  transform-origin: 70% 70%;
+  animation: editorial-wave 2.4s ease-in-out 1.2s 2;
+}
+@keyframes editorial-wave {
+  0%, 60%, 100% { transform: rotate(0deg); }
+  10% { transform: rotate(14deg); }
+  20% { transform: rotate(-8deg); }
+  30% { transform: rotate(14deg); }
+  40% { transform: rotate(-4deg); }
+  50% { transform: rotate(10deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .editorial-greeting-wave {
+    animation: none;
+  }
+}
+.editorial-lede--tight {
+  margin-top: 8px;
 }
 
 /* Hero newsletter — inline (no card, no border) */
@@ -283,6 +321,278 @@
   letter-spacing: 0.1em;
   text-transform: uppercase;
   opacity: 0.6;
+}
+
+/* ============================================================
+ * Hero — Variation C (Contrarian / Insider)
+ * Strikethrough headline, bordered newsletter card, and a side
+ * column with portrait + plate caption + errata panel.
+ * ============================================================ */
+
+/* §-numbered eyebrow with leading rule */
+.editorial-eyebrow--ruled {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+.editorial-eyebrow-rule {
+  display: inline-block;
+  width: 28px;
+  height: 1px;
+  background: #e67e22;
+}
+.dark .editorial-eyebrow-rule {
+  background: #f39c12;
+}
+.editorial-eyebrow-section {
+  font-weight: 600;
+}
+
+/* Headline accents — strikethrough for retracted line, italic em
+ * for the follow-up. */
+.editorial-strike {
+  text-decoration: line-through;
+  text-decoration-color: #e67e22;
+  text-decoration-thickness: 3px;
+  color: #b8a88f;
+  font-weight: 700;
+}
+.dark .editorial-strike {
+  text-decoration-color: #f39c12;
+  color: #94a3b8;
+}
+.editorial-h1-em {
+  font-style: italic;
+  font-weight: 700;
+}
+
+/* Bordered newsletter capture card */
+.editorial-capture--card {
+  margin-top: 18px;
+  padding: 16px 20px 14px;
+  border: 1.5px solid #e67e22;
+  border-radius: 10px;
+  background: #fefdfb;
+  box-shadow:
+    0 4px 0 -1px #e67e22,
+    0 18px 32px -16px rgba(230, 126, 34, 0.35);
+  position: relative;
+  gap: 8px;
+  max-width: none;
+}
+.dark .editorial-capture--card {
+  border-color: #f39c12;
+  background: #1e293b;
+  box-shadow:
+    0 4px 0 -1px #f39c12,
+    0 18px 32px -16px rgba(243, 156, 18, 0.4);
+}
+.editorial-capture--card .editorial-capture-tick {
+  font-size: 13px;
+}
+.editorial-capture-label--card {
+  margin-bottom: 4px;
+}
+.editorial-capture-label--card::after {
+  display: none;
+}
+.editorial-capture-meta {
+  margin-left: auto;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+}
+.editorial-capture-title--card {
+  font-size: 19px;
+  margin: 0 0 2px;
+  line-height: 1.25;
+  text-wrap: balance;
+}
+.editorial-capture-promise {
+  margin: 2px 0 6px;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+.editorial-capture-promise b {
+  color: #2c3e50;
+  font-weight: 600;
+}
+.dark .editorial-capture-promise b {
+  color: #fbf7f0;
+}
+
+/* Right column — portrait + plate caption + errata stack */
+.editorial-hero-c-side {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 320px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+@media (min-width: 1024px) {
+  .editorial-hero-c-side {
+    max-width: 320px;
+    margin-left: 0;
+    margin-right: 0;
+    padding-top: 4px;
+  }
+}
+.editorial-portrait--c {
+  /* Slightly squarer than 4/5 so portrait + plate + errata fit
+   * without dominating the column. Mirrors the design's 280px frame. */
+  aspect-ratio: 4 / 4.6;
+}
+.editorial-portrait-plate {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(139, 115, 85, 0.25);
+  opacity: 0.75;
+}
+.dark .editorial-portrait-plate {
+  border-bottom-color: rgba(148, 163, 184, 0.2);
+}
+
+/* Errata panel — strikethrough rhetoric on a parchment card */
+.editorial-erratum {
+  margin-top: 4px;
+  background: #fefdfb;
+  border: 1px dashed #b8a88f;
+  border-radius: 6px;
+  padding: 14px 16px;
+  position: relative;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+}
+.dark .editorial-erratum {
+  background: #1e293b;
+  border-color: #475569;
+}
+.editorial-erratum-stamp {
+  position: absolute;
+  top: -10px;
+  right: 18px;
+  background: #fbf7f0;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #ef4444;
+  font-weight: 700;
+  padding: 2px 8px;
+  border: 1px solid #ef4444;
+  border-radius: 3px;
+  transform: rotate(-2deg);
+}
+.dark .editorial-erratum-stamp {
+  background: #1a1a2e;
+}
+.editorial-erratum-head {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.editorial-erratum-head::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(139, 115, 85, 0.3);
+}
+.dark .editorial-erratum-head::after {
+  background: rgba(148, 163, 184, 0.25);
+}
+.editorial-erratum-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.editorial-erratum-list li {
+  padding: 5px 0;
+  border-bottom: 1px solid rgba(139, 115, 85, 0.18);
+  font-size: 13px;
+  color: #b8a88f;
+  text-decoration: line-through;
+  text-decoration-color: rgba(230, 126, 34, 0.6);
+  text-decoration-thickness: 2px;
+  list-style: none;
+}
+.dark .editorial-erratum-list li {
+  color: #94a3b8;
+  border-bottom-color: rgba(148, 163, 184, 0.15);
+  text-decoration-color: rgba(243, 156, 18, 0.55);
+}
+.editorial-erratum-list li:last-child {
+  border-bottom: 0;
+}
+.editorial-erratum-keep {
+  text-decoration: none !important;
+  color: #2c3e50 !important;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 14px !important;
+  padding-top: 9px !important;
+}
+.dark .editorial-erratum-keep {
+  color: #fbf7f0 !important;
+}
+.editorial-erratum-keep::before {
+  content: '↳ ';
+  color: #e67e22;
+  font-style: normal;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  margin-right: 4px;
+}
+.dark .editorial-erratum-keep::before {
+  color: #f39c12;
+}
+
+/* Stack the side column under the headline on tablet/mobile */
+@media (max-width: 1023px) {
+  .editorial-hero-c-side {
+    margin-top: 8px;
+    max-width: 480px;
+  }
+}
+@media (max-width: 640px) {
+  .editorial-capture--card {
+    padding: 18px 18px 16px;
+  }
+  .editorial-capture-title--card {
+    font-size: 18px;
+  }
+  .editorial-capture-meta {
+    display: none;
+  }
+  .editorial-hero-c-side {
+    gap: 10px;
+  }
+  .editorial-portrait--c {
+    aspect-ratio: 4 / 4.4;
+    max-width: 280px;
+    margin: 0 auto;
+  }
+  .editorial-portrait-plate {
+    max-width: 280px;
+    margin: 0 auto;
+    width: 100%;
+  }
+  .editorial-erratum {
+    padding: 12px 14px;
+  }
+  .editorial-erratum-list li {
+    font-size: 12.5px;
+  }
 }
 
 /* ---------- Stat row --------------------------------------- */


### PR DESCRIPTION
## Summary

Replaces the homepage hero with **Variation C** of the hero redesign handoff — the contrarian/insider angle. Newsletter capture is the dominant CTA and is sized to stay above the fold.

- **Strikethrough headline** — "Most AI advice ~~is bullshit.~~ *Here's what actually ships.*"
- **"Hi, I'm Zack 👋"** greeting above the lede, in accent color with a brief wave animation
- **Subhead** leads with "I'm an AI engineer on the Applied AI team at WorkOS" — WorkOS-as-auth-for-the-labs positioning, AI enablement framing
- **Bordered newsletter card** with offset accent shadow, "5,000+ engineers" meta, "Dispatches from the edge of applied AI" headline, and "What lands in your inbox" promise
- **Side column** — portrait + Plate I caption + Errata panel ("Things I will not write about") with strikethrough rhetoric
- **Tightened hero typography** so the capture button lands above the fold on standard viewports
- **Responsive** at 1023px (side stacks) and 640px (compact card, hidden meta caption, smaller headline)

## What changed

- `src/app/HomepageClientComponent.tsx` — rewrote `EditorialHero`; removed orphan `ConsultationForm` modal
- `src/components/EditorialNewsletter.tsx` — added `variant: 'inline' | 'card'` with optional `meta`/`promise`/`ctaLabel`; inline default preserves existing consumers
- `src/styles/editorial-home.css` — greeting + wave, ruled eyebrow, strike, errata panel, capture card; hero typography compacted

## Test plan

- [ ] Verify newsletter capture button is above the fold on a 1080p viewport
- [ ] Confirm portrait, plate caption, and Errata render in the right column on desktop
- [ ] Tablet (≤1023px): side column stacks under the main column, capture card stays full-width
- [ ] Mobile (≤640px): capture padding tightens, meta caption hides, form fields stack
- [ ] Dark mode: strikethrough, errata stamp, and capture borders use amber accents
- [ ] Submit the newsletter form (sanity check end-to-end)
- [ ] Confirm `npm run build` is green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily presentation/UX changes to the homepage hero plus a backwards-compatible prop expansion on `EditorialNewsletter`; low risk aside from potential styling/regression in newsletter rendering across pages.
> 
> **Overview**
> Reworks the homepage hero into a new “contrarian/insider” layout: strikethrough headline + greeting, updated lede/positioning copy, new secondary links, and a right-side column with portrait plate + an “Errata” panel.
> 
> Makes the newsletter capture the dominant CTA by extending `EditorialNewsletter` with a `variant="card"` mode (optional `meta`, `promise`, and custom `ctaLabel`) and wiring the hero to use the new card variant.
> 
> Removes the homepage consultation modal/CTA flow and adds substantial new CSS to support the new hero typography, newsletter card styling, errata panel, and responsive/dark-mode tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ed9c924951d0313085e67678896ee928303f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->