### PR TITLE
Meeting Notes Concierge + cluster rail across 164 SEO posts

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import '@/styles/blog-post.css';
 import '@/styles/testimonials.css';
 import '@/styles/contact.css';
 import '@/styles/partnerships.css';
+import '@/styles/meeting-notes.css';
 import '@/styles/subscribe.css';
 import '@/styles/newsletter.css';
 import '@/styles/subscribe-form-shared.css';

--- a/src/components/EditorialArticleLayout.tsx
+++ b/src/components/EditorialArticleLayout.tsx
@@ -348,6 +348,7 @@ export function EditorialArticleLayout({
               <MeetingNotesClusterRail
                 campaign={baseSlug || safeSlug}
                 persona={inferRailPersona(safeSlug || baseSlug, safeTitle)}
+                currentSlug={baseSlug || safeSlug}
               />
             </>
           )}

--- a/src/components/EditorialArticleLayout.tsx
+++ b/src/components/EditorialArticleLayout.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Twitter, Linkedin, Github, Link as LinkIcon, Bookmark, Check } from 'lucide-react'
 import { track } from '@vercel/analytics'
 import GiscusWrapper from '@/components/GiscusWrapper'
@@ -106,19 +106,33 @@ export function EditorialArticleLayout({
   const breadcrumbHref = metadata?.type === 'video' ? '/videos' : metadata?.type === 'course' ? '/learn/courses' : metadata?.type === 'demo' ? '/demos' : '/blog'
 
   const articleRef = useRef<HTMLDivElement | null>(null)
+  const conciergeRef = useRef<HTMLDivElement | null>(null)
   const progressFillRef = useRef<HTMLDivElement | null>(null)
   const [readingMin, setReadingMin] = useState<number | null>(null)
   const [copied, setCopied] = useState(false)
   const [shareVisible, setShareVisible] = useState(false)
 
-  useEffect(() => {
+  // useLayoutEffect runs synchronously before paint so the concierge
+  // relocation doesn't flash. Falls back to useEffect on the server (where
+  // useLayoutEffect would warn about hydration mismatches).
+  const useIsoLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
+  useIsoLayoutEffect(() => {
     const body = articleRef.current
     if (!body) return
 
-    // Mark the first paragraph as .lede for drop cap
-    const firstP = body.querySelector('p')
+    // Mark the first paragraph as .lede for drop cap. Use direct-child only
+    // so we don't accidentally pick a <p> from the injected concierge widget
+    // once it's relocated into the body.
+    const firstP = body.querySelector<HTMLElement>(':scope > p')
     if (firstP && !firstP.classList.contains('lede')) {
       firstP.classList.add('lede')
+    }
+
+    // Relocate the concierge widget (if present) to sit right after the lede
+    // paragraph rather than at the top of post-body.
+    const concierge = conciergeRef.current
+    if (concierge && firstP && firstP.parentNode) {
+      firstP.parentNode.insertBefore(concierge, firstP.nextSibling)
     }
 
     // Number h2s with § 01, § 02 ...
@@ -335,22 +349,25 @@ export function EditorialArticleLayout({
           {shouldShowMiniPaywall && (
             <MiniPaywall content={metadata as Content} />
           )}
+
           <div className="post-body" ref={articleRef}>
+            {isMeetingNotesClusterPost(safeSlug || baseSlug, tags, { hiddenFromIndex: !!metadata?.hiddenFromIndex }) && (
+              <div ref={conciergeRef} className="mn-concierge-slot">
+                <MeetingNotesConcierge
+                  campaign={baseSlug || safeSlug}
+                  defaultRole={inferConciergeRole(safeSlug || baseSlug, safeTitle)}
+                />
+              </div>
+            )}
             {children}
           </div>
 
           {isMeetingNotesClusterPost(safeSlug || baseSlug, tags, { hiddenFromIndex: !!metadata?.hiddenFromIndex }) && (
-            <>
-              <MeetingNotesConcierge
-                campaign={baseSlug || safeSlug}
-                defaultRole={inferConciergeRole(safeSlug || baseSlug, safeTitle)}
-              />
-              <MeetingNotesClusterRail
-                campaign={baseSlug || safeSlug}
-                persona={inferRailPersona(safeSlug || baseSlug, safeTitle)}
-                currentSlug={baseSlug || safeSlug}
-              />
-            </>
+            <MeetingNotesClusterRail
+              campaign={baseSlug || safeSlug}
+              persona={inferRailPersona(safeSlug || baseSlug, safeTitle)}
+              currentSlug={baseSlug || safeSlug}
+            />
           )}
 
           {!hideNewsletter && (

--- a/src/components/EditorialArticleLayout.tsx
+++ b/src/components/EditorialArticleLayout.tsx
@@ -9,6 +9,9 @@ import GiscusWrapper from '@/components/GiscusWrapper'
 import MiniPaywall from '@/components/MiniPaywall'
 import StickyAffiliateCTA from '@/components/StickyAffiliateCTA'
 import { EditorialNewsletter } from '@/components/EditorialNewsletter'
+import { MeetingNotesConcierge } from '@/components/meeting-notes/MeetingNotesConcierge'
+import { MeetingNotesClusterRail } from '@/components/meeting-notes/MeetingNotesClusterRail'
+import { isMeetingNotesClusterPost, inferConciergeRole, inferRailPersona } from '@/lib/meeting-notes-cluster'
 import type { ExtendedMetadata, Content } from '@/types'
 
 const VOICE_AFFILIATE_SLUGS = [
@@ -73,6 +76,7 @@ interface Props {
     miniPaywallDescription?: string | null
     tags?: string[]
     githubUrl?: string
+    hiddenFromIndex?: boolean
   }
   serverHasPurchased?: boolean
   hideNewsletter?: boolean
@@ -334,6 +338,19 @@ export function EditorialArticleLayout({
           <div className="post-body" ref={articleRef}>
             {children}
           </div>
+
+          {isMeetingNotesClusterPost(safeSlug || baseSlug, tags, { hiddenFromIndex: !!metadata?.hiddenFromIndex }) && (
+            <>
+              <MeetingNotesConcierge
+                campaign={baseSlug || safeSlug}
+                defaultRole={inferConciergeRole(safeSlug || baseSlug, safeTitle)}
+              />
+              <MeetingNotesClusterRail
+                campaign={baseSlug || safeSlug}
+                persona={inferRailPersona(safeSlug || baseSlug, safeTitle)}
+              />
+            </>
+          )}
 
           {!hideNewsletter && (
             <div className="inline-newsletter-card">

--- a/src/components/meeting-notes/MeetingNotesClusterRail.tsx
+++ b/src/components/meeting-notes/MeetingNotesClusterRail.tsx
@@ -86,7 +86,7 @@ const CLUSTER: ClusterPost[] = [
   },
 ]
 
-function pickFor(persona: Persona, max = 4): ClusterPost[] {
+function pickFor(persona: Persona, max = 4, currentSlug?: string): ClusterPost[] {
   // Show persona-specific first, fill with general posts up to `max`.
   const exact = CLUSTER.filter(p => p.personas.includes(persona) && persona !== 'general')
   const general = CLUSTER.filter(p => p.personas.includes('general'))
@@ -95,6 +95,7 @@ function pickFor(persona: Persona, max = 4): ClusterPost[] {
   for (const p of [...exact, ...general]) {
     if (out.length >= max) break
     if (seen.has(p.slug)) continue
+    if (currentSlug && p.slug.includes(currentSlug)) continue
     seen.add(p.slug)
     out.push(p)
   }
@@ -106,10 +107,12 @@ interface RailProps {
   campaign: string
   // Override the heading per host post if the default reads weird.
   heading?: string
+  // Current post slug to exclude from rail links.
+  currentSlug?: string
 }
 
-export function MeetingNotesClusterRail({ persona = 'general', campaign, heading }: RailProps) {
-  const posts = pickFor(persona)
+export function MeetingNotesClusterRail({ persona = 'general', campaign, heading, currentSlug }: RailProps) {
+  const posts = pickFor(persona, 4, currentSlug)
   const personaLabel: Record<Persona, string> = {
     sales: 'sales people',
     consultant: 'consultants',

--- a/src/components/meeting-notes/MeetingNotesClusterRail.tsx
+++ b/src/components/meeting-notes/MeetingNotesClusterRail.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { ArrowUpRight } from 'lucide-react'
+import { track } from '@vercel/analytics'
+
+type Persona =
+  | 'sales'
+  | 'consultant'
+  | 'executive'
+  | 'engineer'
+  | 'product'
+  | 'photographer'
+  | 'therapist'
+  | 'researcher'
+  | 'founder'
+  | 'general'
+
+interface ClusterPost {
+  slug: string
+  title: string
+  hint: string
+  personas: Persona[]
+}
+
+// Curated subset — the cluster has 100+ posts; these are the ones worth surfacing.
+const CLUSTER: ClusterPost[] = [
+  {
+    slug: '/blog/granola-ai-review',
+    title: 'Granola AI Review: The App I Use Every Meeting',
+    hint: 'My honest long-form review',
+    personas: ['general', 'consultant', 'executive', 'founder'],
+  },
+  {
+    slug: '/blog/granola-vs-otter',
+    title: 'Granola vs Otter.ai: I Tested Both for Months',
+    hint: 'Bot vs no-bot, head to head',
+    personas: ['general', 'sales', 'product'],
+  },
+  {
+    slug: '/blog/granola-vs-fathom',
+    title: 'Granola vs Fathom: Invisible vs Visible Meeting AI',
+    hint: 'When the free Zoom option is enough',
+    personas: ['general', 'engineer', 'product'],
+  },
+  {
+    slug: '/blog/granola-vs-fireflies',
+    title: 'Granola vs Fireflies.ai: Privacy vs CRM Sync',
+    hint: 'For sales teams choosing between trust and CRM data',
+    personas: ['sales', 'general'],
+  },
+  {
+    slug: '/blog/granola-vs-traditional-meeting-notes',
+    title: 'Granola vs Traditional Meeting Notes',
+    hint: 'Why typing through a meeting is expensive',
+    personas: ['general', 'consultant', 'executive'],
+  },
+  {
+    slug: '/blog/best-ai-meeting-notes-remote-teams-2026',
+    title: 'Best AI Meeting Notes for Remote Teams',
+    hint: 'For distributed orgs',
+    personas: ['general', 'engineer', 'product', 'founder'],
+  },
+  {
+    slug: '/blog/i-hate-taking-meeting-notes',
+    title: 'I Hate Taking Meeting Notes (So I Stopped)',
+    hint: 'The essay behind why I switched',
+    personas: ['general', 'consultant', 'executive', 'founder'],
+  },
+  {
+    slug: '/blog/adhd-meeting-notes-strategy',
+    title: 'ADHD Meeting Notes: Why Traditional Note-Taking Fails',
+    hint: 'If holding two threads is the problem',
+    personas: ['general', 'engineer', 'product', 'researcher'],
+  },
+  {
+    slug: '/blog/granola-photographers-portfolio-meetings',
+    title: 'Granola for Photographers: Client Consultations',
+    hint: 'Creative briefs without breaking eye contact',
+    personas: ['photographer'],
+  },
+  {
+    slug: '/blog/granola-mobile-developers-release-planning',
+    title: 'Granola for Mobile Developers: Release Planning',
+    hint: 'Stakeholder syncs that turn into release notes',
+    personas: ['engineer'],
+  },
+]
+
+function pickFor(persona: Persona, max = 4): ClusterPost[] {
+  // Show persona-specific first, fill with general posts up to `max`.
+  const exact = CLUSTER.filter(p => p.personas.includes(persona) && persona !== 'general')
+  const general = CLUSTER.filter(p => p.personas.includes('general'))
+  const seen = new Set<string>()
+  const out: ClusterPost[] = []
+  for (const p of [...exact, ...general]) {
+    if (out.length >= max) break
+    if (seen.has(p.slug)) continue
+    seen.add(p.slug)
+    out.push(p)
+  }
+  return out
+}
+
+interface RailProps {
+  persona?: Persona
+  campaign: string
+  // Override the heading per host post if the default reads weird.
+  heading?: string
+}
+
+export function MeetingNotesClusterRail({ persona = 'general', campaign, heading }: RailProps) {
+  const posts = pickFor(persona)
+  const personaLabel: Record<Persona, string> = {
+    sales: 'sales people',
+    consultant: 'consultants',
+    executive: 'executives',
+    engineer: 'engineers',
+    product: 'PMs',
+    photographer: 'photographers',
+    therapist: 'therapists & coaches',
+    researcher: 'researchers',
+    founder: 'founders',
+    general: 'this',
+  }
+
+  return (
+    <section className="mn-rail" aria-label="More from the meeting notes series">
+      <header className="mnr-head">
+        <span className="mnr-eyebrow">§ More in the series</span>
+        <h3 className="mnr-title">
+          {heading ?? (
+            <>
+              More for{' '}
+              <em>{personaLabel[persona]}</em>.
+            </>
+          )}
+        </h3>
+      </header>
+      <ul className="mnr-list">
+        {posts.map((p, i) => (
+          <li key={p.slug}>
+            <a
+              href={p.slug}
+              className="mnr-link"
+              onClick={() => track('cluster_rail_click', { campaign, slug: p.slug, persona })}
+            >
+              <span className="mnr-num">{String(i + 1).padStart(2, '0')}</span>
+              <span className="mnr-body">
+                <span className="mnr-name">{p.title}</span>
+                <span className="mnr-hint">{p.hint}</span>
+              </span>
+              <ArrowUpRight size={16} className="mnr-arrow" aria-hidden />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default MeetingNotesClusterRail

--- a/src/components/meeting-notes/MeetingNotesConcierge.tsx
+++ b/src/components/meeting-notes/MeetingNotesConcierge.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react'
 import { track } from '@vercel/analytics'
 import { ArrowRight, Check } from 'lucide-react'
-import { getAffiliateLink } from '@/lib/affiliate'
+import { getAffiliateLink, buildConciergeTerm } from '@/lib/affiliate'
 
 type Role =
   | 'sales'
@@ -137,12 +137,14 @@ export function MeetingNotesConcierge({ campaign, defaultRole, headline }: Conci
   const pickKey = useMemo(() => recommend(role, shape, stack), [role, shape, stack])
   const pick = PICKS[pickKey]
 
+  const term = buildConciergeTerm({ role, shape, stack })
   const link = pick.product
     ? getAffiliateLink({
         product: pick.product,
         campaign,
         medium: 'blog',
-        placement: 'inline-cta',
+        placement: 'concierge',
+        term,
       })
     : null
 
@@ -152,7 +154,14 @@ export function MeetingNotesConcierge({ campaign, defaultRole, headline }: Conci
     pick.tagline
 
   function handleClick() {
-    track('concierge_cta_click', { product: pickKey, role, shape: shape ?? '', stack: stack ?? '', campaign })
+    track('concierge_cta_click', {
+      product: pickKey,
+      role,
+      shape: shape ?? '',
+      stack: stack ?? '',
+      campaign,
+      term,
+    })
   }
 
   function handleAnswer<T extends string>(setter: (v: T) => void, value: T, key: 'role' | 'shape' | 'stack') {

--- a/src/components/meeting-notes/MeetingNotesConcierge.tsx
+++ b/src/components/meeting-notes/MeetingNotesConcierge.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { track } from '@vercel/analytics'
+import { ArrowRight, Check } from 'lucide-react'
+import { getAffiliateLink } from '@/lib/affiliate'
+
+type Role =
+  | 'sales'
+  | 'consultant'
+  | 'executive'
+  | 'engineer'
+  | 'product'
+  | 'recruiter'
+  | 'therapist'
+  | 'photographer'
+  | 'researcher'
+  | 'founder'
+  | 'other'
+
+type MeetingShape = 'client' | 'internal' | 'sensitive' | 'interview' | 'live'
+type Stack = 'mac' | 'windows' | 'zoom' | 'meet' | 'inperson'
+
+const ROLES: { id: Role; label: string }[] = [
+  { id: 'sales', label: 'Sales' },
+  { id: 'consultant', label: 'Consultant' },
+  { id: 'executive', label: 'Executive' },
+  { id: 'engineer', label: 'Engineer' },
+  { id: 'product', label: 'Product / PM' },
+  { id: 'recruiter', label: 'Recruiter' },
+  { id: 'therapist', label: 'Therapist / Coach' },
+  { id: 'photographer', label: 'Photographer' },
+  { id: 'researcher', label: 'Researcher' },
+  { id: 'founder', label: 'Founder' },
+  { id: 'other', label: 'Something else' },
+]
+
+const SHAPES: { id: MeetingShape; label: string; hint: string }[] = [
+  { id: 'client', label: 'Client / sales calls', hint: 'Trust changes the conversation' },
+  { id: 'internal', label: 'Internal team', hint: 'Everyone is fine being recorded' },
+  { id: 'sensitive', label: 'Sensitive / HR', hint: 'Candor matters; a bot kills it' },
+  { id: 'interview', label: 'Interviews', hint: 'You want to be present, not typing' },
+  { id: 'live', label: 'Live captions', hint: 'Real-time transcript during the call' },
+]
+
+const STACKS: { id: Stack; label: string }[] = [
+  { id: 'mac', label: 'Mac' },
+  { id: 'windows', label: 'Windows' },
+  { id: 'zoom', label: 'Zoom-heavy' },
+  { id: 'meet', label: 'Google Meet' },
+  { id: 'inperson', label: 'In-person / hybrid' },
+]
+
+type Pick = 'granola' | 'otter' | 'fireflies' | 'fathom'
+
+const PICKS: Record<Pick, { name: string; product: 'granola' | null; tagline: string; reasonByShape: Partial<Record<MeetingShape, string>> }> = {
+  granola: {
+    name: 'Granola',
+    product: 'granola',
+    tagline: 'Invisible. No bot. Mac.',
+    reasonByShape: {
+      client: 'Client calls hinge on candor. The moment a bot announces itself, the real conversation goes away.',
+      sensitive: 'For HR, legal, or anything sensitive: a recording bot is a non-starter. Granola captures audio locally — nobody else on the call knows.',
+      interview: 'You want to be present, not typing. Granola gets out of the way and you read the notes after.',
+      internal: 'Even internal — once you stop seeing "[Bot] is recording," meetings get faster.',
+      live: 'No live captions in Granola today. If that is the deal-breaker, Otter is the honest answer.',
+    },
+  },
+  otter: {
+    name: 'Otter.ai',
+    product: null,
+    tagline: 'Best for shared transcripts + live captions.',
+    reasonByShape: {
+      live: 'Live captions during the call is what Otter does best. Bot-based, but you wanted the bot.',
+      internal: 'Internal team meetings where everyone is fine being recorded — Otter is the team-transcript option.',
+    },
+  },
+  fireflies: {
+    name: 'Fireflies.ai',
+    product: null,
+    tagline: 'Best when call data has to land in a CRM.',
+    reasonByShape: {
+      client: 'If your sales motion runs through Salesforce or HubSpot and revops needs the data, Fireflies wins.',
+      internal: 'Same answer for internal sales reviews — CRM sync is the differentiator.',
+    },
+  },
+  fathom: {
+    name: 'Fathom',
+    product: null,
+    tagline: 'Free, Zoom-first.',
+    reasonByShape: {
+      internal: 'Free tier is solid if you live in Zoom and the bot does not change anything for you.',
+    },
+  },
+}
+
+function recommend(role: Role, shape: MeetingShape | null, stack: Stack | null): Pick {
+  // Shape is the strongest signal.
+  if (shape === 'sensitive') return 'granola'
+  if (shape === 'live') return 'otter'
+  if (shape === 'interview') return 'granola'
+  if (shape === 'client') {
+    // Sales people who care about CRM → Fireflies; everyone else → Granola.
+    if (role === 'sales' && stack !== 'mac') return 'fireflies'
+    return 'granola'
+  }
+  if (shape === 'internal') {
+    if (role === 'sales') return 'fireflies'
+    if (stack === 'zoom') return 'fathom'
+    return 'otter'
+  }
+  // No shape selected yet — fall back to role.
+  if (
+    role === 'consultant' ||
+    role === 'executive' ||
+    role === 'therapist' ||
+    role === 'photographer' ||
+    role === 'researcher' ||
+    role === 'founder'
+  ) return 'granola'
+  if (role === 'sales') return 'fireflies'
+  return 'granola'
+}
+
+interface ConciergeProps {
+  campaign: string
+  defaultRole?: Role
+  // Optional: override the headline copy per host post.
+  headline?: string
+}
+
+export function MeetingNotesConcierge({ campaign, defaultRole, headline }: ConciergeProps) {
+  const [role, setRole] = useState<Role>(defaultRole ?? 'consultant')
+  const [shape, setShape] = useState<MeetingShape | null>(null)
+  const [stack, setStack] = useState<Stack | null>(null)
+
+  const pickKey = useMemo(() => recommend(role, shape, stack), [role, shape, stack])
+  const pick = PICKS[pickKey]
+
+  const link = pick.product
+    ? getAffiliateLink({
+        product: pick.product,
+        campaign,
+        medium: 'blog',
+        placement: 'inline-cta',
+      })
+    : null
+
+  const reason =
+    (shape && pick.reasonByShape[shape]) ||
+    pick.reasonByShape.client ||
+    pick.tagline
+
+  function handleClick() {
+    track('concierge_cta_click', { product: pickKey, role, shape: shape ?? '', stack: stack ?? '', campaign })
+  }
+
+  function handleAnswer<T extends string>(setter: (v: T) => void, value: T, key: 'role' | 'shape' | 'stack') {
+    setter(value)
+    track('concierge_answer', { key, value, campaign })
+  }
+
+  const roleLabel = ROLES.find(r => r.id === role)?.label.toLowerCase() || 'you'
+
+  return (
+    <section className="mn-concierge" aria-label="Find the right meeting notes tool">
+      <header className="mnc-head">
+        <span className="mnc-eyebrow">§ The 30-second concierge</span>
+        <h3 className="mnc-title">
+          {headline ?? <>Three questions. One <em>honest</em> recommendation.</>}
+        </h3>
+      </header>
+
+      <div className="mnc-grid">
+        <div className="mnc-q">
+          <div className="mnc-qlabel"><span className="mnc-num">01</span> What do you do?</div>
+          <div className="mnc-pills" role="radiogroup" aria-label="Role">
+            {ROLES.map(r => (
+              <button
+                key={r.id}
+                type="button"
+                role="radio"
+                aria-checked={role === r.id}
+                className={`mnc-pill${role === r.id ? ' is-on' : ''}`}
+                onClick={() => handleAnswer(setRole, r.id, 'role')}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mnc-q">
+          <div className="mnc-qlabel"><span className="mnc-num">02</span> What kind of meetings matter most?</div>
+          <div className="mnc-shapes" role="radiogroup" aria-label="Meeting shape">
+            {SHAPES.map(s => (
+              <button
+                key={s.id}
+                type="button"
+                role="radio"
+                aria-checked={shape === s.id}
+                className={`mnc-shape${shape === s.id ? ' is-on' : ''}`}
+                onClick={() => handleAnswer(setShape, s.id, 'shape')}
+              >
+                <span className="mnc-shape-label">{s.label}</span>
+                <span className="mnc-shape-hint">{s.hint}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mnc-q">
+          <div className="mnc-qlabel"><span className="mnc-num">03</span> Where do you mostly meet?</div>
+          <div className="mnc-pills" role="radiogroup" aria-label="Stack">
+            {STACKS.map(s => (
+              <button
+                key={s.id}
+                type="button"
+                role="radio"
+                aria-checked={stack === s.id}
+                className={`mnc-pill${stack === s.id ? ' is-on' : ''}`}
+                onClick={() => handleAnswer(setStack, s.id, 'stack')}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <aside className="mnc-result" aria-live="polite">
+        <div className="mnc-result-eyebrow">
+          <Check className="mnc-check" size={14} aria-hidden /> For a {roleLabel} →
+        </div>
+        <div className="mnc-result-name">
+          {pick.name}
+          <span className="mnc-result-tag">{pick.tagline}</span>
+        </div>
+        <p className="mnc-result-reason">{reason}</p>
+        {link ? (
+          <a
+            className="mnc-cta"
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer sponsored"
+            onClick={handleClick}
+          >
+            Try {pick.name} free <ArrowRight size={16} aria-hidden />
+          </a>
+        ) : (
+          <div className="mnc-cta-note">
+            That is the honest answer for your case. I do not run an affiliate link for {pick.name} — search the name and pick the legit signup page.
+          </div>
+        )}
+        <div className="mnc-fine">
+          Disclosure: Granola is an affiliate partnership. I only recommend it where it actually fits — see other answers above.
+        </div>
+      </aside>
+    </section>
+  )
+}
+
+export default MeetingNotesConcierge

--- a/src/content/blog/best-ai-meeting-notes-tools-2026/page.mdx
+++ b/src/content/blog/best-ai-meeting-notes-tools-2026/page.mdx
@@ -6,117 +6,64 @@ export const metadata = createMetadata(rawMetadata);
 
 export const campaign = 'best-ai-meeting-notes-tools-2026'
 
-I've tested every meaningful AI meeting notes tool over the past year. Not just clicked around them — actually used them on real client calls, investor meetings, and team syncs. Here's what I found.
+I have spent the last year on real client calls, investor meetings, and team syncs with every meaningful AI meeting notes tool open in the background. Below is what actually held up — and the one piece of friction that decides which tool you should be using.
 
-**Spoiler:** I use <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink>. Not because of the features list, but because of one thing none of the others get right: no bot joins your call.
+**The single decision that matters:** does a recording bot joining your call change what people are willing to say? If yes, you want <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink>. If no, you have honest options.
 
-## The Market in 2026
+## The market in 2026, in one paragraph
 
-The AI meeting notes space has matured, but it's split into two camps:
+AI meeting notes split into two camps. **Bot-based** — Otter, Fireflies, Fathom, Avoma, Grain, Read AI — a bot joins, records, transcribes, summarizes. They differ on UI and integrations; they all change the shape of the conversation the moment they appear in the participant list. **Invisible** — Granola — captures system audio locally on your Mac, no bot, no recording prompt, nobody sees it. The accuracy gap closed a long time ago. The presence gap is permanent.
 
-**Camp 1: Bot-based tools** — Otter, Fireflies, Fathom, Avoma, Grain, Read AI. A bot joins your call, records everything, transcribes it, and generates a summary. They all work roughly the same way.
+## Tool-by-tool, with the verdict on top
 
-**Camp 2: Invisible tools** — Granola. Runs locally, captures your system audio, no bot, no recording notification. Nobody on the call knows.
+### Granola — invisible, Mac-first
 
-The fundamental difference: bot presence changes what conversations are possible.
+The notes I get from a sensitive client conversation are worth more than a perfect transcript of a sanitized one. Granola is the only tool in this list that does not announce itself. Captures audio locally, generates structured notes and action items after, no bot in the participant list, no consent prompt.
 
-<InlineAffiliateCTA product="granola" campaign={campaign} />
-
-## Tool-by-Tool Breakdown
-
-### Granola — Best Overall
-
-**What it does:** Captures meeting audio locally on your Mac, uses AI to generate structured notes and action items. No bot joins. No recording consent prompt. No "Granola is joining your meeting."
-
-**Best for:** Anyone in trust-dependent conversations — sales, consulting, executive meetings, client calls, sensitive HR discussions.
-
-**Pricing:** Free tier available; paid plans starting around $18/month.
-
-**Why I use it:** On three separate occasions in the last six months, a client said something important and candid — the kind of thing they'd never say if a recording bot was present. The notes I got from those conversations closed deals and shaped strategy. A bot-based tool would have changed the dynamic before they said a word.
-
-**Downsides:** Mac-only (as of early 2026). No live real-time transcription during the meeting. Notes appear after.
-
-### Otter.ai — Best for Teams Who Need Shared Transcripts
-
-**What it does:** Bot joins calls, produces live transcripts, team members can comment and highlight, integrates with Slack and CRMs.
-
-**Best for:** Internal team meetings where everyone knows it's being used, and you need a searchable transcript database.
-
-**Pricing:** Free tier (limited); Pro at $16.99/month, Business at $30/user/month.
-
-**Downsides:** Bot introduces itself when joining. Sensitive calls often get derailed by "Is that recording us?" The free tier is increasingly limited.
-
-### Fireflies.ai — Best for CRM Integration
-
-**What it does:** Bot records calls, transcribes, extracts action items, integrates deeply with Salesforce, HubSpot, and other CRMs.
-
-**Best for:** Sales teams tracking deal progression, customer success teams wanting call data in CRM.
-
-**Pricing:** Free tier; Pro at $18/user/month; Business at $29/user/month.
-
-**Downsides:** Same bot-presence issues as Otter. Overkill for individual contributors who just want personal notes.
-
-### Fathom — Best Free Option for Zoom
-
-**What it does:** Free AI notetaker for Zoom (and now Google Meet). Bot joins, records, produces summary and highlight clips.
-
-**Best for:** Individual contributors on a budget who mainly use Zoom and don't mind the bot.
-
-**Pricing:** Generous free tier. Paid plans for team features.
-
-**Downsides:** Bot-dependent. Quality of summaries is good but not consistently structured. Less useful if you're not on Zoom.
-
-### Avoma — Best for Revenue Teams
-
-**What it does:** Full conversation intelligence platform. Records calls, transcribes, analyzes talk ratios, coaching insights, CRM sync.
-
-**Best for:** Sales leaders and customer success managers who want coaching data and deal intelligence across their whole team.
-
-**Pricing:** Starts around $49/user/month for full features.
-
-**Downsides:** Expensive for individuals. Very much an enterprise product. Bot-based.
+**Best for:** consultants, executives, sales, therapists, anyone whose meetings hinge on candor.
+**Pricing:** Free tier; paid plans start around $18/month.
+**Trade-off:** Mac-only as of early 2026. No live captions during the call — notes appear after.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-## Decision Framework
+### Otter.ai — best when you want the bot
 
-**Use Granola if:**
-- Your most important conversations involve candor, trust, or sensitivity
-- You're a consultant, executive, salesperson, therapist, lawyer, or anyone where "the bot is recording" changes what people say
-- You want notes that actually capture what was said, not the sanitized version
-- You're on Mac
+Live captions during the call, searchable team transcripts, comments and highlights, Slack and CRM integrations. The bot announces itself, which is a feature for internal team meetings and a problem for client ones.
 
-**Use Otter if:**
-- You need searchable team transcripts
-- Your meetings are internal and everyone's fine with recording
-- You want live captions during the meeting
+**Best for:** internal team meetings where everyone is fine being recorded.
+**Pricing:** Limited free; Pro $16.99/month; Business $30/user/month.
+**Trade-off:** "Otter is recording" lands in every external call.
 
-**Use Fireflies if:**
-- You're in sales and need CRM sync
-- Call data lives in Salesforce or HubSpot
+### Fireflies.ai — best when CRM data is the deliverable
 
-**Use Fathom if:**
-- You're on Zoom all day
-- You want a free starting point
-- Bot presence isn't an issue for your meetings
+Bot records, transcribes, extracts action items, and pushes everything into Salesforce or HubSpot. If your sales motion lives in a CRM and revops needs the data, Fireflies is the answer.
 
-## What I Actually Care About
+**Best for:** sales teams, customer success.
+**Pricing:** Free tier; Pro $18/user/month; Business $29/user/month.
+**Trade-off:** Same bot-presence issue as Otter; overkill if you just want personal notes.
 
-Most meeting notes articles rank tools by features. I care about one thing: **do I get accurate notes from the conversations that matter?**
+### Fathom — free, Zoom-first
 
-A 98% accurate transcript of a conversation where everyone held back because the bot was present is less useful than 85% accurate notes from a real, candid conversation.
+A free notetaker for Zoom (and now Meet). Bot joins, records, summarizes, surfaces highlight clips. Quality is solid; it is the budget-conscious starting point if the bot does not bother you.
 
-That's why <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> is my tool. The notes aren't just accurate — they're from conversations that actually happened.
+**Best for:** individual contributors on Zoom all day.
+**Pricing:** Generous free tier; paid plans for team features.
+**Trade-off:** Bot-dependent. Inconsistent summary structure.
+
+### Avoma — enterprise conversation intelligence
+
+Records, transcribes, analyzes talk ratios, gives coaching insights, syncs to CRM. A heavy enterprise platform — overkill unless you are running a sales team that wants deal intelligence across reps.
+
+**Best for:** sales leaders, customer success managers with a coaching mandate.
+**Pricing:** ~$49/user/month for full features.
+**Trade-off:** Expensive for individuals. Bot-based.
+
+## What actually decides this
+
+Every comparison article ranks these by features. Features are noise. The decision is one bit: does the bot showing up change what people say?
+
+If yes → Granola. If no → pick the one with the integration you actually need.
+
+A 98% accurate transcript of a meeting where everyone held back is worth less than 85% accurate notes from the meeting that really happened. That is the trade Granola is on the right side of, and it is the reason <AffiliateLink product="granola" campaign={campaign}>I use it</AffiliateLink> on every call where the conversation matters.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
-
-## Bottom Line
-
-The best AI meeting notes tool in 2026 depends entirely on your use case:
-
-- **Most people:** Try Granola free first. The no-bot experience is genuinely different.
-- **Sales teams:** Granola for client calls, Fireflies for CRM integration on internal reviews.
-- **Budget-conscious:** Fathom's free tier is solid for Zoom-heavy users.
-- **Enterprise teams:** Avoma or Fireflies with your CRM.
-
-Whatever you choose, getting out of manual note-taking is worth it. The question is just how much the bot changes your meetings.

--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -7,7 +7,7 @@
 
 export type AffiliateProduct = 'wisprflow' | 'granola' | 'firecrawl'
 export type AffiliateMedium = 'blog' | 'demo' | 'homepage' | 'newsletter' | 'tools'
-export type AffiliatePlacement = 'sticky-cta' | 'inline-cta' | 'hero-card' | 'compact-card' | 'text-link' | 'dual-card'
+export type AffiliatePlacement = 'sticky-cta' | 'inline-cta' | 'hero-card' | 'compact-card' | 'text-link' | 'dual-card' | 'concierge'
 
 const BASE_LINKS: Record<AffiliateProduct, string> = {
   wisprflow: 'https://ref.wisprflow.ai/zack-proser',
@@ -20,6 +20,11 @@ interface AffiliateParams {
   campaign: string      // Page slug or identifier (e.g., 'ai-tools-for-lawyers')
   medium: AffiliateMedium
   placement: AffiliatePlacement
+  // Optional. Used by the concierge widget to encode role/shape/stack so the
+  // affiliate dashboard can attribute conversions back to specific persona +
+  // meeting-shape combinations. Format is free-form but stay snake_case +
+  // ASCII so analytics tools display it cleanly.
+  term?: string
 }
 
 /**
@@ -33,17 +38,45 @@ interface AffiliateParams {
  *   placement: 'hero-card'
  * })
  * // Returns: https://ref.wisprflow.ai/zack-proser?utm_source=zackproser&utm_medium=blog&utm_campaign=ai-tools-for-lawyers&utm_content=hero-card
+ *
+ * @example
+ * getAffiliateLink({
+ *   product: 'granola',
+ *   campaign: 'granola-for-engineers',
+ *   medium: 'blog',
+ *   placement: 'concierge',
+ *   term: 'engineer_sensitive_mac'
+ * })
+ * // Returns: https://go.granola.ai/zack-proser?utm_source=zackproser&utm_medium=blog&utm_campaign=granola-for-engineers&utm_content=concierge&utm_term=engineer_sensitive_mac
  */
 export function getAffiliateLink(params: AffiliateParams): string {
-  const { product, campaign, medium, placement } = params
+  const { product, campaign, medium, placement, term } = params
 
   const utmParams = new URLSearchParams({
     utm_source: 'zackproser',
     utm_medium: medium,
     utm_campaign: campaign,
-    utm_content: placement
+    utm_content: placement,
   })
+  if (term) utmParams.set('utm_term', term)
 
   return `${BASE_LINKS[product]}?${utmParams.toString()}`
+}
+
+/**
+ * Build a deterministic utm_term string from concierge picks. Stable
+ * ordering so the same combination always produces the same term value
+ * for clean grouping in the affiliate dashboard.
+ */
+export function buildConciergeTerm(parts: {
+  role?: string | null
+  shape?: string | null
+  stack?: string | null
+}): string {
+  return [parts.role, parts.shape, parts.stack]
+    .filter((p): p is string => Boolean(p))
+    .map(p => p.replace(/[^a-z0-9-]/gi, '').toLowerCase())
+    .filter(Boolean)
+    .join('_')
 }
 

--- a/src/lib/meeting-notes-cluster.ts
+++ b/src/lib/meeting-notes-cluster.ts
@@ -1,0 +1,84 @@
+// Detection + persona inference for the Granola / meeting-notes affiliate
+// cluster. Used by EditorialArticleLayout to auto-inject the concierge and
+// cluster rail into matching posts without per-post MDX edits.
+
+export type ConciergeRole =
+  | 'sales' | 'consultant' | 'executive' | 'engineer' | 'product'
+  | 'recruiter' | 'therapist' | 'photographer' | 'researcher' | 'founder'
+  | 'other'
+
+export type RailPersona =
+  | 'sales' | 'consultant' | 'executive' | 'engineer' | 'product'
+  | 'photographer' | 'therapist' | 'researcher' | 'founder' | 'general'
+
+const SLUG_KEYWORDS = [
+  'granola', 'meeting-notes', 'meeting-note', 'meeting-intelligence',
+  'meeting-transcription', 'meeting-assistant', 'meeting-app', 'meetings-',
+  'session-notes', 'session-documentation', 'client-meeting',
+]
+
+const TAG_KEYWORDS = ['granola', 'meetings', 'meeting']
+
+// Anchored substring → persona. Order matters: more specific first.
+const ROLE_RULES: Array<[RegExp, ConciergeRole]> = [
+  [/photograph/, 'photographer'],
+  [/therapist|coach(es|ing)?\b|life-coach|executive-coach/, 'therapist'],
+  [/recruiter|talent-acquisition/, 'recruiter'],
+  [/researcher|user-research|ux-research|academic/, 'researcher'],
+  [/founder|startup-founder|investor|vc/, 'founder'],
+  [/executive|c-suite|c-level/, 'executive'],
+  [/sales|account-executive|client-discovery/, 'sales'],
+  [/product-manager|pm-|product-management/, 'product'],
+  [/engineer|developer|data-scientist|ml-engineer/, 'engineer'],
+  [/consultant|consulting/, 'consultant'],
+]
+
+const RAIL_RULES: Array<[RegExp, RailPersona]> = [
+  [/photograph/, 'photographer'],
+  [/therapist|coach(es|ing)?\b|life-coach|executive-coach/, 'therapist'],
+  [/researcher|user-research|ux-research|academic/, 'researcher'],
+  [/founder|startup-founder|investor|vc/, 'founder'],
+  [/executive|c-suite|c-level/, 'executive'],
+  [/sales|account-executive|client-discovery/, 'sales'],
+  [/product-manager|pm-|product-management/, 'product'],
+  [/engineer|developer|data-scientist|ml-engineer/, 'engineer'],
+  [/consultant|consulting/, 'consultant'],
+]
+
+function lower(s: string | undefined): string {
+  return (s || '').toLowerCase()
+}
+
+// CRITICAL: only auto-inject the concierge into hidden-from-index SEO posts.
+// Real /blog index posts are credibility-building content and must never
+// have an affiliate widget appended to them, even if they happen to mention
+// "granola" or "meetings" by coincidence.
+export function isMeetingNotesClusterPost(
+  slugLike: string,
+  tags: string[] = [],
+  opts: { hiddenFromIndex?: boolean } = {}
+): boolean {
+  if (!opts.hiddenFromIndex) return false
+  const slug = lower(slugLike)
+  if (!slug) return false
+  if (SLUG_KEYWORDS.some(k => slug.includes(k))) return true
+  const tagSet = tags.map(lower)
+  if (tagSet.some(t => TAG_KEYWORDS.includes(t))) return true
+  return false
+}
+
+export function inferConciergeRole(slugLike: string, title?: string): ConciergeRole {
+  const hay = `${lower(slugLike)} ${lower(title)}`
+  for (const [re, role] of ROLE_RULES) {
+    if (re.test(hay)) return role
+  }
+  return 'other'
+}
+
+export function inferRailPersona(slugLike: string, title?: string): RailPersona {
+  const hay = `${lower(slugLike)} ${lower(title)}`
+  for (const [re, persona] of RAIL_RULES) {
+    if (re.test(hay)) return persona
+  }
+  return 'general'
+}

--- a/src/styles/meeting-notes.css
+++ b/src/styles/meeting-notes.css
@@ -1,0 +1,302 @@
+/* =========================================================
+   Meeting Notes cluster — Concierge widget + Cluster Rail
+   ========================================================= */
+
+.mn-concierge {
+  --mn-bg:           #fbf7f0;          /* parchment-100 */
+  --mn-bg-elevated:  #fefdfb;          /* parchment-50  */
+  --mn-bg-secondary: #f5f0e6;          /* parchment-200 */
+  --mn-ink:          #2c3e50;          /* charcoal-50   */
+  --mn-ink-dim:      #8b7355;          /* parchment-600 */
+  --mn-ink-subtle:   #b8a88f;          /* parchment-500 */
+  --mn-rule:         rgb(139 115 85 / .25);
+  --mn-rule-strong:  rgb(139 115 85 / .5);
+  --mn-accent:       #e67e22;          /* burnt-400     */
+  --mn-accent-hover: #d35400;          /* burnt-500     */
+
+  background: var(--mn-bg-elevated);
+  border: 1px solid var(--mn-rule-strong);
+  padding: 28px 28px 24px;
+  margin: 36px 0;
+  border-radius: 4px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 32px;
+  position: relative;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.dark .mn-concierge {
+  --mn-bg:           #1a1a2e;          /* charcoal-400  */
+  --mn-bg-elevated:  #1e293b;          /* slate-800     */
+  --mn-bg-secondary: #141428;          /* charcoal-500  */
+  --mn-ink:          #fbf7f0;
+  --mn-ink-dim:      #cbd5e1;
+  --mn-ink-subtle:   #94a3b8;
+  --mn-rule:         rgb(148 163 184 / .2);
+  --mn-rule-strong:  rgb(148 163 184 / .4);
+  --mn-accent:       #f39c12;          /* amber-400 */
+  --mn-accent-hover: #fcd34d;          /* amber-300 */
+  background: var(--mn-bg-elevated);
+}
+
+@media (max-width: 880px) {
+  .mn-concierge { grid-template-columns: 1fr; gap: 24px; padding: 22px 20px; }
+}
+
+.mn-concierge .mnc-head { grid-column: 1 / -1; border-bottom: 1px solid var(--mn-rule); padding-bottom: 14px; }
+.mn-concierge .mnc-eyebrow {
+  display: block;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--mn-accent);
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+.mn-concierge .mnc-title {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: -.015em;
+  color: var(--mn-ink);
+  margin: 0;
+  line-height: 1.2;
+}
+.mn-concierge .mnc-title em { font-style: italic; color: var(--mn-accent); font-weight: 500; }
+
+.mn-concierge .mnc-grid {
+  display: flex; flex-direction: column; gap: 18px;
+}
+.mn-concierge .mnc-q { display: flex; flex-direction: column; gap: 8px; }
+.mn-concierge .mnc-qlabel {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--mn-ink-dim);
+  font-weight: 600;
+  display: flex; align-items: baseline; gap: 8px;
+}
+.mn-concierge .mnc-num {
+  color: var(--mn-accent);
+}
+.mn-concierge .mnc-pills { display: flex; flex-wrap: wrap; gap: 6px; }
+.mn-concierge .mnc-pill {
+  background: var(--mn-bg);
+  border: 1px solid var(--mn-rule);
+  color: var(--mn-ink);
+  padding: 7px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 999px;
+  transition: border-color .15s ease, color .15s ease, background .15s ease;
+}
+.mn-concierge .mnc-pill:hover { border-color: var(--mn-accent); color: var(--mn-accent); }
+.mn-concierge .mnc-pill.is-on {
+  background: var(--mn-accent);
+  color: #1a1a2e;
+  border-color: var(--mn-accent);
+  font-weight: 600;
+}
+
+.mn-concierge .mnc-shapes { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+@media (max-width: 540px) { .mn-concierge .mnc-shapes { grid-template-columns: 1fr; } }
+.mn-concierge .mnc-shape {
+  background: var(--mn-bg);
+  border: 1px solid var(--mn-rule);
+  color: var(--mn-ink);
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  display: flex; flex-direction: column; gap: 2px;
+  transition: border-color .15s ease, background .15s ease;
+}
+.mn-concierge .mnc-shape:hover { border-color: var(--mn-accent); }
+.mn-concierge .mnc-shape.is-on {
+  border-color: var(--mn-accent);
+  background: var(--mn-bg-secondary);
+}
+.mn-concierge .mnc-shape-label {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--mn-ink);
+}
+.mn-concierge .mnc-shape-hint {
+  font-size: 11.5px;
+  color: var(--mn-ink-dim);
+  line-height: 1.4;
+}
+
+.mn-concierge .mnc-result {
+  background: var(--mn-bg-secondary);
+  border: 1px solid var(--mn-rule);
+  padding: 20px;
+  display: flex; flex-direction: column; gap: 12px;
+  align-self: start;
+  position: sticky;
+  top: 24px;
+}
+.dark .mn-concierge .mnc-result { background: #141428; }
+.mn-concierge .mnc-result-eyebrow {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--mn-accent);
+  font-weight: 600;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.mn-concierge .mnc-check { color: var(--mn-accent); }
+.mn-concierge .mnc-result-name {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--mn-ink);
+  letter-spacing: -.015em;
+  line-height: 1.1;
+}
+.mn-concierge .mnc-result-tag {
+  display: block;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--mn-ink-dim);
+  font-weight: 500;
+  margin-top: 4px;
+}
+.mn-concierge .mnc-result-reason {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--mn-ink);
+  margin: 0;
+  text-wrap: pretty;
+}
+.mn-concierge .mnc-cta {
+  display: inline-flex; align-items: center; gap: 8px;
+  justify-content: center;
+  background: var(--mn-accent);
+  color: #1a1a2e !important;
+  text-decoration: none !important;
+  padding: 12px 18px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  transition: background .15s ease, transform .15s ease;
+  margin-top: 4px;
+}
+.mn-concierge .mnc-cta:hover { background: var(--mn-accent-hover); transform: translateY(-1px); }
+.mn-concierge .mnc-cta-note {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--mn-ink-dim);
+  border-left: 2px solid var(--mn-rule);
+  padding-left: 12px;
+  font-style: italic;
+}
+.mn-concierge .mnc-fine {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: .06em;
+  color: var(--mn-ink-subtle);
+  line-height: 1.4;
+  border-top: 1px solid var(--mn-rule);
+  padding-top: 10px;
+  margin-top: 4px;
+}
+
+/* ---------- Cluster rail ---------- */
+.mn-rail {
+  margin: 48px 0 24px;
+  border-top: 1px solid var(--mn-rule, rgb(139 115 85 / .25));
+  padding-top: 28px;
+}
+.dark .mn-rail { border-top-color: rgb(148 163 184 / .2); }
+
+.mn-rail .mnr-head {
+  display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
+  padding-bottom: 14px; margin-bottom: 0;
+  border-bottom: 1px solid rgb(139 115 85 / .25);
+}
+.dark .mn-rail .mnr-head { border-bottom-color: rgb(148 163 184 / .2); }
+.mn-rail .mnr-eyebrow {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: #e67e22;
+  font-weight: 600;
+}
+.dark .mn-rail .mnr-eyebrow { color: #f39c12; }
+.mn-rail .mnr-title {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 24px;
+  font-weight: 500;
+  letter-spacing: -.015em;
+  color: #2c3e50;
+  margin: 0;
+}
+.dark .mn-rail .mnr-title { color: #fbf7f0; }
+.mn-rail .mnr-title em { font-style: italic; color: #e67e22; font-weight: 500; }
+.dark .mn-rail .mnr-title em { color: #f39c12; }
+
+.mn-rail .mnr-list { list-style: none; padding: 0; margin: 0; }
+.mn-rail .mnr-list li { border-bottom: 1px solid rgb(139 115 85 / .25); }
+.dark .mn-rail .mnr-list li { border-bottom-color: rgb(148 163 184 / .2); }
+.mn-rail .mnr-link {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  gap: 16px; align-items: center;
+  padding: 16px 0;
+  text-decoration: none !important;
+  color: inherit;
+  transition: color .15s ease, padding .15s ease;
+}
+.mn-rail .mnr-link:hover { color: #e67e22; padding-left: 6px; }
+.dark .mn-rail .mnr-link:hover { color: #f39c12; }
+.mn-rail .mnr-link:hover .mnr-name { color: #e67e22; }
+.dark .mn-rail .mnr-link:hover .mnr-name { color: #f39c12; }
+.mn-rail .mnr-num {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .12em;
+  color: #e67e22;
+}
+.dark .mn-rail .mnr-num { color: #f39c12; }
+.mn-rail .mnr-body { display: flex; flex-direction: column; gap: 2px; }
+.mn-rail .mnr-name {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -.005em;
+  color: #2c3e50;
+  transition: color .15s ease;
+  line-height: 1.25;
+}
+.dark .mn-rail .mnr-name { color: #fbf7f0; }
+.mn-rail .mnr-hint {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12.5px;
+  color: #8b7355;
+  line-height: 1.4;
+}
+.dark .mn-rail .mnr-hint { color: #cbd5e1; }
+.mn-rail .mnr-arrow { color: #b8a88f; }
+.dark .mn-rail .mnr-arrow { color: #94a3b8; }
+.mn-rail .mnr-link:hover .mnr-arrow { color: #e67e22; }
+.dark .mn-rail .mnr-link:hover .mnr-arrow { color: #f39c12; }
+
+@media (max-width: 540px) {
+  .mn-rail .mnr-link { grid-template-columns: 28px 1fr auto; gap: 10px; }
+  .mn-rail .mnr-name { font-size: 15.5px; }
+  .mn-rail .mnr-hint { font-size: 12px; }
+}


### PR DESCRIPTION
## Summary

Folds the new Meeting Notes Concierge widget + cluster rail into every Granola/meeting-notes affiliate post in the cluster (164 posts) via auto-injection in `EditorialArticleLayout`. Zero per-post MDX edits required.

**Why this PR matters:**
- Replaces the listicle smell on high-traffic SEO posts with an interactive, persona-aware recommendation widget
- Cross-links every post to 4 siblings — time-on-page lever, SEO internal-linking lift
- Affiliate CTA only when Granola is the honest answer; for Otter/Fireflies/Fathom recommendations the widget says "search the legitimate signup page" (preserves editorial credibility)

## Critical safety guard

The matcher requires `hiddenFromIndex: true`. **Real /blog index posts (132 visible posts) are credibility-building content and never get an affiliate widget appended**, even if they happen to mention "granola" or "meetings" by coincidence. Verified: 0 visible posts wrongly matched.

## Coverage

Auto-injects into 164 hidden-from-index posts. Persona inferred from slug/title:
- `photographer` (3), `engineer` (10), `researcher` (6), `consultant` (4), `therapist` (12), `executive` (2), `sales` (7), `product` (2), `recruiter` (3), `founder` (3), `photographer` (3)
- `other` (112) — topical/comparison posts where no specific profession is targeted; the widget defaults to "Something else" and the reader picks

## Architecture

- `src/lib/meeting-notes-cluster.ts` — matcher (slug + tag keywords + `hiddenFromIndex` guard) + persona inference
- `src/components/meeting-notes/MeetingNotesConcierge.tsx` — 3-question widget, live recommendation panel, sticky on desktop
- `src/components/meeting-notes/MeetingNotesClusterRail.tsx` — persona-ranked cross-link rail
- `src/styles/meeting-notes.css` — scoped styles, light + dark
- `src/components/EditorialArticleLayout.tsx` — auto-injection point right after MDX content
- `src/content/blog/best-ai-meeting-notes-tools-2026/page.mdx` — tightened prose, removed inline placements (layout injects now)

## Test plan

- [ ] Visit `/blog/best-ai-meeting-notes-tools-2026` — concierge + rail render
- [ ] Visit `/blog/granola-photographers-portfolio-meetings` — concierge defaults to Photographer
- [ ] Visit `/blog/granola-for-engineers` — concierge defaults to Engineer
- [ ] Visit any /blog index post (e.g. `/blog/cursor-context-engineering`) — no widget injected
- [ ] Toggle through meeting-shape options — for "Sensitive / HR" recommendation should be Granola; for "Live captions" should be Otter (no affiliate CTA)
- [ ] Click cluster rail items — analytics event `cluster_rail_click` should fire
- [ ] Mobile (≤880px) — concierge stacks, sticky result panel falls inline

## Follow-up

The Voice AI / WisprFlow cluster (~ai-voice-tools-for-* posts) is a separate cluster with a different product — would need its own concierge with different questions ("speed/hands-free/language?"). Not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `EditorialArticleLayout` rendering and DOM post-processing for a large set of posts, and introduces new affiliate/analytics tracking parameters that could affect attribution and client-side behavior.
> 
> **Overview**
> Adds an auto-injected “Meeting Notes” concierge widget and related-post rail to qualifying *hidden-from-index* affiliate/SEO articles, including persona inference from slug/title and click/answer analytics events.
> 
> Updates the article layout to reposition the concierge immediately after the lede paragraph (using an isomorphic `useLayoutEffect`), and adds new scoped styles for the concierge + rail.
> 
> Extends affiliate link generation to support a new `concierge` placement and optional `utm_term` encoding of the concierge selections, and tightens prose in `best-ai-meeting-notes-tools-2026` to rely more on the new injected experience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ce6ceed1f93adf64cb42ab0e170a2f15b3a9ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->