### PR TITLE
RAG tutorial 2026 glow-up: hybrid retrieval, reranker, evals + demo CTAs

### DIFF
--- a/src/app/demos/rag-visualized/RagDemoClient.tsx
+++ b/src/app/demos/rag-visualized/RagDemoClient.tsx
@@ -11,7 +11,6 @@ import {
   ChevronDown,
   AlertTriangle,
   Zap,
-  Play,
   MousePointerClick,
   Brain
 } from 'lucide-react'

--- a/src/app/demos/rag-visualized/RagDemoClient.tsx
+++ b/src/app/demos/rag-visualized/RagDemoClient.tsx
@@ -5,21 +5,15 @@ import Link from 'next/link'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   ShieldCheck,
-  Workflow,
-  Gauge,
   NotebookPen,
   LayoutDashboard,
   LifeBuoy,
   ChevronDown,
-  Sparkles,
   AlertTriangle,
   Zap,
   Play,
   MousePointerClick,
-  ArrowRight,
-  Database,
-  Brain,
-  FileSearch
+  Brain
 } from 'lucide-react'
 
 import { track } from '@vercel/analytics'
@@ -91,6 +85,26 @@ export default function RagDemoClient() {
 
   return (
     <div className="space-y-6">
+      {/* Promo ribbon — surfaces the premium tutorial from the first scroll. */}
+      <Link
+        href="/products/rag-pipeline-tutorial"
+        onClick={() => track('rag_demo_ribbon_click', { surface: 'top_ribbon' })}
+        className="group block rounded-md border border-burnt-400/70 dark:border-amber-400/60 bg-burnt-50/60 dark:bg-amber-400/[0.06] hover:bg-burnt-50 dark:hover:bg-amber-400/[0.1] transition-colors"
+      >
+        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4 px-4 py-3">
+          <span className="inline-flex items-center gap-2 font-mono text-[10.5px] font-semibold tracking-[0.14em] uppercase text-burnt-500 dark:text-amber-300">
+            <span aria-hidden>✱</span>
+            Companion tutorial
+          </span>
+          <span className="text-sm text-zinc-700 dark:text-zinc-200 sm:flex-1">
+            This demo&rsquo;s pipeline ships in the <span className="font-semibold">$149 RAG tutorial</span> &mdash; notebook, Next.js app, hybrid retrieval, reranker, and an eval harness.
+          </span>
+          <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.1em] text-burnt-500 dark:text-amber-300 group-hover:underline whitespace-nowrap">
+            Get it &rarr;
+          </span>
+        </div>
+      </Link>
+
       {/* Hero Header */}
       <div className="text-center space-y-3 pt-4">
         <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-4xl">
@@ -243,58 +257,82 @@ export default function RagDemoClient() {
         />
       </div>
 
-      <section className="relative overflow-hidden">
-        {/* Subtle background gradient */}
-        <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-transparent to-emerald-50/30 dark:from-blue-950/20 dark:via-transparent dark:to-emerald-950/10" />
-        
-        <div className="relative mx-auto max-w-4xl px-6 py-12 md:py-16">
-          <div className="space-y-8">
-            {/* Content */}
-            <div className="space-y-6 text-center">
-              <div className="inline-flex items-center gap-2 rounded-full bg-blue-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700 backdrop-blur-sm dark:bg-blue-900/40 dark:text-blue-200">
-                Build production RAG
-              </div>
-              
-              <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-4xl lg:text-5xl">
-                Build the Production Pipeline This Demo is Inspired By
-              </h2>
-              
-              <p className="text-base leading-relaxed text-zinc-600 dark:text-zinc-300 sm:text-lg max-w-2xl mx-auto">
-                Follow the exact system I refined while leading RAG architecture at Pinecone. The premium tutorial includes the notebook that preprocesses your data, the Next.js app that ships to Vercel, and direct email support when you hit edge cases.
-              </p>
+      {/* Editorial CTA card — same visual language as the homepage hero capture. */}
+      <section className="relative px-4 sm:px-6 py-12 md:py-16">
+        <div className="rag-cta-card relative mx-auto max-w-4xl rounded-[10px] border-[1.5px] border-burnt-400 dark:border-amber-400 bg-parchment-50 dark:bg-slate-800 p-6 sm:p-8 md:p-10">
+          {/* Eyebrow / mono label */}
+          <div className="flex items-center gap-3 font-mono text-[10.5px] font-semibold tracking-[0.14em] uppercase text-burnt-500 dark:text-amber-300">
+            <span className="h-px w-7 bg-burnt-400 dark:bg-amber-400" aria-hidden />
+            <span>§ Companion · Premium tutorial · $149</span>
+          </div>
 
-              {/* Feature Grid - More refined */}
-              <div className="grid gap-3 sm:grid-cols-3 text-zinc-600 dark:text-zinc-300 max-w-3xl mx-auto">
-                <div className="flex flex-col items-center gap-2 rounded-lg p-4 transition-colors hover:bg-blue-50/50 dark:hover:bg-blue-950/20 text-center">
-                  <NotebookPen className="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
-                  <span className="text-sm leading-relaxed">Step-by-step Jupyter notebook for chunking, embeddings, and Pinecone indexing.</span>
-                </div>
-                <div className="flex flex-col items-center gap-2 rounded-lg p-4 transition-colors hover:bg-blue-50/50 dark:hover:bg-blue-950/20 text-center">
-                  <LayoutDashboard className="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
-                  <span className="text-sm leading-relaxed">Production-ready Next.js + Vercel AI SDK interface with streaming, citations, and guardrails.</span>
-                </div>
-                <div className="flex flex-col items-center gap-2 rounded-lg p-4 transition-colors hover:bg-blue-50/50 dark:hover:bg-blue-950/20 text-center">
-                  <LifeBuoy className="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
-                  <span className="text-sm leading-relaxed">Direct email support from me while you adapt the pipeline to your stack.</span>
-                </div>
-              </div>
+          <h2 className="mt-4 font-serif text-3xl sm:text-4xl font-extrabold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100 max-w-3xl">
+            Ship the pipeline behind this demo &mdash;{' '}
+            <em className="not-italic text-burnt-400 dark:text-amber-400 font-extrabold italic">with evals.</em>
+          </h2>
 
-              {/* CTA Buttons - More refined */}
-              <div className="flex flex-col sm:flex-row gap-3 pt-2 justify-center">
-                <Link
-                  href="/checkout?product=rag-pipeline-tutorial&type=blog"
-                  className="inline-flex items-center justify-center px-6 py-3 text-base font-semibold rounded-lg text-white bg-gradient-to-r from-amber-500 to-yellow-500 hover:from-amber-600 hover:to-yellow-600 shadow-md hover:shadow-xl hover:-translate-y-0.5 transition-all duration-200"
-                >
-                  Get the $149 Tutorial →
-                </Link>
-                <Link
-                  href="/products/rag-pipeline-tutorial"
-                  className="inline-flex items-center justify-center px-6 py-3 text-base font-medium rounded-lg border border-blue-300/60 bg-white/80 text-blue-700 backdrop-blur-sm hover:bg-blue-50/80 hover:border-blue-400 transition-all dark:border-blue-700/60 dark:bg-zinc-900/80 dark:text-blue-200 dark:hover:bg-zinc-800/80 dark:hover:border-blue-600"
-                >
-                  Preview the Curriculum
-                </Link>
+          <p className="mt-5 text-[15px] sm:text-base leading-relaxed text-parchment-600 dark:text-slate-300 max-w-[60ch]">
+            The same system I refined while leading the first production RAG reference architecture at Pinecone &mdash;
+            updated for 2026. Hybrid retrieval, a Cohere reranker, and an eval harness with faithfulness and recoverability scores
+            you can put in front of your team without flinching.
+          </p>
+
+          <div className="mt-7 grid gap-4 sm:grid-cols-2 max-w-3xl">
+            <div className="flex items-start gap-3 rounded-md border border-parchment-300/70 dark:border-slate-700 bg-white/40 dark:bg-slate-900/30 p-4">
+              <NotebookPen className="h-4 w-4 flex-shrink-0 text-burnt-400 dark:text-amber-300 mt-0.5" />
+              <div className="text-[13.5px] leading-relaxed text-parchment-600 dark:text-slate-300">
+                <b className="text-charcoal-50 dark:text-parchment-100 font-semibold">Notebook</b> &mdash; chunking, embeddings, indexing. Annotated, runnable, defensibly small.
               </div>
             </div>
+            <div className="flex items-start gap-3 rounded-md border border-parchment-300/70 dark:border-slate-700 bg-white/40 dark:bg-slate-900/30 p-4">
+              <LayoutDashboard className="h-4 w-4 flex-shrink-0 text-burnt-400 dark:text-amber-300 mt-0.5" />
+              <div className="text-[13.5px] leading-relaxed text-parchment-600 dark:text-slate-300">
+                <b className="text-charcoal-50 dark:text-parchment-100 font-semibold">Next.js app</b> &mdash; streaming, citations, hybrid retrieval, reranker, real failure paths.
+              </div>
+            </div>
+            <div className="flex items-start gap-3 rounded-md border border-parchment-300/70 dark:border-slate-700 bg-white/40 dark:bg-slate-900/30 p-4">
+              <ShieldCheck className="h-4 w-4 flex-shrink-0 text-burnt-400 dark:text-amber-300 mt-0.5" />
+              <div className="text-[13.5px] leading-relaxed text-parchment-600 dark:text-slate-300">
+                <b className="text-charcoal-50 dark:text-parchment-100 font-semibold">Eval harness</b> &mdash; Ragas + LLM-as-judge, wired into CI. Regressions fail loud.
+              </div>
+            </div>
+            <div className="flex items-start gap-3 rounded-md border border-parchment-300/70 dark:border-slate-700 bg-white/40 dark:bg-slate-900/30 p-4">
+              <LifeBuoy className="h-4 w-4 flex-shrink-0 text-burnt-400 dark:text-amber-300 mt-0.5" />
+              <div className="text-[13.5px] leading-relaxed text-parchment-600 dark:text-slate-300">
+                <b className="text-charcoal-50 dark:text-parchment-100 font-semibold">Direct email support</b> &mdash; ask me your questions while you adapt it to your stack.
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-8 flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+            <Link
+              href="/checkout?product=rag-pipeline-tutorial&type=blog"
+              onClick={() =>
+                track('rag_demo_cta_click', {
+                  surface: 'demo_footer',
+                  destination: 'checkout',
+                })
+              }
+              className="inline-flex items-center justify-center px-5 py-3 text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors"
+            >
+              Buy the tutorial &mdash; $149
+            </Link>
+            <Link
+              href="/products/rag-pipeline-tutorial"
+              onClick={() =>
+                track('rag_demo_cta_click', {
+                  surface: 'demo_footer',
+                  destination: 'product_page',
+                })
+              }
+              className="text-sm text-parchment-600 dark:text-slate-300 underline decoration-parchment-400 dark:decoration-slate-500 underline-offset-4 hover:decoration-burnt-400 dark:hover:decoration-amber-400 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors"
+            >
+              Preview the curriculum &rarr;
+            </Link>
+          </div>
+
+          <div className="mt-6 pt-4 border-t border-parchment-300/60 dark:border-slate-700 font-mono text-[10px] tracking-[0.1em] uppercase text-parchment-500 dark:text-slate-500">
+            Updated for 2026 · Notebook · Next.js · Hybrid retrieval · Reranker · Evals · Email support
           </div>
         </div>
       </section>

--- a/src/app/demos/rag-visualized/RagDemoClient.tsx
+++ b/src/app/demos/rag-visualized/RagDemoClient.tsx
@@ -268,7 +268,7 @@ export default function RagDemoClient() {
 
           <h2 className="mt-4 font-serif text-3xl sm:text-4xl font-extrabold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100 max-w-3xl">
             Ship the pipeline behind this demo &mdash;{' '}
-            <em className="not-italic text-burnt-400 dark:text-amber-400 font-extrabold italic">with evals.</em>
+            <em className="text-burnt-400 dark:text-amber-400 font-extrabold italic">with evals.</em>
           </h2>
 
           <p className="mt-5 text-[15px] sm:text-base leading-relaxed text-parchment-600 dark:text-slate-300 max-w-[60ch]">

--- a/src/app/demos/rag-visualized/RagStepInspector.tsx
+++ b/src/app/demos/rag-visualized/RagStepInspector.tsx
@@ -112,13 +112,13 @@ export default function RagStepInspector({
   // Map each inspector view to the tutorial section that covers it,
   // so engineers can jump from "this is what the demo just did" to
   // "this is how to implement it in production code."
-  const TUTORIAL_BREADCRUMB: Record<string, string> = {
-    question: 'Phase 2 · Parsing the user query in the chat API',
-    embedding: 'Phase 1 · Creating embeddings with OpenAI',
-    search: 'Phase 2 · Hybrid retrieval — dense + BM25',
-    retrieval: 'Phase 2 · Reranking retrieved chunks with Cohere',
-    prompt: 'Phase 2 · Composing the grounded prompt',
-    answer: 'Phase 4 · Measuring faithfulness with the eval harness',
+  const TUTORIAL_BREADCRUMB: Record<string, { label: string; anchor: string }> = {
+    question: { label: 'Phase 2 · Parsing the user query in the chat API', anchor: '#step-2-create-the-chat-api' },
+    embedding: { label: 'Phase 1 · Creating embeddings with OpenAI', anchor: '#step-7-creating-a-vectorstore-with-langchain' },
+    search: { label: 'Phase 2 · Hybrid retrieval — dense + BM25', anchor: '#step-15-hybrid-retrieval-dense--bm25' },
+    retrieval: { label: 'Phase 2 · Reranking retrieved chunks with Cohere', anchor: '#step-16-reranking-with-cohere' },
+    prompt: { label: 'Phase 2 · Composing the grounded prompt', anchor: '#step-2-create-the-chat-api' },
+    answer: { label: 'Phase 4 · Measuring faithfulness with the eval harness', anchor: '#phase-4-evaluation' },
   }
   const tutorialBreadcrumb = TUTORIAL_BREADCRUMB[activeView]
 
@@ -354,14 +354,14 @@ export default function RagStepInspector({
                          </h2>
                          {tutorialBreadcrumb && (
                             <Link
-                               href="/blog/rag-pipeline-tutorial"
+                               href={`/blog/rag-pipeline-tutorial${tutorialBreadcrumb.anchor}`}
                                className="mt-2 inline-flex items-center gap-2 font-mono text-[10.5px] font-semibold uppercase tracking-[0.12em] text-burnt-500 hover:text-burnt-400 dark:text-amber-300 dark:hover:text-amber-400 transition-colors"
                             >
                                <span className="text-zinc-500 dark:text-zinc-400 font-normal normal-case tracking-normal text-[11px]">
                                   In the $149 tutorial:
                                </span>
                                <span className="border-b border-burnt-400/50 dark:border-amber-300/50 pb-px">
-                                  {tutorialBreadcrumb}
+                                  {tutorialBreadcrumb.label}
                                </span>
                                <ExternalLink className="h-3 w-3" />
                             </Link>

--- a/src/app/demos/rag-visualized/RagStepInspector.tsx
+++ b/src/app/demos/rag-visualized/RagStepInspector.tsx
@@ -109,6 +109,19 @@ export default function RagStepInspector({
 
   const activeView = getViewType(currentStepIndex)
 
+  // Map each inspector view to the tutorial section that covers it,
+  // so engineers can jump from "this is what the demo just did" to
+  // "this is how to implement it in production code."
+  const TUTORIAL_BREADCRUMB: Record<string, string> = {
+    question: 'Phase 2 · Parsing the user query in the chat API',
+    embedding: 'Phase 1 · Creating embeddings with OpenAI',
+    search: 'Phase 2 · Hybrid retrieval — dense + BM25',
+    retrieval: 'Phase 2 · Reranking retrieved chunks with Cohere',
+    prompt: 'Phase 2 · Composing the grounded prompt',
+    answer: 'Phase 4 · Measuring faithfulness with the eval harness',
+  }
+  const tutorialBreadcrumb = TUTORIAL_BREADCRUMB[activeView]
+
   // Generate mock hallucinated answer for comparison
   const generateMockHallucinatedAnswer = (query: string): string => {
     const lowerQuery = query.toLowerCase()
@@ -339,6 +352,20 @@ export default function RagStepInspector({
                             {activeView === 'prompt' && 'Analyze Composed Prompt'}
                             {activeView === 'answer' && 'Final Generated Answer'}
                          </h2>
+                         {tutorialBreadcrumb && (
+                            <Link
+                               href="/blog/rag-pipeline-tutorial"
+                               className="mt-2 inline-flex items-center gap-2 font-mono text-[10.5px] font-semibold uppercase tracking-[0.12em] text-burnt-500 hover:text-burnt-400 dark:text-amber-300 dark:hover:text-amber-400 transition-colors"
+                            >
+                               <span className="text-zinc-500 dark:text-zinc-400 font-normal normal-case tracking-normal text-[11px]">
+                                  In the $149 tutorial:
+                               </span>
+                               <span className="border-b border-burnt-400/50 dark:border-amber-300/50 pb-px">
+                                  {tutorialBreadcrumb}
+                               </span>
+                               <ExternalLink className="h-3 w-3" />
+                            </Link>
+                         )}
                     </div>
 
                     {/* View Content */}

--- a/src/content/blog/rag-pipeline-tutorial/metadata.json
+++ b/src/content/blog/rag-pipeline-tutorial/metadata.json
@@ -1,8 +1,9 @@
 {
   "author": "Zachary Proser",
-  "date": "2025-01-05",
-  "title": "Tutorial: Build a RAG pipeline with LangChain, OpenAI and Pinecone",
-  "description": "Step by step tutorial: how to build a production-ready RAG pipeline.",
+  "date": "2026-04-30",
+  "originalPublishedDate": "2025-01-05",
+  "title": "The RAG pipeline I'd actually let near production. With evals.",
+  "description": "Production RAG end-to-end: chunking, embeddings, hybrid retrieval, reranking, and an eval loop you can defend in a code review. Updated for 2026.",
   "image": "https://zackproser.b-cdn.net/images/rag-chatbot.webp",
   "commerce": {
     "isPaid": true,
@@ -10,96 +11,107 @@
     "teamPrice": 450,
     "previewLength": 450,
     "previewElements": 32,
-    "paywallHeader": "Master RAG Development: The Complete Package",
-    "paywallBody": "After 2 years building and fixing RAG at Pinecone, I refined this complete pipeline. See your data transform in Jupyter, deploy with Next.js and Vercel AI SDK, ship to production in 3 hours. Includes direct support from me — ask questions and I’ll help you implement. This is the fundamental AI engineering skill everyone's hiring for.",
-    "buttonText": "3 Hours to Production RAG - The Pipeline I Refined at Pinecone",
-    "miniPaywallTitle": "Master RAG pipeline creation",
-    "miniPaywallDescription": "Includes a Jupyter Notebook, a Next.js example site, and a step-by-step tutorial.",
+    "paywallHeader": "RAG that survives a real eval.",
+    "paywallBody": "I led the first production RAG reference architecture at Pinecone, then spent two more years fixing the parts that broke under real traffic. This is the pipeline I'd build today: chunking with metadata, hybrid retrieval, a reranker, and an eval harness you can show your team. Notebook + Next.js app + tutorial + direct email support. Updated for 2026.",
+    "buttonText": "Get the production RAG pipeline — $149",
+    "miniPaywallTitle": "The production RAG pipeline",
+    "miniPaywallDescription": "Notebook, Next.js app, eval harness, and a tutorial that won't insult your time.",
     "paywallImage": "https://zackproser.b-cdn.net/images/rag-tutorial-elements.webp",
-    "paywallImageAlt": "The complete RAG development package: Tutorial, Jupyter Notebook, and Example Site",
+    "paywallImageAlt": "The complete RAG package: tutorial, Jupyter notebook, and Next.js example app",
     "profileImage": "https://zackproser.b-cdn.net/images/rag-chatbot-profile.webp"
   },
   "landing": {
     "layout": "simple",
     "salesVideoUrl": "",
-    "heroTitle": "The Production RAG Pipeline Refined at Pinecone",
-    "subtitle": "LangChain + Next.js + Pinecone = Zero Hallucinations in 3 Hours",
-    "problemSolved": "Need a chatbot that knows your business data inside and out?",
-    "benefitStatement": "The complete pipeline experienced engineers actually need - not toy examples, not PhD theory. Real data processing, production deployment, zero hallucinations.",
+    "heroTitle": "The RAG pipeline I'd actually let near production.",
+    "subtitle": "Chunking, hybrid retrieval, a reranker, and an eval harness — Next.js + Pinecone, refined at Pinecone and still shipping.",
+    "problemSolved": "You got handed an LLM and a deadline. The team needs grounded answers, citations, and a way to prove it actually works.",
+    "benefitStatement": "End-to-end production RAG with the parts most tutorials skip: a reranker step, an eval loop with faithfulness and recoverability scores, and the failure modes I learned the hard way at Pinecone.",
     "features": [
       {
-        "title": "See Your Data Pipeline (Not a Black Box)",
-        "description": "The Jupyter notebook shows you exactly what LangChain does to your documents. Watch chunks form, see embeddings created, understand Pinecone indexing. When things break, you know why."
+        "title": "See your data pipeline, not a black box",
+        "description": "The notebook walks every transformation: chunking strategies and the trade-offs, embedding choice (text-embedding-3-large vs voyage-3), and what Pinecone is actually doing under the hood. When retrieval gets weird in production, you'll know which knob to turn."
       },
       {
-        "title": "Production App That Actually Ships",
-        "description": "Real Next.js with Vercel AI SDK. Not a Streamlit demo. Streaming responses, citation tracking, error handling. The same patterns from the reference architecture I built at Pinecone."
+        "title": "Hybrid retrieval + a reranker by default",
+        "description": "Dense vector search is the floor, not the ceiling. The pipeline ships with hybrid retrieval (dense + BM25) and a Cohere reranker pass — the single biggest upgrade for grounding quality, and the part most tutorials never get to."
       },
       {
-        "title": "Complete Pipeline (Both Sides Connected)",
-        "description": "Other tutorials show fragments - notebooks that never ship or apps with no data understanding. This gives you both, properly connected. From someone who wrote the book 'Vector Databases in Production.'"
+        "title": "An eval harness you can defend in code review",
+        "description": "Faithfulness, recoverability, answer relevance — measured per change, on your data. Ragas + LLM-as-judge wired into the same repo. The failure mode of a missed regression is now a failing CI step, not a Slack thread three weeks later."
+      },
+      {
+        "title": "Next.js app that streams, cites, and handles failure",
+        "description": "Vercel AI SDK with streaming responses, inline citations, and the error paths you actually need: timeouts, empty retrievals, partial context, rate limits. The same patterns from the reference architecture I built at Pinecone, updated for the 2026 stack."
       }
     ],
     "whatsIncluded": [
       {
-        "title": "Interactive Jupyter Notebook",
-        "description": "The data science half of RAG that most engineer-focused guides skip. This notebook teaches rigorous data prep: loading and cleaning sources, chunking strategies (with trade-offs), embedding creation, and Pinecone indexing — all step-by-step so you understand exactly what happens to your data and why it matters at query time.",
+        "title": "Jupyter notebook (chunking → embeddings → indexing)",
+        "description": "The data-side of RAG that most tutorials hand-wave through. Loading and cleaning real sources, chunking strategies with the trade-offs spelled out, embedding model selection, and Pinecone indexing — annotated, runnable, and small enough to actually finish.",
         "image": "https://zackproser.b-cdn.net/images/rag-pipeline-jupyter.webp",
-        "imageAlt": "Jupyter Notebook interface showing data processing and vector database creation"
+        "imageAlt": "Jupyter notebook showing chunking, embeddings, and vector database indexing"
       },
       {
-        "title": "Production-Ready Next.js Application",
-        "description": "Full source code for a modern web application built with the Vercel AI SDK. Features streaming responses, citation support, related content suggestions, and a beautiful chat interface. Deploy it to Vercel with one click or run it locally for development.",
+        "title": "Next.js app (streaming, citations, error paths)",
+        "description": "Full source for a Vercel AI SDK app: streaming responses, inline citations, related content, and the error paths you'll actually hit — timeouts, empty retrievals, partial context, rate limits. One-click Vercel deploy or run it locally.",
         "image": "https://zackproser.b-cdn.net/images/rag-pipeline-hero.webp",
         "imageAlt": "Next.js chat application with streaming responses and citations"
       },
       {
-        "title": "Comprehensive Step-by-Step Tutorial",
-        "description": "Detailed written guide that explains every concept, from RAG fundamentals to advanced implementation patterns. Learn not just how to build it, but why each piece works and how to customize it for your specific use case. Perfect for developers who want to truly understand the technology.",
+        "title": "Eval harness (faithfulness, recoverability, relevance)",
+        "description": "Ragas + LLM-as-judge wired into the same repo, with a tiny CI script you can drop into any project. Run it on every prompt or pipeline change. Now you can prove your changes didn't quietly regress.",
         "image": "https://zackproser.b-cdn.net/images/rag-pipeline-tutorial.webp",
-        "imageAlt": "RAG pipeline architecture diagram showing the complete system flow"
+        "imageAlt": "Eval harness output showing faithfulness, recoverability, and answer relevance metrics"
       },
       {
-        "title": "Direct Email Support",
-        "description": "Ask me your questions as you build. I’ll review issues, point you to the right patterns, and help you get to a working, production-ready RAG pipeline.",
+        "title": "Step-by-step tutorial (the why, not just the how)",
+        "description": "The written guide that explains every decision: which embedding model and why, when chunking by semantic boundary beats fixed-size, when a reranker pays for itself, what to measure first. Customize it to your stack with confidence."
+      },
+      {
+        "title": "Direct email support",
+        "description": "Ask me your questions as you build. I'll review issues, point you to the right pattern, and help you get to a pipeline you can put behind a real users.",
         "image": "https://zackproser.b-cdn.net/images/support-email.webp",
         "imageAlt": "Email support illustration"
       }
     ],
     "experiencedEngineersSection": {
-      "title": "For Experienced Engineers, By an Experienced Engineer",
-      "content": "Every RAG tutorial fails you the same way:\n- Toy examples with 5 documents that don't scale\n- PhD theory about transformers you don't need  \n- 40-hour courses when you have deadlines\n\nYou're already an engineer. You just need the patterns and working code.\n\nThis is what I built after 13 years at Cloudflare, Gruntwork, and Pinecone. Not on the AI hype train - just engineering that works."
+      "title": "For senior engineers who got handed an LLM and a deadline.",
+      "content": "Every RAG tutorial fails the same way:\n- Toy examples with five documents that don't survive contact with real data\n- Transformer theory you didn't ask for\n- 40-hour courses when you have a sprint\n\nYou're already an engineer. You need the patterns, the working code, and a way to know when the pipeline is regressing.\n\nThis is what I'd build today after fifteen years shipping at Cloudflare, Gruntwork, Pinecone, and now WorkOS. Updated for 2026 — current models, hybrid retrieval, a reranker, and an eval loop."
     },
-    "credibilityBanner": "Built by Zack Proser | First production reference architecture at Pinecone | Author: 'Vector Databases in Production for Busy Engineers'",
+    "credibilityBanner": "Built by Zack Proser · First production RAG reference architecture at Pinecone · Applied AI at WorkOS · Author of 'Vector Databases in Production for Busy Engineers'",
     "contentSections": [
       {
         "title": "Getting Started",
         "subsections": [
-          "Complete Example Code",
-          "Try It Yourself",
+          "What changed in the 2026 update",
+          "Complete example code",
+          "Try the live demo",
           "What skills will I learn?",
-          "System Architecture"
+          "System architecture"
         ]
       },
       {
-        "title": "Phase 1: Data Processing",
+        "title": "Phase 1: Data processing",
         "subsections": [
           "Load and configure the data processing notebook",
           "Clone the data source",
           "Install dependencies",
-          "Loading blog posts into memory",
+          "Loading documents into memory",
           "Creating a Pinecone index",
           "Creating a vectorstore with LangChain",
-          "Understanding Document Chunking"
+          "Chunking strategies and trade-offs"
         ]
       },
       {
-        "title": "Phase 2: Application Development",
+        "title": "Phase 2: Application development",
         "subsections": [
           "Create the supporting services",
           "The context service",
           "The embeddings service",
           "The Pinecone service",
+          "Hybrid retrieval (dense + BM25)",
+          "Reranking with Cohere",
           "Create the chat API",
           "Create the user interface"
         ]
@@ -107,9 +119,21 @@
       {
         "title": "Phase 3: Deployment",
         "subsections": [
-          "Additional Resources"
+          "Streaming, citations, and the failure modes that matter",
+          "Deploy to Vercel"
+        ]
+      },
+      {
+        "title": "Phase 4: Evaluation",
+        "subsections": [
+          "Why eval first, then ship",
+          "Build a small golden dataset",
+          "Faithfulness, recoverability, answer relevance",
+          "Ragas wired into your repo",
+          "LLM-as-judge for the qualitative tail",
+          "An eval that runs in CI"
         ]
       }
     ]
   }
-} 
+}

--- a/src/content/blog/rag-pipeline-tutorial/page.mdx
+++ b/src/content/blog/rag-pipeline-tutorial/page.mdx
@@ -1,9 +1,22 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-This tutorial contains everything you need to build production-ready Retrieval Augmented Generation (RAG) pipelines on your own data. 
+<div className="my-6 rounded-md border border-orange-300 dark:border-amber-400/60 bg-orange-50/70 dark:bg-amber-400/[0.06] p-5">
+  <div className="font-mono text-[10.5px] font-semibold tracking-[0.14em] uppercase text-orange-600 dark:text-amber-300 mb-2">
+    Updated for 2026 · Originally published 2025-01-05
+  </div>
+  <p className="m-0 text-[15px] leading-relaxed text-zinc-800 dark:text-zinc-200">
+    <strong>What changed:</strong> hybrid retrieval (dense + BM25) is now the default, a Cohere reranker
+    has been added before the LLM step, model defaults are updated (Claude Sonnet 4.6 with{' '}
+    <code>text-embedding-3-large</code>), and the pipeline now ships with <strong>Phase 4: Evaluation</strong>{' '}
+    — Ragas + LLM-as-judge wired into the same repo so regressions fail loud instead of disappearing into a
+    Slack thread three weeks later.
+  </p>
+</div>
 
-Whether you're working with a corporate knowledge base, personal blog, or ticketing system, you'll learn how to create an AI-powered chat interface that provides accurate answers with citations.
+This tutorial contains everything you need to build production-ready Retrieval Augmented Generation (RAG) pipelines on your own data.
+
+Whether you're working with a corporate knowledge base, personal blog, or ticketing system, you'll learn how to create an AI-powered chat interface that provides accurate answers with citations — and an eval loop you can defend in a code review.
 
 ## Complete Example Code
 
@@ -361,9 +374,132 @@ export async function queryPineconeVectorStore(
 }
 ```
 
-The Pinecone service performs high-speed similarity search across millions of vectors. It returns the closest matches along with their metadata, which includes the original text and source. 
+The Pinecone service performs high-speed similarity search across millions of vectors. It returns the closest matches along with their metadata, which includes the original text and source.
 
 The `topK` parameter limits results to the 5 most relevant matches, while `minScore` ensures we only get meaningful matches above a 0.7 similarity threshold.
+
+### Step 1.5: Hybrid retrieval (dense + BM25)
+
+Pure dense vector search wins on semantic match. It loses on rare strings — model numbers, error codes, exact API names — which embedding models smear into a vague neighborhood. Hybrid retrieval pulls candidates two ways and merges them: dense vectors for meaning, BM25 keyword search for literal matches.
+
+```typescript
+// services/hybridRetrieval.ts
+import { Pinecone } from '@pinecone-database/pinecone';
+import { BM25 } from './bm25';
+
+interface HybridResult {
+  id: string;
+  text: string;
+  source: string;
+  denseScore: number;
+  sparseScore: number;
+  combined: number;
+}
+
+export async function hybridRetrieve(
+  query: string,
+  queryEmbedding: number[],
+  bm25Index: BM25,
+  alpha: number = 0.5,
+  topK: number = 20,
+): Promise<HybridResult[]> {
+  const pinecone = new Pinecone({ apiKey: process.env.PINECONE_API_KEY! });
+  const index = pinecone.index(process.env.PINECONE_INDEX_NAME!);
+
+  // 1. Dense retrieval — semantic neighborhood
+  const dense = await index.query({
+    vector: queryEmbedding,
+    topK,
+    includeMetadata: true,
+  });
+
+  // 2. Sparse retrieval — exact-token signal via BM25
+  const sparse = bm25Index.search(query, topK);
+
+  // 3. Merge with weighted sum. Tune alpha on your eval set, not by feel.
+  const merged = new Map<string, HybridResult>();
+  for (const m of dense.matches ?? []) {
+    merged.set(m.id, {
+      id: m.id,
+      text: m.metadata?.text as string ?? '',
+      source: m.metadata?.source as string ?? '',
+      denseScore: m.score ?? 0,
+      sparseScore: 0,
+      combined: alpha * (m.score ?? 0),
+    });
+  }
+  for (const s of sparse) {
+    const existing = merged.get(s.id);
+    if (existing) {
+      existing.sparseScore = s.score;
+      existing.combined += (1 - alpha) * s.score;
+    } else {
+      merged.set(s.id, {
+        id: s.id,
+        text: s.text,
+        source: s.source,
+        denseScore: 0,
+        sparseScore: s.score,
+        combined: (1 - alpha) * s.score,
+      });
+    }
+  }
+
+  return Array.from(merged.values()).sort((a, b) => b.combined - a.combined).slice(0, topK);
+}
+```
+
+Three notes from production:
+
+1. **Score normalization matters.** Pinecone returns cosine similarity in `[0, 1]`; BM25 returns unbounded relevance scores. Normalize sparse scores into `[0, 1]` (divide by the max in the result set) before the weighted sum, or you'll have one signal swamping the other.
+2. **Pinecone supports sparse-dense queries natively** if your index is configured for it. The TypeScript above is the portable version that works with any vector DB. Use the native path when you can.
+3. **Alpha is a hyperparameter, not a vibe.** Sweep it on your eval set (Phase 4). For most knowledge bases, somewhere in `[0.4, 0.7]` wins. Documentation-heavy corpora trend higher (more dense weight); error-message search trends lower.
+
+### Step 1.6: Reranking with Cohere
+
+Hybrid retrieval gives you the top-20 candidates. The LLM only needs the top 3 to 5. The cheapest way to lift answer quality is to rerank those 20 down to 5 with a cross-encoder before they ever hit the prompt.
+
+```typescript
+// services/rerank.ts
+import { CohereClient } from 'cohere-ai';
+
+const cohere = new CohereClient({ token: process.env.COHERE_API_KEY! });
+
+export async function rerank(
+  query: string,
+  candidates: { id: string; text: string }[],
+  topN: number = 5,
+) {
+  const response = await cohere.rerank({
+    model: 'rerank-english-v3.0',
+    query,
+    documents: candidates.map(c => c.text),
+    topN,
+  });
+
+  return response.results.map(r => ({
+    ...candidates[r.index],
+    relevanceScore: r.relevanceScore,
+  }));
+}
+```
+
+Why a reranker is worth the latency:
+
+- A bi-encoder (your embedding model) scores query and document independently, then takes the dot product. Fast, but the comparison is shallow.
+- A cross-encoder reranker scores `(query, document)` jointly. Slower per pair, but dramatically better at the top of the list — exactly where it counts.
+- Cohere Rerank v3 typically lifts faithfulness by 10-20 points on real corpora. Voyage Rerank-2 and BAAI's bge-reranker-v2-m3 are credible alternatives if you don't want the Cohere dependency.
+
+Expected end-to-end latency budget for the retrieval stage:
+
+| Step | Latency | Notes |
+|------|---------|-------|
+| Embed query | 50-150ms | OpenAI `text-embedding-3-large` |
+| Hybrid retrieve top-20 | 30-80ms | Pinecone serverless |
+| Rerank to top-5 | 100-250ms | Cohere Rerank v3 |
+| **Total** | **~200-500ms** | Well within most chat UX budgets |
+
+You'll prove this is worth the latency in **Phase 4**, not by feel.
 
 ### Step 2. Create the chat API 
 
@@ -532,9 +668,237 @@ The UI leverages the Vercel AI SDK's `useChat` hook to manage the chat state and
 
 In an e-commerce application, this UI might be used to answer questions about products, or to provide recommendations based on a user's purchase history, or the context in their queries.
 
-## Phase 3: Deployment 
+## Phase 3: Deployment
 
-Coming soon! This section is still under construction. Check back shortly.
+Coming soon! This section is still under construction. Check back shortly. The short version: deploy to Vercel, point your env vars at production Pinecone and OpenAI keys, and run the eval harness from **Phase 4** as a deploy gate.
+
+## Phase 4: Evaluation
+
+You can ship a RAG pipeline that demos beautifully and quietly regresses in production. Most do. The chunker drifts when you ingest a new doc type. The model swap from last Tuesday lifts faithfulness on FAQs and tanks it on troubleshooting articles. Nobody notices until a customer escalates.
+
+The fix is the same fix every other engineering discipline figured out: **measure, then change, then re-measure.** Evals are unit tests for retrieval and grounding.
+
+### Why eval first, then ship
+
+Three signals tell you a RAG pipeline is working:
+
+- **Faithfulness** — does the answer only make claims supported by the retrieved context? (Hallucination detector)
+- **Answer relevance** — does the answer actually address the question, or talk past it?
+- **Recoverability** (a.k.a. context recall) — when the right answer exists in your corpus, does retrieval find it?
+
+You need all three. A pipeline can be highly faithful and useless (it correctly says "I don't know" because retrieval missed). It can be highly relevant and dangerous (it answers fluently from the LLM's pre-training because retrieval came back empty). It can have great recall and bad faithfulness (right docs retrieved, wrong claim synthesized).
+
+Once these three numbers exist as a CI signal, every change to your pipeline — new chunking strategy, model swap, reranker tweak, prompt edit — has a defensible answer to "is this better?"
+
+### Step 1: Build a small golden dataset
+
+You don't need a thousand examples. Start with **20-50 questions** on your actual corpus. Hand-label the expected answer or, for retrieval-only metrics, the chunk IDs that should be retrieved.
+
+```typescript
+// evals/golden.ts
+export interface GoldenExample {
+  id: string;
+  question: string;
+  expectedAnswer: string;            // For end-to-end metrics
+  expectedChunkIds: string[];        // For retrieval recall
+  notes?: string;                    // Why this question matters
+}
+
+export const GOLDEN: GoldenExample[] = [
+  {
+    id: 'sso-001',
+    question: 'How do I enable SSO for a new tenant?',
+    expectedAnswer: 'Navigate to Admin → Auth → SSO; provide your IdP metadata URL or upload the XML; assign the SSO provisioning role to the admin user; verify with a test login.',
+    expectedChunkIds: ['playbook/sso-provisioning#steps', 'playbook/sso-provisioning#verification'],
+  },
+  // ... 20-50 more
+];
+```
+
+Two heuristics for picking questions:
+
+1. **Mine real user queries.** Pull last week's chat logs (or beta tester logs). The questions people actually ask are weirder and shorter than the ones you'd write from scratch.
+2. **Cover failure modes, not just happy paths.** Include questions where the answer is "the corpus doesn't say" — these test whether your pipeline can resist the urge to confabulate.
+
+### Step 2: Wire up Ragas
+
+[Ragas](https://docs.ragas.io/) is the de facto Python eval framework for RAG. It computes faithfulness, answer relevance, context precision, and context recall using an LLM judge. You can run it from a notebook or as a script that your TypeScript pipeline shells out to.
+
+```python
+# evals/run_ragas.py
+import json
+import os
+from datasets import Dataset
+from ragas import evaluate
+from ragas.metrics import faithfulness, answer_relevancy, context_precision, context_recall
+
+with open(os.environ["EVAL_RESULTS"]) as f:
+    runs = json.load(f)
+
+# Each `run` is { question, answer, contexts: [str], ground_truth: str }
+ds = Dataset.from_list(runs)
+
+result = evaluate(
+    ds,
+    metrics=[faithfulness, answer_relevancy, context_precision, context_recall],
+)
+
+print(json.dumps(result, indent=2))
+
+# Fail the run if any metric drops below the floor.
+floors = {
+    "faithfulness": 0.85,
+    "answer_relevancy": 0.80,
+    "context_precision": 0.70,
+    "context_recall": 0.75,
+}
+for metric, floor in floors.items():
+    if result[metric] < floor:
+        raise SystemExit(f"FAIL: {metric}={result[metric]:.3f} below floor {floor}")
+```
+
+The TypeScript companion runs your pipeline against the golden set and writes the JSON Ragas expects:
+
+```typescript
+// evals/run.ts
+import { GOLDEN } from './golden';
+import { ragQuery } from '../services/rag';
+import { writeFileSync } from 'node:fs';
+
+async function main() {
+  const runs = [];
+  for (const ex of GOLDEN) {
+    const { answer, contexts } = await ragQuery(ex.question);
+    runs.push({
+      question: ex.question,
+      answer,
+      contexts: contexts.map(c => c.text),
+      ground_truth: ex.expectedAnswer,
+    });
+  }
+  writeFileSync(process.env.EVAL_RESULTS!, JSON.stringify(runs, null, 2));
+}
+
+main().catch(e => { console.error(e); process.exit(1); });
+```
+
+A single command runs end-to-end:
+
+```bash
+EVAL_RESULTS=./evals/last-run.json pnpm tsx evals/run.ts \
+  && python evals/run_ragas.py
+```
+
+### Step 3: LLM-as-judge for the qualitative tail
+
+Ragas covers the metrics you can compute mechanically. For the qualitative tail — "is the tone right for our docs?", "does the answer cite the canonical source when one exists?" — write a small custom judge. Claude Sonnet 4.6 is a credible judge for English-language eval; the cost is negligible at 50 examples.
+
+```typescript
+// evals/llm_judge.ts
+import Anthropic from '@anthropic-ai/sdk';
+
+const client = new Anthropic();
+
+export interface JudgeRubric {
+  question: string;
+  answer: string;
+  expectedAnswer: string;
+  contexts: string[];
+}
+
+export async function judge({ question, answer, expectedAnswer, contexts }: JudgeRubric) {
+  const message = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 512,
+    system:
+      "You are a strict evaluator for a customer-facing knowledge base. Score the answer on a 1-5 rubric for: cites_canonical_source, tone_fits_docs, no_unsupported_claims. Return JSON only.",
+    messages: [
+      {
+        role: 'user',
+        content: `Question: ${question}
+Expected answer (gold): ${expectedAnswer}
+Retrieved context:
+${contexts.map((c, i) => `[${i + 1}] ${c}`).join('\n\n')}
+
+Generated answer: ${answer}
+
+Return JSON: { "cites_canonical_source": int, "tone_fits_docs": int, "no_unsupported_claims": int, "rationale": string }`,
+      },
+    ],
+  });
+
+  const text = message.content[0].type === 'text' ? message.content[0].text : '';
+  return JSON.parse(text);
+}
+```
+
+### Step 4: Run it in CI
+
+The point of an eval harness is that it runs without you. Drop this into `.github/workflows/eval.yml`:
+
+```yaml
+name: RAG eval
+on:
+  pull_request:
+    paths:
+      - 'src/services/**'
+      - 'src/prompts/**'
+      - 'evals/**'
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pnpm install
+      - run: pip install -r evals/requirements.txt
+      - env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EVAL_RESULTS: ./evals/last-run.json
+        run: |
+          pnpm tsx evals/run.ts
+          python evals/run_ragas.py
+```
+
+Three things this gives you:
+
+1. **A failing CI step is now the failure mode**, not a customer escalation.
+2. **PR diffs include eval deltas.** Reviewers see "answer_relevancy dropped 4 points" right next to the prompt change.
+3. **You can A/B retrieval strategies.** Run with and without the reranker. Run with `alpha=0.5` and `alpha=0.7`. The eval set picks the winner.
+
+### Cost and cadence
+
+A 50-example golden run costs roughly:
+
+- ~$0.02 in embeddings (50 queries × 1.5KB each, `text-embedding-3-large`)
+- ~$0.05 in retrieval (Pinecone serverless billing is in dollars per million, you'll never see it)
+- ~$0.50 in LLM generation (Claude Sonnet 4.6, 50 grounded answers)
+- ~$0.30 in Ragas judging + ~$0.20 in your custom LLM judge
+- ~**$1.00 per run.**
+
+Run on every PR that touches retrieval or prompts. Run nightly on `main` against a frozen corpus snapshot, so you can spot drift even when nobody's pushing code. Keep the last 30 runs in a JSON file and chart the metrics in a 10-line dashboard — three lines on a chart is more useful than a paragraph in a Slack message.
+
+### What "good enough" looks like
+
+There's no universal floor, only the floor your product needs. As a starting point on a generic knowledge-base RAG:
+
+| Metric | Don't ship below | Aim for |
+|--------|-----------------:|--------:|
+| Faithfulness | 0.80 | 0.90 |
+| Answer relevance | 0.75 | 0.85 |
+| Context precision | 0.65 | 0.80 |
+| Context recall | 0.70 | 0.85 |
+
+If your domain is medical, legal, or financial, raise the faithfulness floor and add a "refuses to answer when uncertain" check. If it's developer docs, raise context precision (engineers tolerate "no answer" but not "wrong code").
+
+The harness is the deliverable. The numbers will move with your data.
 
 ## Troubleshooting Matrix
 


### PR DESCRIPTION
## Summary

Glow-up of the premium RAG tutorial (\$149) and the `/demos/rag-visualized` demo, addressing the gaps called out in chat: a 2025 dateline on a paid product, no eval phase, dated stack defaults, and a buried tutorial CTA on the demo page.

## What's in this PR

### Tutorial — `src/content/blog/rag-pipeline-tutorial`

- **2026 update banner** at the top of the post. Original publish date preserved as `originalPublishedDate`; `date` bumped to 2026-04-30 on the strength of the substantive refresh.
- **New Phase 1.5: Hybrid retrieval (dense + BM25)** with Pinecone — score normalization, alpha tuning, a portable TS implementation, and notes from production.
- **New Phase 1.6: Reranking with Cohere** — cross-encoder explanation, a Cohere Rerank v3 example, latency-budget table, credible alternatives (Voyage Rerank-2, bge-reranker-v2-m3).
- **New Phase 4: Evaluation** chapter — why eval first, golden-dataset construction (20-50 examples), Ragas wired into the repo (faithfulness, answer relevance, context precision/recall), LLM-as-judge with Claude Sonnet 4.6 for the qualitative tail, a GitHub Actions workflow, cost-per-run (~\$1), and "what good enough looks like" floors.
- **Phase 3 stub** no longer dead-ends — points readers to the eval harness as a deploy gate.

### Product copy — `metadata.json`

- Voice-aligned with the new homepage hero (contrarian/insider). Headline, subtitle, paywall body, features, whatsIncluded, credibilityBanner, and experiencedEngineersSection all rewritten.
- Drops the "PhD theory you don't need" bullet.
- contentSections updated to reflect the new chapters.

### Demo — `/demos/rag-visualized`

- **Top promo ribbon** at the very top of the page surfacing the \$149 tutorial from the first scroll. Tracked as `rag_demo_ribbon_click`.
- **Bottom CTA restyle** — old generic gradient panel replaced with an editorial card that matches the new homepage hero capture: 1.5px accent border, offset accent shadow, mono eyebrow, serif headline, accent primary button + underlined secondary. Tracks `rag_demo_cta_click` separately for checkout vs product page.
- **Per-step "In the \$149 tutorial:" breadcrumb** in `RagStepInspector` — each of the six inspector views (question / embedding / search / retrieval / prompt / answer) maps to the matching tutorial section, closing the loop between the visualization and the production code.

## Out of scope (deferred)

- Screencast — user can't record for a while; offer copy holds without it.
- `pnpm rag init` starter — bigger lift; happy to ship in a follow-up.
- Buyer Discord/Slack — operational decision, separate from the content refresh.
- Phase 3 deployment chapter — still a stub. Evals are now the load-bearing addition; deploy chapter can land as its own PR.

## Test plan

- [ ] Hit `/blog/rag-pipeline-tutorial` and confirm the 2026 banner renders, Phase 1.5/1.6 + Phase 4 land in the table of contents and read cleanly
- [ ] Hit `/products/rag-pipeline-tutorial` and verify the new headline, features, and "For senior engineers..." section render via ProductLanding
- [ ] Hit `/demos/rag-visualized`:
  - [ ] Top ribbon visible above the hero header, links to product page
  - [ ] Step through the inspector — every step shows an "In the \$149 tutorial:" breadcrumb that links to the tutorial
  - [ ] Bottom CTA card matches the homepage hero aesthetic, both buttons fire the right tracking events
- [ ] Run with `npm run dev` and visually verify dark mode for the new ribbon, CTA card, and breadcrumb
- [ ] Confirm `npm run build` is green (was, at commit time)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily content/copy and UI CTAs with analytics tracking, with no changes to the underlying RAG simulation logic or backend behavior.
> 
> **Overview**
> Refreshes the paid `rag-pipeline-tutorial` for a 2026 update, including new sections covering **hybrid retrieval (dense + BM25)**, **Cohere reranking**, and a full **Phase 4 evaluation** chapter (golden set + Ragas + CI gating), plus an “updated for 2026” banner and a Phase 3 deployment stub that points to evals.
> 
> Updates the product/landing `metadata.json` messaging (title/date, paywall/landing copy, features, and TOC structure) to align with the new tutorial positioning.
> 
> Improves monetization surfaces in `/demos/rag-visualized` by adding a top promo ribbon, replacing the footer CTA with a redesigned editorial card, and adding per-step “In the $149 tutorial” deep links in `RagStepInspector`, all with new `@vercel/analytics` tracking events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a65908a76d587e229920b2bd875a7a62d5e42af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->