### PR TITLE
Retitle current role to AI Engineer · Applied AI at WorkOS

### DIFF
--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -9,7 +9,7 @@ import { resumeData } from "@/data/resume"
 const data = {
   title: "About Zachary Proser",
   description:
-    "Full-stack open-source hacker, technical writer, and Developer Experience Engineer at WorkOS.",
+    "AI Engineer on the Applied AI team at WorkOS. Full-stack open-source hacker, technical writer, and operator behind Modern Coding.",
 }
 
 const ogUrl = generateOgUrl(data)
@@ -32,7 +32,7 @@ export const metadata = {
 // Career history with additional blurbs for the about page
 const resume = resumeData.map((role) => {
   const blurbs = {
-    'WorkOS-Developer Experience Engineer': "Applied AI work on developer-facing products. Retrieval, agent harnesses, and the writing that helps teams adopt them.",
+    'WorkOS-AI Engineer · Applied AI': "Applied AI engineering on WorkOS's developer-facing products. Retrieval, agent harnesses, evals, and the production systems behind them.",
     'WorkOS-Developer Education': "Built and led the developer-education surface at WorkOS — documentation, workshops, and video.",
     'Pinecone.io-Staff Developer Advocate': "Designed the RAG reference architectures and tutorials that thousands of teams used to go from embeddings to a shipped retrieval system.",
     'Gruntwork.io-Tech Lead': "Wrote, maintained, and open-sourced Terraform modules used by hundreds of companies to run their AWS infrastructure.",
@@ -74,15 +74,14 @@ export default function About() {
                 <span className="text-burnt-400 dark:text-amber-400">Zachary</span>.
               </h1>
               <p className="editorial-lede text-parchment-600 dark:text-slate-300">
-                I&apos;m a full-stack open-source hacker with {years} years of
-                software development experience at top startups and established
-                enterprise companies. Currently a Developer Experience Engineer
-                at{' '}
+                I&apos;m an AI Engineer on the Applied AI team at{' '}
                 <Link href="https://workos.com" className="text-burnt-400 dark:text-amber-400 hover:underline">
                   WorkOS
                 </Link>
-                , where we help companies add enterprise features to their apps
-                in minutes, not months.
+                , shipping retrieval, agent harnesses, and the evals that keep
+                them honest. {years} years in production as a full-stack
+                engineer before that — at top startups and enterprise infra
+                companies.
               </p>
               <div className="editorial-secondary text-burnt-400 dark:text-amber-400 mt-6">
                 <a href="#work">Work history →</a>
@@ -95,7 +94,7 @@ export default function About() {
               </div>
               <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
                 <dt>Currently</dt>
-                <dd>Developer Experience Engineer · WorkOS</dd>
+                <dd>AI Engineer · Applied AI · WorkOS</dd>
                 <dt>Formerly</dt>
                 <dd>Pinecone · Cloudflare · Gruntwork</dd>
                 <dt>Writes</dt>
@@ -174,13 +173,16 @@ export default function About() {
             </div>
             <div className="prose-editorial text-[17px] leading-[1.7] text-charcoal-50 dark:text-parchment-100 space-y-5 mt-6">
               <p className="first-letter:float-left first-letter:font-serif first-letter:text-[64px] first-letter:leading-[0.9] first-letter:mr-2 first-letter:mt-1 first-letter:text-burnt-400 dark:first-letter:text-amber-400">
-                I&apos;m a Developer Experience Engineer at{' '}
+                I&apos;m an AI Engineer on the Applied AI team at{' '}
                 <Link href="https://workos.com" className="underline decoration-burnt-400/40 hover:decoration-burnt-400 dark:decoration-amber-400/40 dark:hover:decoration-amber-400">
                   WorkOS
                 </Link>
-                . Before that I did developer-education and staff developer-
-                advocacy work at Pinecone, senior engineering at Cloudflare, and
-                tech-lead work at Gruntwork. {years} years in production as a
+                , where I ship retrieval, agent harnesses, and the evals that
+                keep them honest. Before that: staff developer advocacy at
+                Pinecone (where I designed the RAG reference architectures
+                thousands of teams shipped against), senior engineering at
+                Cloudflare, and tech-lead work at Gruntwork on the Terraform
+                modules behind hundreds of companies&apos; AWS infrastructure. {years} years in production as a
                 full-stack engineer — databases, backends, middleware, and
                 frontends — with a deep love for{' '}
                 <span className="text-burnt-400 dark:text-amber-400 font-semibold">

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -58,11 +58,11 @@ export async function POST(req: Request) {
   const contextText = docs.join("\n").substring(0, 3000)
 
   const prompt = `
-          Zachary Proser is a Developer Experience Engineer, open-source maintainer, and technical writer 
+          Zachary Proser is an AI Engineer on the Applied AI team at WorkOS, open-source maintainer, and technical writer.
           Zachary Proser's traits include expert knowledge, helpfulness, cleverness, and articulateness.
           Zachary Proser is a well - behaved and well - mannered individual.
           Zachary Proser is always friendly, kind, and inspiring, and he is eager to provide vivid and thoughtful responses to the user.
-          Zachary Proser is a Developer Experience Engineer at WorkOS.
+          Zachary Proser is an AI Engineer on the Applied AI team at WorkOS, where he ships retrieval, agent harnesses, and evaluation systems.
           Zachary Proser builds and maintains open source applications, Jupyter Notebooks, and distributed systems in AWS
           START CONTEXT BLOCK
           ${contextText}

--- a/src/app/products/products-client.tsx
+++ b/src/app/products/products-client.tsx
@@ -474,7 +474,7 @@ export default function ProductsPageClient({ products }: { products: ProductCont
                     {[
                       {
                         company: 'WorkOS',
-                        title: 'Developer Experience Engineer',
+                        title: 'AI Engineer · Applied AI',
                         logo: logoWorkOS,
                         start: '2025',
                         end: 'Present'

--- a/src/components/Author.tsx
+++ b/src/components/Author.tsx
@@ -23,7 +23,7 @@ export function Author({ name, bio }: AuthorProps) {
   const experience = [
     {
       company: 'WorkOS',
-      title: 'Developer Experience Engineer',
+      title: 'AI Engineer · Applied AI',
       logo: logoWorkOS,
       start: '2025',
       end: 'Present'

--- a/src/components/GenAILandingPage.jsx
+++ b/src/components/GenAILandingPage.jsx
@@ -263,10 +263,10 @@ export default function GenAILandingPage() {
                 I eat, sleep and breathe code.
               </p>
               <p className="mt-6 text-lg leading-8 text-gray-300">
-                Hi, I&apos;m Zachary, a Developer Experience Engineer at WorkOS.
+                Hi, I&apos;m Zachary, an AI Engineer on the Applied AI team at WorkOS.
               </p>
               <p className="mt-6 text-lg leading-8 text-gray-300">
-                My current title is Developer Experience Engineer at WorkOS. I build AI applications and developer tooling in public to demonstrate secure authentication patterns, MCP integrations, and production-grade workflows.
+                I ship retrieval, agent harnesses, and the evals that keep them honest. I build AI applications and developer tooling in public to demonstrate production-grade RAG pipelines, MCP integrations, and secure authentication patterns.
               </p>
               <p className="mt-6 text-lg leading-8 text-gray-300">
                 I also maintain our many open-source examples such as Jupyter Notebooks and TypeScript / Next.js applications, which demonstrate machine learning and AI techniques such as semantic search and Retrieval Augmented Generation (RAG).

--- a/src/components/OpengraphImage.tsx
+++ b/src/components/OpengraphImage.tsx
@@ -43,7 +43,7 @@ const OpengraphImage: React.FC<OpengraphImageProps> = async ({
         </div>
         <div tw="flex flex-col ml-4 items-center">
           <h1 tw="text-4xl text-white">Zachary Proser</h1>
-          <h2 tw="text-3xl text-white">Developer Experience Engineer @WorkOS</h2>
+          <h2 tw="text-3xl text-white">AI Engineer · Applied AI @WorkOS</h2>
         </div>
       </div>
       <div

--- a/src/components/applied-ai/PersonSchema.tsx
+++ b/src/components/applied-ai/PersonSchema.tsx
@@ -16,11 +16,11 @@ export default function PersonSchema() {
     "name": "Zachary D Proser",
     "alternateName": ["Zack Proser", "Zachary Proser"],
     "jobTitle": [
-      "Developer Experience Engineer",
+      "AI Engineer",
+      "Applied AI Engineer",
       "Staff AI Engineer",
-      "Applied AI Engineer", 
-      "Developer Education Specialist",
-      "AI Technical Trainer"
+      "AI Technical Trainer",
+      "Developer Education Specialist"
     ],
     "description": "Staff-level Applied AI Engineer with 13+ years experience building scalable systems and 3+ years specializing in AI/LLM solutions, RAG systems, and enterprise AI infrastructure. Specializes in vector databases, machine learning, and AI architecture.",
     "url": "https://zackproser.com",

--- a/src/data/applied-ai-experience.ts
+++ b/src/data/applied-ai-experience.ts
@@ -21,11 +21,11 @@ export interface ExperienceData {
 export const appliedAiExperience: ExperienceData[] = [
   {
     company: "WorkOS",
-    role: "Developer Experience Engineer",
+    role: "AI Engineer · Applied AI",
     duration: "2025–Present",
     location: "Remote",
     logo: logoWorkOS,
-    description: "Building developer experience across SDKs, templates, and AI integrations. Focused on AuthKit-secured MCP servers, high-quality examples, docs, and pragmatic developer tooling that accelerates adoption and success.",
+    description: "Applied AI engineering on WorkOS's developer-facing products: retrieval pipelines, agent harnesses, evaluation systems, and AuthKit-secured MCP servers. Production AI infrastructure that other teams ship against.",
     achievements: [],
     technologies: []
   },

--- a/src/data/resume.js
+++ b/src/data/resume.js
@@ -1,7 +1,7 @@
 export const resumeData = [
   {
     company: 'WorkOS',
-    title: 'Developer Experience Engineer',
+    title: 'AI Engineer · Applied AI',
     logo: 'https://zackproser.b-cdn.net/images/logos/workos.svg',
     start: '2025',
     end: 'Present',


### PR DESCRIPTION
## Summary

Updates the current-role title from "Developer Experience Engineer" to "AI Engineer · Applied AI" at WorkOS — the previous title was undersell. Refreshes every place the title appeared:

- `/about` — metadata description, lede, biography, currently row, blurb key
- Global `Author` byline (every blog post)
- OpenGraph image template (every share card)
- GenAI landing page intro
- JSON-LD `PersonSchema` (jobTitle reordered, AI Engineer first)
- `applied-ai-experience` data + description
- `/products` experience block
- Chat agent persona prompt
- `resume.js`

Leaves intact:
- The prior WorkOS Developer Education entry (2024–2025) — separate historical role
- The Nick Nisi blog post (`/blog/nick-nisi-is-one-talented-motherfucker`) — historical narrative; both were DXEs at the time those workshops happened

## Test plan

- [ ] Visit `/about` — hero, currently row, and biography all read AI Engineer · Applied AI
- [ ] Open any blog post — author byline shows new title
- [ ] Generate an OG image (`npm run og:generate-for -- --slug <any>`) and confirm subtitle
- [ ] Hit `/api/chat` with "what does Zack do" — agent should mention Applied AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy/metadata updates across pages and structured data; no behavioral or data-flow changes beyond updating the chat system prompt text.
> 
> **Overview**
> Updates the site-wide messaging of the current WorkOS role from **"Developer Experience Engineer"** to **`AI Engineer · Applied AI`**, including refreshed bio copy highlighting retrieval, agent harnesses, and evaluation systems.
> 
> Propagates the new title through `/about` (metadata, lede, biography, resume blurb key), the `Author` component/bylines, `/products` author section, the GenAI landing page intro, OpenGraph image template subtitle, JSON-LD `PersonSchema` job titles, `applied-ai-experience` + `resume` data, and the `/api/chat` persona prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20062e8f41cf9790dfd51d30b0bbe905948774dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->