### PR TITLE
feat(recruiters): /recruiters policy page (no-index, off-nav)

### DIFF
--- a/src/app/recruiters/RecruitersContent.jsx
+++ b/src/app/recruiters/RecruitersContent.jsx
@@ -2,136 +2,27 @@ import Link from 'next/link'
 
 const CONTACT_EMAIL = 'zackproser@gmail.com'
 
-const roles = [
+const rules = [
   {
-    num: 'R.01 · AI/ML engineering',
-    status: { label: 'Selectively', tone: 'ok' },
-    title: 'Senior+ engineer building applied AI in production.',
+    num: 'R.01 · The bar',
+    status: { label: 'Hard floor', tone: 'warn' },
+    title: 'Base $300K+ AND meaningful equity.',
     desc:
-      'Retrieval, agents, evals, ML infra. Real systems shipping to real users. Not research-only — I ship; I don’t write papers.',
-    meta: [
-      ['Level', 'Senior → Principal'],
-      ['Stack', 'Python/TS · LLMs · infra'],
-      ['Mode', 'IC'],
-    ],
+      'Both. Either alone is not enough. If your role doesn’t clear both dimensions, the message is auto-filtered before I see it. There is no negotiation around this — it’s the line.',
   },
   {
-    num: 'R.02 · Applied AI / ML platform',
-    status: { label: 'Open', tone: 'ok' },
-    title: 'Build the substrate teams use to ship AI internally.',
+    num: 'R.02 · The status',
+    status: { label: 'Where I am', tone: 'ok' },
+    title: 'Not actively looking — but always listening for the right thing.',
     desc:
-      'Eval frameworks, model-routing, agent runtimes, retrieval pipelines, observability. The closer to the metal of real LLM systems, the better.',
-    meta: [
-      ['Type', 'Platform / infra'],
-      ['Team', '∼5–25 engineers'],
-      ['Mode', 'IC or TL'],
-    ],
+      'I’m an AI engineer on an Applied AI team supporting the whole org. The roles likely to make it past this page: principal-level Applied AI at top-tier teams, or any role at Anthropic / OpenAI. Everything else is a stretch.',
   },
   {
-    num: 'R.03 · Anthropic / OpenAI · any role',
-    status: { label: 'Always · any role', tone: 'ok' },
-    title: 'The two labs I’d hear out for almost anything.',
+    num: 'R.03 · The pitch',
+    status: { label: 'How to clear it', tone: 'ok' },
+    title: 'Hand-crafted, or auto-filtered.',
     desc:
-      'Engineering, applied research, infra — happy to chat. The frontier labs are the exception to most of my other filters.',
-    meta: [
-      ['Companies', 'Anthropic · OpenAI'],
-      ['Roles', 'Engineering / applied'],
-      ['Bar', 'Their bar, I trust'],
-    ],
-  },
-  {
-    num: 'R.04 · Anthropic / OpenAI DevRel',
-    status: { label: 'Sole DevRel exception', tone: 'ok' },
-    title: 'The only DevRel role I’d actively consider.',
-    desc:
-      "Everywhere else, I'm not interested in DevRel. The frontier labs are the exception — their audience is the one worth speaking to from that seat.",
-    meta: [
-      ['Roles', 'DevRel · DX · Advocate'],
-      ['Companies', 'Anthropic · OpenAI'],
-      ['Mode', 'Hybrid OK'],
-    ],
-  },
-]
-
-const yesSignals = [
-  {
-    lede: 'Personalized.',
-    gloss:
-      'Addresses me by name. References something I’ve actually written or shipped — a specific post, talk, or repo.',
-  },
-  {
-    lede: 'Comp range upfront.',
-    gloss:
-      'A concrete TC range, or an explicit “compensation is openly discussed.” Below my floor? Just say so — saves us both a round-trip.',
-  },
-  {
-    lede: 'Real role description.',
-    gloss:
-      'Team size, reporting line, scope, remote policy, on-call. Specifics that signal you’ve talked to the hiring manager.',
-  },
-  {
-    lede: 'Sent by someone close to the role.',
-    gloss:
-      'Internal recruiter or hiring manager directly. Agency outreach is fine when it carries the same level of detail.',
-  },
-]
-
-const noSignals = [
-  {
-    lede: 'Template blasts.',
-    gloss:
-      'Generic openings, “Hi {first_name}”, no personalization, mass-CC headers. Auto-declined with a one-liner.',
-  },
-  {
-    lede: 'DevRel / Developer Advocate / DX.',
-    gloss:
-      'I’m an engineer, not in DevRel. The only exception is Anthropic and OpenAI — see R.04.',
-  },
-  {
-    lede: 'Engineering outside AI.',
-    gloss:
-      'Mobile, frontend without an AI angle, sales engineering, full-stack web, embedded, blockchain. Not what I do.',
-  },
-  {
-    lede: 'Total comp below my floor.',
-    gloss:
-      'I’m an AI engineer on an Applied AI team supporting the whole org. To consider leaving a place I’m still happy and learning at, I need real upside in scope and comp.',
-  },
-  {
-    lede: 'Pre-approved content · paid placements · link exchanges.',
-    gloss:
-      'Different bucket — see /partnerships for editorial standards. Don’t pitch a job in the same email as a sponsorship ask.',
-  },
-]
-
-const procSteps = [
-  {
-    pn: '01 · Confirm fit',
-    title: 'Check the bar before sending.',
-    body:
-      'AI engineering role. Comp well above my current package. Not DevRel (unless Anthropic / OpenAI). Not outside the AI domain.',
-    when: '30 seconds',
-  },
-  {
-    pn: '02 · Write a real email',
-    title: 'Address me by name. Lead with role + comp.',
-    body:
-      'First three lines: who you are, what the role is, the TC range. Then team / reporting / remote. Two paragraphs is plenty.',
-    when: '5 minutes',
-  },
-  {
-    pn: '03 · Send it directly',
-    title: 'No InMail · no agency CRM blasts.',
-    body:
-      'Direct email beats LinkedIn — InMail is high-noise and easy to miss. Forwarded chains and CRM templates land in spam.',
-    when: 'Same day',
-  },
-  {
-    pn: '04 · I reply within ~5 business days',
-    title: 'Yes, no, or a question.',
-    body:
-      'Hand-drafted, well-targeted outreach gets a real reply. Template blasts get a one-line decline that points back here.',
-    when: '≤ 5 business days',
+      'If you clear the bar, send a hand-crafted email — name the role, the comp range, and what about my work prompted you to reach out. Templates get flagged. Templates you ran through ChatGPT or Claude to disguise still get flagged — the classifier reads those too.',
   },
 ]
 
@@ -151,8 +42,8 @@ export function RecruitersContent() {
       <section className="c-hero">
         <div className="container mx-auto max-w-6xl px-4 md:px-6">
           <div className="kicker">
-            § R · <em>Recruiter brief</em> · Status · What I&apos;d consider ·
-            How to reach me
+            § R · <em>For recruiters</em> · Not looking · How to reach me
+            anyway
           </div>
 
           <div className="dispatch">
@@ -163,15 +54,14 @@ export function RecruitersContent() {
                 me
               </div>
               <h1 className="dispatch-display">
-                AI engineer on an Applied AI team,{' '}
-                <em>supporting the whole org</em>.
+                Not actively looking.{' '}
+                <em>Here&apos;s the bar your pitch has to clear.</em>
               </h1>
               <p className="dispatch-lead">
-                If we both spend 30 seconds reading this page before writing the
-                email, we save a lot of back-and-forth. I&apos;m not actively
-                looking — I&apos;m still happy and learning where I am — but I
-                do hear out the right roles. Below is what those look like and
-                what they don&apos;t.
+                My inbox runs through an AI classifier. It auto-filters anything
+                below the bar so we both save time. The three rules below are
+                what your message has to clear before I read it. If you&apos;re
+                confident, the direct line is at the bottom.
               </p>
             </div>
             <aside className="dispatch-side">
@@ -184,19 +74,17 @@ export function RecruitersContent() {
             </aside>
           </div>
 
-          {/* Status slab — mirrors aud-slab on /partnerships */}
+          {/* Status slab — 4 cells, all short */}
           <div className="aud-slab">
             <div className="aud-cell">
-              <div className="aud-k">Current role</div>
+              <div className="aud-k">Role</div>
               <div className="aud-v">AI engineer</div>
-              <div className="aud-sub">Applied AI · supporting whole org</div>
+              <div className="aud-sub">Applied AI</div>
             </div>
             <div className="aud-cell">
-              <div className="aud-k">Tenure</div>
-              <div className="aud-v">
-                ∼2<span className="unit">years</span>
-              </div>
-              <div className="aud-sub">Still happy and learning</div>
+              <div className="aud-k">Team</div>
+              <div className="aud-v"><em>Whole</em> org</div>
+              <div className="aud-sub">Cross-functional support</div>
             </div>
             <div className="aud-cell">
               <div className="aud-k">Status</div>
@@ -205,50 +93,24 @@ export function RecruitersContent() {
             </div>
             <div className="aud-cell">
               <div className="aud-k">Bar</div>
-              <div className="aud-v">Real upside</div>
-              <div className="aud-sub">Scope and comp both</div>
+              <div className="aud-v">Both</div>
+              <div className="aud-sub">$300K+ base · equity</div>
             </div>
-          </div>
-
-          <div className="avail-strip" style={{ marginTop: 24 }}>
-            <span className="slot">
-              <span className="dot" />
-              <span className="k">AI engineering</span>&nbsp;
-              <span className="v">Selectively</span>
-            </span>
-            <span className="sep">·</span>
-            <span className="slot">
-              <span className="dot" />
-              <span className="k">Anthropic / OpenAI</span>&nbsp;
-              <span className="v">Always</span>
-            </span>
-            <span className="sep">·</span>
-            <span className="slot">
-              <span className="dot warn" />
-              <span className="k">DevRel elsewhere</span>&nbsp;
-              <span className="v">Closed</span>
-            </span>
-            <span className="sep">·</span>
-            <span className="slot">
-              <span className="dot warn" />
-              <span className="k">Below minimal TC</span>&nbsp;
-              <span className="v">Save us both the email</span>
-            </span>
           </div>
         </div>
       </section>
 
-      {/* Roles I'd actually consider */}
+      {/* Three rules — replaces rate grid + yes/no + process */}
       <section>
         <div className="container mx-auto max-w-6xl px-4 md:px-6 rates-wrap">
           <header className="rates-head">
             <div className="num">§ 01</div>
-            <h2>Roles I&apos;d <em>actually consider</em>.</h2>
-            <span className="more">R.01 — R.04</span>
+            <h2>The <em>three rules</em>.</h2>
+            <span className="more">R.01 — R.03</span>
           </header>
 
           <div className="rates-grid">
-            {roles.map((r) => (
+            {rules.map((r) => (
               <div key={r.num} className="rate">
                 <div className="rate-top">
                   <span className="rate-num">{r.num}</span>
@@ -259,101 +121,30 @@ export function RecruitersContent() {
                 </div>
                 <h3 className="rate-title">{r.title}</h3>
                 <p className="rate-desc">{r.desc}</p>
-                <div className="rate-meta">
-                  {r.meta.map(([k, v]) => (
-                    <div key={k} className="m">
-                      <div className="mk">{k}</div>
-                      <div className="mv">{v}</div>
-                    </div>
-                  ))}
-                </div>
               </div>
             ))}
           </div>
         </div>
       </section>
 
-      {/* Yes signals / No signals */}
-      <section>
-        <div className="standards-wrap">
-          <div className="container mx-auto max-w-6xl px-4 md:px-6 standards-grid">
-            <div>
-              <header className="stand-head">
-                <span className="num">§ 02</span>
-                <h3>What gets a <em>real reply</em>.</h3>
-              </header>
-              <ul className="stand-list">
-                {yesSignals.map((s) => (
-                  <li key={s.lede}>
-                    <span className="glyph">✓</span>
-                    <span>
-                      <span className="lede">{s.lede}</span>
-                      <span className="gloss">{s.gloss}</span>
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <header className="stand-head">
-                <span className="num">§ 03</span>
-                <h3>What I <em>won&apos;t engage with</em>.</h3>
-              </header>
-              <ul className="stand-list">
-                {noSignals.map((s) => (
-                  <li key={s.lede}>
-                    <span className="glyph no">×</span>
-                    <span>
-                      <span className="lede">{s.lede}</span>
-                      <span className="gloss">{s.gloss}</span>
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Process */}
-      <section>
-        <div className="container mx-auto max-w-6xl px-4 md:px-6 proc-wrap">
-          <header className="proc-head">
-            <span className="num">§ 04</span>
-            <h2>How to <em>reach me</em>.</h2>
-          </header>
-          <div className="proc-grid">
-            {procSteps.map((s) => (
-              <div key={s.pn} className="proc-step">
-                <div className="pn">{s.pn}</div>
-                <h4>{s.title}</h4>
-                <p>{s.body}</p>
-                <span className="when">{s.when}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Direct line / Why */}
+      {/* Direct line + Why */}
       <section>
         <div className="container mx-auto max-w-6xl px-4 md:px-6 intake-wrap">
           <div className="intake-grid">
             <div>
               <div className="db-head">
-                <div className="num">§ 05</div>
+                <div className="num">§ 02</div>
                 <h3>Direct line.</h3>
               </div>
               <p className="intake-lead">
-                For roles that clear the bar above —{' '}
+                If your role clears all three rules —{' '}
                 <a href={`mailto:${CONTACT_EMAIL}`}><code>{CONTACT_EMAIL}</code></a>.
-                Lead with the role, the TC range, the team, and the remote
-                policy. Two paragraphs is plenty.
+                Three sentences is plenty. Name the role, the comp, the reason
+                you&apos;re writing.
               </p>
               <p className="intake-lead">
-                I reply within ~5 business days when there&apos;s a fit. Template
-                blasts get a one-line decline that points back here so you know
-                for next time.
+                Real replies within ~5 business days. Templates get a one-line
+                decline that points back here so you know for next time.
               </p>
             </div>
 
@@ -361,10 +152,9 @@ export function RecruitersContent() {
               <div>
                 <h4>Why this page exists</h4>
                 <p>
-                  Engineering attention is expensive. We both win when low-fit
+                  Engineering attention is expensive. Both of us win when low-fit
                   outreach gets a fast &ldquo;no&rdquo; so high-fit roles get a
-                  fast &ldquo;tell me more.&rdquo; This page lets you self-screen
-                  in 30 seconds.
+                  fast &ldquo;tell me more.&rdquo;
                 </p>
               </div>
 

--- a/src/app/recruiters/RecruitersContent.jsx
+++ b/src/app/recruiters/RecruitersContent.jsx
@@ -4,15 +4,15 @@ const CONTACT_EMAIL = 'zackproser@gmail.com'
 
 const roles = [
   {
-    num: 'R.01 · Senior+ AI/ML engineering',
-    status: { label: 'Open if compelling', tone: 'ok' },
-    title: 'A real role at a place that ships AI to users.',
+    num: 'R.01 · AI/ML engineering',
+    status: { label: 'Selectively', tone: 'ok' },
+    title: 'Senior+ engineer building applied AI in production.',
     desc:
-      "Senior, staff, or principal. Building applied AI systems — retrieval, agents, LLM pipelines, evals, ML infra. Not research-only. I'm an engineer who ships, not a paper author.",
+      'Retrieval, agents, evals, ML infra. Real systems shipping to real users. Not research-only — I ship; I don’t write papers.',
     meta: [
       ['Level', 'Senior → Principal'],
       ['Stack', 'Python/TS · LLMs · infra'],
-      ['Comp', '$250K+ TC'],
+      ['Mode', 'IC'],
     ],
   },
   {
@@ -20,35 +20,35 @@ const roles = [
     status: { label: 'Open', tone: 'ok' },
     title: 'Build the substrate teams use to ship AI internally.',
     desc:
-      "Platform / infra work — eval frameworks, model-routing, agent runtimes, retrieval pipelines, observability. The closer to the metal of real-world LLM systems, the better.",
+      'Eval frameworks, model-routing, agent runtimes, retrieval pipelines, observability. The closer to the metal of real LLM systems, the better.',
     meta: [
-      ['Type', 'Platform/infra'],
-      ['Team', '∼5–25 engs'],
-      ['Comp', '$250K+ TC'],
+      ['Type', 'Platform / infra'],
+      ['Team', '∼5–25 engineers'],
+      ['Mode', 'IC or TL'],
     ],
   },
   {
     num: 'R.03 · Anthropic / OpenAI · any role',
-    status: { label: 'Always open', tone: 'ok' },
-    title: 'The two AI labs I would hear out for almost anything.',
+    status: { label: 'Always · any role', tone: 'ok' },
+    title: 'The two labs I’d hear out for almost anything.',
     desc:
-      'Engineering, applied research, infra — happy to chat. The labs are exceptions to most of my other filters.',
+      'Engineering, applied research, infra — happy to chat. The frontier labs are the exception to most of my other filters.',
     meta: [
       ['Companies', 'Anthropic · OpenAI'],
       ['Roles', 'Engineering / applied'],
-      ['Comp', "Their comp, I trust"],
+      ['Bar', 'Their bar, I trust'],
     ],
   },
   {
     num: 'R.04 · Anthropic / OpenAI DevRel',
-    status: { label: 'The DevRel exception', tone: 'ok' },
-    title: 'The only DevRel roles I would actively consider.',
+    status: { label: 'Sole DevRel exception', tone: 'ok' },
+    title: 'The only DevRel role I’d actively consider.',
     desc:
-      "Everywhere else, I'm not interested in DevRel — I work as an engineer and want to keep doing that. The frontier labs are the exception because of who their audience is.",
+      "Everywhere else, I'm not interested in DevRel. The frontier labs are the exception — their audience is the one worth speaking to from that seat.",
     meta: [
-      ['Roles', 'DevRel / DX / Advocate'],
+      ['Roles', 'DevRel · DX · Advocate'],
       ['Companies', 'Anthropic · OpenAI'],
-      ['Comp', '$250K+ TC'],
+      ['Mode', 'Hybrid OK'],
     ],
   },
 ]
@@ -57,22 +57,22 @@ const yesSignals = [
   {
     lede: 'Personalized.',
     gloss:
-      'Addresses me by name. References something I have actually written or shipped — a specific blog post, talk, or repo.',
+      'Addresses me by name. References something I’ve actually written or shipped — a specific post, talk, or repo.',
   },
   {
-    lede: 'Total comp range upfront.',
+    lede: 'Comp range upfront.',
     gloss:
-      'Either a concrete range or an explicit "compensation is openly discussed." If TC is below $250K, just say so — saves both of us a round-trip.',
+      'A concrete TC range, or an explicit “compensation is openly discussed.” Below my floor? Just say so — saves us both a round-trip.',
   },
   {
     lede: 'Real role description.',
     gloss:
-      "Team size, reporting line, scope of the role, remote policy, on-call expectations. Specifics that make it clear you've spoken to the hiring manager.",
+      'Team size, reporting line, scope, remote policy, on-call. Specifics that signal you’ve talked to the hiring manager.',
   },
   {
     lede: 'Sent by someone close to the role.',
     gloss:
-      'Internal recruiter or the hiring manager themselves. External agency outreach is fine when it carries the same level of detail.',
+      'Internal recruiter or hiring manager directly. Agency outreach is fine when it carries the same level of detail.',
   },
 ]
 
@@ -80,27 +80,27 @@ const noSignals = [
   {
     lede: 'Template blasts.',
     gloss:
-      'Generic openings, "Hi {first_name}", no personalization, mass-CC visible in headers. Auto-declined with a polite one-liner.',
+      'Generic openings, “Hi {first_name}”, no personalization, mass-CC headers. Auto-declined with a one-liner.',
   },
   {
-    lede: 'DevRel / Developer Advocate / DX / Community.',
+    lede: 'DevRel / Developer Advocate / DX.',
     gloss:
-      "I'm an engineer, not in DevRel. The only exception is Anthropic and OpenAI — see R.04.",
+      'I’m an engineer, not in DevRel. The only exception is Anthropic and OpenAI — see R.04.',
   },
   {
     lede: 'Engineering outside AI.',
     gloss:
-      'Mobile, frontend without an AI angle, sales engineering, full-stack web, embedded, blockchain. Not what I do or want to do.',
+      'Mobile, frontend without an AI angle, sales engineering, full-stack web, embedded, blockchain. Not what I do.',
   },
   {
-    lede: 'Total comp under $250K.',
+    lede: 'Total comp below my floor.',
     gloss:
-      "I'm a senior AI engineer at WorkOS, ∼2 years in, raise expected. To consider a move I need $250K+ TC. Junior/mid-level positioning is an instant no.",
+      'I’m an AI engineer on an Applied AI team supporting the whole org. To consider leaving a place I’m still happy and learning at, I need real upside in scope and comp.',
   },
   {
-    lede: 'Pre-approved-content / paid placements / link exchanges.',
+    lede: 'Pre-approved content · paid placements · link exchanges.',
     gloss:
-      "Different bucket entirely — see /partnerships for editorial standards. Don't pitch a job in the same email as a sponsorship ask.",
+      'Different bucket — see /partnerships for editorial standards. Don’t pitch a job in the same email as a sponsorship ask.',
   },
 ]
 
@@ -109,28 +109,28 @@ const procSteps = [
     pn: '01 · Confirm fit',
     title: 'Check the bar before sending.',
     body:
-      "Senior+ AI engineering role. $250K+ TC. Not DevRel (unless Anthropic/OpenAI). Not outside the AI domain.",
+      'AI engineering role. Comp well above my current package. Not DevRel (unless Anthropic / OpenAI). Not outside the AI domain.',
     when: '30 seconds',
   },
   {
     pn: '02 · Write a real email',
-    title: "Address me by name. Lead with the role + comp.",
+    title: 'Address me by name. Lead with role + comp.',
     body:
-      "First three lines: who you are, what the role is, the TC range. Then team / reporting / remote. Two paragraphs is plenty.",
+      'First three lines: who you are, what the role is, the TC range. Then team / reporting / remote. Two paragraphs is plenty.',
     when: '5 minutes',
   },
   {
-    pn: '03 · Send to the address below',
-    title: "No InMail / LinkedIn forms / agency CRM blasts.",
+    pn: '03 · Send it directly',
+    title: 'No InMail · no agency CRM blasts.',
     body:
-      "Direct email beats LinkedIn — InMail is high-noise and easy to miss. Forwarded chains and CRM templates land in spam.",
+      'Direct email beats LinkedIn — InMail is high-noise and easy to miss. Forwarded chains and CRM templates land in spam.',
     when: 'Same day',
   },
   {
     pn: '04 · I reply within ~5 business days',
-    title: "Yes, no, or a question.",
+    title: 'Yes, no, or a question.',
     body:
-      "Hand-drafted, well-targeted outreach gets a real reply. Template blasts get a one-line decline pointing back here.",
+      'Hand-drafted, well-targeted outreach gets a real reply. Template blasts get a one-line decline that points back here.',
     when: '≤ 5 business days',
   },
 ]
@@ -163,15 +163,15 @@ export function RecruitersContent() {
                 me
               </div>
               <h1 className="dispatch-display">
-                I&apos;m a senior AI engineer at WorkOS.{' '}
-                <em>Here&apos;s how to reach me productively</em> about roles.
+                AI engineer on an Applied AI team,{' '}
+                <em>supporting the whole org</em>.
               </h1>
               <p className="dispatch-lead">
-                If we both spend 30 seconds reading what&apos;s on this page
-                before writing the email, we save a lot of back-and-forth.
-                I&apos;m not actively looking, but I do hear out the right
-                roles. Here&apos;s what those look like — and what they
-                don&apos;t.
+                If we both spend 30 seconds reading this page before writing the
+                email, we save a lot of back-and-forth. I&apos;m not actively
+                looking — I&apos;m still happy and learning where I am — but I
+                do hear out the right roles. Below is what those look like and
+                what they don&apos;t.
               </p>
             </div>
             <aside className="dispatch-side">
@@ -179,7 +179,7 @@ export function RecruitersContent() {
               <div className="a-plate">ZP</div>
               <div className="who">Zachary Proser</div>
               <div className="role">
-                Senior AI Engineer · Applied AI · WorkOS · Brooklyn, NY · GMT−5
+                AI Engineer · Applied AI · Brooklyn, NY · GMT−5
               </div>
             </aside>
           </div>
@@ -188,41 +188,39 @@ export function RecruitersContent() {
           <div className="aud-slab">
             <div className="aud-cell">
               <div className="aud-k">Current role</div>
-              <div className="aud-v">Senior AI eng.</div>
-              <div className="aud-sub">WorkOS · Applied AI team</div>
+              <div className="aud-v">AI engineer</div>
+              <div className="aud-sub">Applied AI · supporting whole org</div>
             </div>
             <div className="aud-cell">
               <div className="aud-k">Tenure</div>
               <div className="aud-v">
                 ∼2<span className="unit">years</span>
               </div>
-              <div className="aud-sub">Coming up on 2-year mark · raise expected</div>
+              <div className="aud-sub">Still happy and learning</div>
             </div>
             <div className="aud-cell">
               <div className="aud-k">Status</div>
               <div className="aud-v"><em>Not</em> looking</div>
-              <div className="aud-sub">Happy here · open to the right thing</div>
+              <div className="aud-sub">Open to the right thing</div>
             </div>
             <div className="aud-cell">
-              <div className="aud-k">Comp bar</div>
-              <div className="aud-v">
-                $250k<span className="unit">+ TC</span>
-              </div>
-              <div className="aud-sub">To consider leaving WorkOS</div>
+              <div className="aud-k">Bar</div>
+              <div className="aud-v">Real upside</div>
+              <div className="aud-sub">Scope and comp both</div>
             </div>
           </div>
 
           <div className="avail-strip" style={{ marginTop: 24 }}>
             <span className="slot">
               <span className="dot" />
-              <span className="k">Senior+ AI eng.</span>&nbsp;
-              <span className="v">Open if compelling</span>
+              <span className="k">AI engineering</span>&nbsp;
+              <span className="v">Selectively</span>
             </span>
             <span className="sep">·</span>
             <span className="slot">
               <span className="dot" />
               <span className="k">Anthropic / OpenAI</span>&nbsp;
-              <span className="v">Always open</span>
+              <span className="v">Always</span>
             </span>
             <span className="sep">·</span>
             <span className="slot">
@@ -233,8 +231,8 @@ export function RecruitersContent() {
             <span className="sep">·</span>
             <span className="slot">
               <span className="dot warn" />
-              <span className="k">{'< $250K TC'}</span>&nbsp;
-              <span className="v">Closed</span>
+              <span className="k">Below minimal TC</span>&nbsp;
+              <span className="v">Save us both the email</span>
             </span>
           </div>
         </div>
@@ -354,8 +352,8 @@ export function RecruitersContent() {
               </p>
               <p className="intake-lead">
                 I reply within ~5 business days when there&apos;s a fit. Template
-                blasts get a one-line decline pointing back here so you know for
-                next time.
+                blasts get a one-line decline that points back here so you know
+                for next time.
               </p>
             </div>
 
@@ -375,8 +373,7 @@ export function RecruitersContent() {
                 <p className="partners">
                   Pinecone (vector DB / RAG) · Gruntwork (Terragrunt &amp;
                   OpenTofu) · Cloudflare (workers, edge) · Cloudmark / Proofpoint
-                  (anti-spam) ·{' '}
-                  <em>currently WorkOS, applied AI</em>.
+                  (anti-spam) · <em>currently Applied AI</em>.
                 </p>
               </div>
 

--- a/src/app/recruiters/RecruitersContent.jsx
+++ b/src/app/recruiters/RecruitersContent.jsx
@@ -1,0 +1,422 @@
+import Link from 'next/link'
+
+const CONTACT_EMAIL = 'zackproser@gmail.com'
+
+const roles = [
+  {
+    num: 'R.01 · Senior+ AI/ML engineering',
+    status: { label: 'Open if compelling', tone: 'ok' },
+    title: 'A real role at a place that ships AI to users.',
+    desc:
+      "Senior, staff, or principal. Building applied AI systems — retrieval, agents, LLM pipelines, evals, ML infra. Not research-only. I'm an engineer who ships, not a paper author.",
+    meta: [
+      ['Level', 'Senior → Principal'],
+      ['Stack', 'Python/TS · LLMs · infra'],
+      ['Comp', '$250K+ TC'],
+    ],
+  },
+  {
+    num: 'R.02 · Applied AI / ML platform',
+    status: { label: 'Open', tone: 'ok' },
+    title: 'Build the substrate teams use to ship AI internally.',
+    desc:
+      "Platform / infra work — eval frameworks, model-routing, agent runtimes, retrieval pipelines, observability. The closer to the metal of real-world LLM systems, the better.",
+    meta: [
+      ['Type', 'Platform/infra'],
+      ['Team', '∼5–25 engs'],
+      ['Comp', '$250K+ TC'],
+    ],
+  },
+  {
+    num: 'R.03 · Anthropic / OpenAI · any role',
+    status: { label: 'Always open', tone: 'ok' },
+    title: 'The two AI labs I would hear out for almost anything.',
+    desc:
+      'Engineering, applied research, infra — happy to chat. The labs are exceptions to most of my other filters.',
+    meta: [
+      ['Companies', 'Anthropic · OpenAI'],
+      ['Roles', 'Engineering / applied'],
+      ['Comp', "Their comp, I trust"],
+    ],
+  },
+  {
+    num: 'R.04 · Anthropic / OpenAI DevRel',
+    status: { label: 'The DevRel exception', tone: 'ok' },
+    title: 'The only DevRel roles I would actively consider.',
+    desc:
+      "Everywhere else, I'm not interested in DevRel — I work as an engineer and want to keep doing that. The frontier labs are the exception because of who their audience is.",
+    meta: [
+      ['Roles', 'DevRel / DX / Advocate'],
+      ['Companies', 'Anthropic · OpenAI'],
+      ['Comp', '$250K+ TC'],
+    ],
+  },
+]
+
+const yesSignals = [
+  {
+    lede: 'Personalized.',
+    gloss:
+      'Addresses me by name. References something I have actually written or shipped — a specific blog post, talk, or repo.',
+  },
+  {
+    lede: 'Total comp range upfront.',
+    gloss:
+      'Either a concrete range or an explicit "compensation is openly discussed." If TC is below $250K, just say so — saves both of us a round-trip.',
+  },
+  {
+    lede: 'Real role description.',
+    gloss:
+      "Team size, reporting line, scope of the role, remote policy, on-call expectations. Specifics that make it clear you've spoken to the hiring manager.",
+  },
+  {
+    lede: 'Sent by someone close to the role.',
+    gloss:
+      'Internal recruiter or the hiring manager themselves. External agency outreach is fine when it carries the same level of detail.',
+  },
+]
+
+const noSignals = [
+  {
+    lede: 'Template blasts.',
+    gloss:
+      'Generic openings, "Hi {first_name}", no personalization, mass-CC visible in headers. Auto-declined with a polite one-liner.',
+  },
+  {
+    lede: 'DevRel / Developer Advocate / DX / Community.',
+    gloss:
+      "I'm an engineer, not in DevRel. The only exception is Anthropic and OpenAI — see R.04.",
+  },
+  {
+    lede: 'Engineering outside AI.',
+    gloss:
+      'Mobile, frontend without an AI angle, sales engineering, full-stack web, embedded, blockchain. Not what I do or want to do.',
+  },
+  {
+    lede: 'Total comp under $250K.',
+    gloss:
+      "I'm a senior AI engineer at WorkOS, ∼2 years in, raise expected. To consider a move I need $250K+ TC. Junior/mid-level positioning is an instant no.",
+  },
+  {
+    lede: 'Pre-approved-content / paid placements / link exchanges.',
+    gloss:
+      "Different bucket entirely — see /partnerships for editorial standards. Don't pitch a job in the same email as a sponsorship ask.",
+  },
+]
+
+const procSteps = [
+  {
+    pn: '01 · Confirm fit',
+    title: 'Check the bar before sending.',
+    body:
+      "Senior+ AI engineering role. $250K+ TC. Not DevRel (unless Anthropic/OpenAI). Not outside the AI domain.",
+    when: '30 seconds',
+  },
+  {
+    pn: '02 · Write a real email',
+    title: "Address me by name. Lead with the role + comp.",
+    body:
+      "First three lines: who you are, what the role is, the TC range. Then team / reporting / remote. Two paragraphs is plenty.",
+    when: '5 minutes',
+  },
+  {
+    pn: '03 · Send to the address below',
+    title: "No InMail / LinkedIn forms / agency CRM blasts.",
+    body:
+      "Direct email beats LinkedIn — InMail is high-noise and easy to miss. Forwarded chains and CRM templates land in spam.",
+    when: 'Same day',
+  },
+  {
+    pn: '04 · I reply within ~5 business days',
+    title: "Yes, no, or a question.",
+    body:
+      "Hand-drafted, well-targeted outreach gets a real reply. Template blasts get a one-line decline pointing back here.",
+    when: '≤ 5 business days',
+  },
+]
+
+export function RecruitersContent() {
+  return (
+    <div className="contact-page partnerships-page editorial-home min-h-screen text-charcoal-50 dark:text-parchment-100">
+      {/* Breadcrumb */}
+      <div className="container mx-auto max-w-6xl px-4 md:px-6">
+        <div className="post-crumbs">
+          <Link href="/">Home</Link>
+          <span className="sep">/</span>
+          <span className="current">For recruiters</span>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <section className="c-hero">
+        <div className="container mx-auto max-w-6xl px-4 md:px-6">
+          <div className="kicker">
+            § R · <em>Recruiter brief</em> · Status · What I&apos;d consider ·
+            How to reach me
+          </div>
+
+          <div className="dispatch">
+            <div>
+              <div className="brand-lockup">
+                <b>Zack Proser</b> <span className="slash">/</span>{' '}
+                <em>zackproser.com</em> <span className="slash">·</span> hiring
+                me
+              </div>
+              <h1 className="dispatch-display">
+                I&apos;m a senior AI engineer at WorkOS.{' '}
+                <em>Here&apos;s how to reach me productively</em> about roles.
+              </h1>
+              <p className="dispatch-lead">
+                If we both spend 30 seconds reading what&apos;s on this page
+                before writing the email, we save a lot of back-and-forth.
+                I&apos;m not actively looking, but I do hear out the right
+                roles. Here&apos;s what those look like — and what they
+                don&apos;t.
+              </p>
+            </div>
+            <aside className="dispatch-side">
+              <span className="label">Issued</span>
+              <div className="a-plate">ZP</div>
+              <div className="who">Zachary Proser</div>
+              <div className="role">
+                Senior AI Engineer · Applied AI · WorkOS · Brooklyn, NY · GMT−5
+              </div>
+            </aside>
+          </div>
+
+          {/* Status slab — mirrors aud-slab on /partnerships */}
+          <div className="aud-slab">
+            <div className="aud-cell">
+              <div className="aud-k">Current role</div>
+              <div className="aud-v">Senior AI eng.</div>
+              <div className="aud-sub">WorkOS · Applied AI team</div>
+            </div>
+            <div className="aud-cell">
+              <div className="aud-k">Tenure</div>
+              <div className="aud-v">
+                ∼2<span className="unit">years</span>
+              </div>
+              <div className="aud-sub">Coming up on 2-year mark · raise expected</div>
+            </div>
+            <div className="aud-cell">
+              <div className="aud-k">Status</div>
+              <div className="aud-v"><em>Not</em> looking</div>
+              <div className="aud-sub">Happy here · open to the right thing</div>
+            </div>
+            <div className="aud-cell">
+              <div className="aud-k">Comp bar</div>
+              <div className="aud-v">
+                $250k<span className="unit">+ TC</span>
+              </div>
+              <div className="aud-sub">To consider leaving WorkOS</div>
+            </div>
+          </div>
+
+          <div className="avail-strip" style={{ marginTop: 24 }}>
+            <span className="slot">
+              <span className="dot" />
+              <span className="k">Senior+ AI eng.</span>&nbsp;
+              <span className="v">Open if compelling</span>
+            </span>
+            <span className="sep">·</span>
+            <span className="slot">
+              <span className="dot" />
+              <span className="k">Anthropic / OpenAI</span>&nbsp;
+              <span className="v">Always open</span>
+            </span>
+            <span className="sep">·</span>
+            <span className="slot">
+              <span className="dot warn" />
+              <span className="k">DevRel elsewhere</span>&nbsp;
+              <span className="v">Closed</span>
+            </span>
+            <span className="sep">·</span>
+            <span className="slot">
+              <span className="dot warn" />
+              <span className="k">{'< $250K TC'}</span>&nbsp;
+              <span className="v">Closed</span>
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Roles I'd actually consider */}
+      <section>
+        <div className="container mx-auto max-w-6xl px-4 md:px-6 rates-wrap">
+          <header className="rates-head">
+            <div className="num">§ 01</div>
+            <h2>Roles I&apos;d <em>actually consider</em>.</h2>
+            <span className="more">R.01 — R.04</span>
+          </header>
+
+          <div className="rates-grid">
+            {roles.map((r) => (
+              <div key={r.num} className="rate">
+                <div className="rate-top">
+                  <span className="rate-num">{r.num}</span>
+                  <span className={`rate-status${r.status.tone === 'warn' ? ' warn' : ''}`}>
+                    <span className="dot" />
+                    {r.status.label}
+                  </span>
+                </div>
+                <h3 className="rate-title">{r.title}</h3>
+                <p className="rate-desc">{r.desc}</p>
+                <div className="rate-meta">
+                  {r.meta.map(([k, v]) => (
+                    <div key={k} className="m">
+                      <div className="mk">{k}</div>
+                      <div className="mv">{v}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Yes signals / No signals */}
+      <section>
+        <div className="standards-wrap">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6 standards-grid">
+            <div>
+              <header className="stand-head">
+                <span className="num">§ 02</span>
+                <h3>What gets a <em>real reply</em>.</h3>
+              </header>
+              <ul className="stand-list">
+                {yesSignals.map((s) => (
+                  <li key={s.lede}>
+                    <span className="glyph">✓</span>
+                    <span>
+                      <span className="lede">{s.lede}</span>
+                      <span className="gloss">{s.gloss}</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <header className="stand-head">
+                <span className="num">§ 03</span>
+                <h3>What I <em>won&apos;t engage with</em>.</h3>
+              </header>
+              <ul className="stand-list">
+                {noSignals.map((s) => (
+                  <li key={s.lede}>
+                    <span className="glyph no">×</span>
+                    <span>
+                      <span className="lede">{s.lede}</span>
+                      <span className="gloss">{s.gloss}</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Process */}
+      <section>
+        <div className="container mx-auto max-w-6xl px-4 md:px-6 proc-wrap">
+          <header className="proc-head">
+            <span className="num">§ 04</span>
+            <h2>How to <em>reach me</em>.</h2>
+          </header>
+          <div className="proc-grid">
+            {procSteps.map((s) => (
+              <div key={s.pn} className="proc-step">
+                <div className="pn">{s.pn}</div>
+                <h4>{s.title}</h4>
+                <p>{s.body}</p>
+                <span className="when">{s.when}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Direct line / Why */}
+      <section>
+        <div className="container mx-auto max-w-6xl px-4 md:px-6 intake-wrap">
+          <div className="intake-grid">
+            <div>
+              <div className="db-head">
+                <div className="num">§ 05</div>
+                <h3>Direct line.</h3>
+              </div>
+              <p className="intake-lead">
+                For roles that clear the bar above —{' '}
+                <a href={`mailto:${CONTACT_EMAIL}`}><code>{CONTACT_EMAIL}</code></a>.
+                Lead with the role, the TC range, the team, and the remote
+                policy. Two paragraphs is plenty.
+              </p>
+              <p className="intake-lead">
+                I reply within ~5 business days when there&apos;s a fit. Template
+                blasts get a one-line decline pointing back here so you know for
+                next time.
+              </p>
+            </div>
+
+            <aside className="intake-side">
+              <div>
+                <h4>Why this page exists</h4>
+                <p>
+                  Engineering attention is expensive. We both win when low-fit
+                  outreach gets a fast &ldquo;no&rdquo; so high-fit roles get a
+                  fast &ldquo;tell me more.&rdquo; This page lets you self-screen
+                  in 30 seconds.
+                </p>
+              </div>
+
+              <div>
+                <h4>About my work</h4>
+                <p className="partners">
+                  Pinecone (vector DB / RAG) · Gruntwork (Terragrunt &amp;
+                  OpenTofu) · Cloudflare (workers, edge) · Cloudmark / Proofpoint
+                  (anti-spam) ·{' '}
+                  <em>currently WorkOS, applied AI</em>.
+                </p>
+              </div>
+
+              <div>
+                <h4>See for yourself</h4>
+                <ul className="proof-links">
+                  <li>
+                    <Link href="/speaking">
+                      <span className="pl-num">→ 01</span>
+                      <span className="pl-name">Speaking</span>
+                      <span className="pl-meta">conferences &amp; podcasts</span>
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/publications">
+                      <span className="pl-num">→ 02</span>
+                      <span className="pl-name">Publications</span>
+                      <span className="pl-meta">where my writing runs</span>
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/testimonials">
+                      <span className="pl-num">→ 03</span>
+                      <span className="pl-name">Testimonials</span>
+                      <span className="pl-meta">what colleagues say</span>
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/videos">
+                      <span className="pl-num">→ 04</span>
+                      <span className="pl-name">Videos</span>
+                      <span className="pl-meta">essay-videos &amp; demos</span>
+                    </Link>
+                  </li>
+                </ul>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/recruiters/page.jsx
+++ b/src/app/recruiters/page.jsx
@@ -1,0 +1,32 @@
+import { generateOgUrl } from '@/utils/ogUrl'
+import { RecruitersContent } from './RecruitersContent'
+
+const data = {
+  title: 'For recruiters',
+  description:
+    "How to reach Zack Proser productively about engineering roles. Current status, comp bar, what I'd consider, what I won't, and the brief format that gets a real reply.",
+};
+
+const ogUrl = generateOgUrl(data);
+
+export const metadata = {
+  title: data.title,
+  description: data.description,
+  // Stable URL but explicitly NOT discoverable — this page exists to be linked
+  // from auto-replies to recruiter outreach, not surfaced in nav or search.
+  robots: { index: false, follow: false },
+  alternates: { canonical: 'https://zackproser.com/recruiters' },
+  openGraph: {
+    title: data.title,
+    description: data.description,
+    url: ogUrl,
+    siteName: 'Modern Coding',
+    images: [{ url: ogUrl }],
+    locale: 'en_US',
+    type: 'website',
+  },
+};
+
+export default function RecruitersPage() {
+  return <RecruitersContent />
+}

--- a/src/app/recruiters/page.jsx
+++ b/src/app/recruiters/page.jsx
@@ -19,7 +19,7 @@ export const metadata = {
   openGraph: {
     title: data.title,
     description: data.description,
-    url: ogUrl,
+    url: 'https://zackproser.com/recruiters',
     siteName: 'Modern Coding',
     images: [{ url: ogUrl }],
     locale: 'en_US',

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -14,6 +14,7 @@ const excludeRoutePatterns = [
   /^\/checkout(\/|$)/,
   /^\/success(\/|$)/,
   /^\/login(\/|$)/,
+  /^\/recruiters(\/|$)/,
   /\[.*\]/, // Exclude any literal dynamic route patterns like [slug]
 ];
 


### PR DESCRIPTION
Stable URL the inbound-classifier links to from recruiter auto-replies. Mirrors /partnerships design.

robots: index=false, follow=false. Not linked from nav. Lint clean. See full diff for sections + content.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new mostly-static Next.js page and excludes it from indexing/sitemap, with no changes to auth, data handling, or core application flows.
> 
> **Overview**
> Adds a new `/recruiters` page with a dedicated `RecruitersContent` layout outlining outreach rules and a direct contact email, reusing the existing contact/partnerships styling patterns.
> 
> Marks the route as intentionally non-discoverable via `metadata.robots` (`index: false`, `follow: false`) and explicitly excludes `/recruiters` from `sitemap.js` generation while still providing canonical + Open Graph metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 676f0f5049259bb892f8244dde8d818963fb25b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->