### PR TITLE
Form hardening: honeypot + double-submit guards + server-side dedup

### DIFF
--- a/src/app/api/form/route.ts
+++ b/src/app/api/form/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTagsFromReferrer } from "@/lib/subscriber-tags";
 import { subscribeToResend } from "@/lib/resend-subscribe";
+import { createSubmitDedup } from "@/lib/submit-dedup";
 
 export const maxDuration = 300;
+
+// Same email submitted twice within 30s gets the cached result back rather
+// than re-firing the chain trigger + ops notification. See submit-dedup.ts
+// for the warm-lambda caveat.
+const dedup = createSubmitDedup();
 
 export async function POST(req: NextRequest) {
 	const body = await req.json();
@@ -12,6 +18,22 @@ export async function POST(req: NextRequest) {
 			JSON.stringify({ data: "Error: no valid email found in request" }),
 			{ status: 400 },
 		);
+	}
+
+	// Honeypot: bots auto-fill the hidden `hp` field. Return a fake success
+	// (200, same body shape) so the bot doesn't adapt to a 400 and retry
+	// with a different shape. Never log, never alert, never subscribe.
+	if (typeof body.hp === "string" && body.hp.trim().length > 0) {
+		return new NextResponse(
+			JSON.stringify({ data: `Successfully subscribed ${body.email}` }),
+			{ status: 200 },
+		);
+	}
+
+	const dedupKey = String(body.email).trim().toLowerCase();
+	const cached = dedup.get(dedupKey);
+	if (cached) {
+		return new NextResponse(JSON.stringify(cached), { status: 200 });
 	}
 
 	// Auto-tag based on referrer page (e.g., voice-ai, real-estate, etc.).
@@ -42,10 +64,7 @@ export async function POST(req: NextRequest) {
 		console.warn(`[form] Resend topic warning: ${result.topicWarning}`);
 	}
 
-	return new NextResponse(
-		JSON.stringify({
-			data: `Successfully subscribed ${body.email}`,
-		}),
-		{ status: 200 },
-	);
+	const responseBody = { data: `Successfully subscribed ${body.email}` };
+	dedup.remember(dedupKey, responseBody);
+	return new NextResponse(JSON.stringify(responseBody), { status: 200 });
 }

--- a/src/app/api/waitinglist-subscribe/route.ts
+++ b/src/app/api/waitinglist-subscribe/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTagsFromReferrer } from "@/lib/subscriber-tags";
 import { subscribeToResend } from "@/lib/resend-subscribe";
+import { createSubmitDedup } from "@/lib/submit-dedup";
 
 /**
  * Used to be a separate EmailOctopus list for product waitlists. Post-Resend
@@ -9,8 +10,13 @@ import { subscribeToResend } from "@/lib/resend-subscribe";
  * in one segmentable place instead of fragmenting audiences across multiple
  * lists.
  */
+
+// Own dedup namespace — a regular signup and a waitlist signup for the same
+// email within 30s are distinct intents and should NOT collide.
+const dedup = createSubmitDedup();
+
 export async function POST(req: NextRequest) {
-	const { email, referrer, productSlug } = await req.json();
+	const { email, referrer, productSlug, hp } = await req.json();
 
 	if (!email) {
 		return new NextResponse(
@@ -24,6 +30,21 @@ export async function POST(req: NextRequest) {
 			JSON.stringify({ data: "Error: no product slug found in request" }),
 			{ status: 400 },
 		);
+	}
+
+	// Honeypot — same pattern as /api/form. Fake-success the bot, don't
+	// actually subscribe.
+	if (typeof hp === "string" && hp.trim().length > 0) {
+		return new NextResponse(
+			JSON.stringify({ data: `Successfully added ${email} to ${productSlug} waitlist` }),
+			{ status: 200 },
+		);
+	}
+
+	const dedupKey = `${String(email).trim().toLowerCase()}::${productSlug}`;
+	const cached = dedup.get(dedupKey);
+	if (cached) {
+		return new NextResponse(JSON.stringify(cached), { status: 200 });
 	}
 
 	// Preserve referrer-derived segmentation alongside the waitlist tag so
@@ -59,10 +80,7 @@ export async function POST(req: NextRequest) {
 		console.warn(`[waitinglist] Resend topic warning: ${result.topicWarning}`);
 	}
 
-	return new NextResponse(
-		JSON.stringify({
-			data: `Successfully added ${email} to ${productSlug} waitlist`,
-		}),
-		{ status: 200 },
-	);
+	const responseBody = { data: `Successfully added ${email} to ${productSlug} waitlist` };
+	dedup.remember(dedupKey, responseBody);
+	return new NextResponse(JSON.stringify(responseBody), { status: 200 });
 }

--- a/src/components/ProductWaitinglistForm.jsx
+++ b/src/components/ProductWaitinglistForm.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/Button";
 import { track } from "@vercel/analytics";
 
@@ -34,6 +34,11 @@ export const ProductWaitinglistForm = ({
 }) => {
 	const [formSuccess, setSuccess] = useState(false);
 	const [email, setEmail] = useState(userEmail);
+	// Honeypot bait — bots auto-fill named fields; humans never touch this.
+	const [hp, setHp] = useState("");
+	// Synchronous in-flight flag (React setState is async; useRef catches the
+	// rapid double-click before the state update propagates).
+	const inFlightRef = useRef(false);
 
 	useEffect(() => {
 		setEmail(userEmail);
@@ -57,11 +62,14 @@ export const ProductWaitinglistForm = ({
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();
+		if (inFlightRef.current) return;
+		inFlightRef.current = true;
 		const form = event.target;
 
 		const data = {
 			email: form.email.value,
 			productSlug,
+			hp,
 		};
 
 		await fetch("/api/waitinglist-subscribe", {
@@ -77,6 +85,8 @@ export const ProductWaitinglistForm = ({
 			})
 			.catch((e) => {
 				console.error(e);
+				// Release the in-flight guard on error so the user can retry.
+				inFlightRef.current = false;
 			});
 	};
 
@@ -94,6 +104,29 @@ export const ProductWaitinglistForm = ({
 			onSubmit={handleSubmit}
 			className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40"
 		>
+			{/* Honeypot. Off-screen + aria/tab hidden — invisible to real users,
+			    bots auto-fill it and the server short-circuits. */}
+			<div
+				aria-hidden="true"
+				style={{
+					position: "absolute",
+					left: "-9999px",
+					width: "1px",
+					height: "1px",
+					overflow: "hidden",
+				}}
+			>
+				<label htmlFor={`waitlist-hp-${productSlug}`}>Leave this empty</label>
+				<input
+					id={`waitlist-hp-${productSlug}`}
+					type="text"
+					name="company"
+					tabIndex={-1}
+					autoComplete="off"
+					value={hp}
+					onChange={(e) => setHp(e.target.value)}
+				/>
+			</div>
 			<div className="mt-6 flex">
 				<input
 					type="email"

--- a/src/components/SubscribeForm.tsx
+++ b/src/components/SubscribeForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -18,13 +18,21 @@ export function SubscribeForm({
   const [email, setEmail] = useState('')
   const [state, setState] = useState<State>('idle')
   const [errMsg, setErrMsg] = useState<string | null>(null)
+  // Honeypot bait. Real humans never see or touch this — bots that auto-fill
+  // every field by name do, which is the spam signal we forward to the server.
+  const [hp, setHp] = useState('')
+  // Synchronous in-flight flag. React's setState is async, so two rapid
+  // clicks could both pass `state === 'submitting'` before the state update
+  // propagates. The ref flips immediately so the second handler bails out.
+  const inFlightRef = useRef(false)
 
   const trimmed = email.trim()
   const validShape = trimmed.length === 0 ? null : EMAIL_RE.test(trimmed)
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    if (!validShape || state === 'submitting') return
+    if (!validShape || inFlightRef.current) return
+    inFlightRef.current = true
     setState('submitting')
     setErrMsg(null)
     try {
@@ -34,6 +42,7 @@ export function SubscribeForm({
         body: JSON.stringify({
           email: trimmed,
           referrer: typeof window !== 'undefined' ? window.location.pathname : '',
+          hp,
         }),
       })
       if (!res.ok) throw new Error(`status ${res.status}`)
@@ -42,6 +51,9 @@ export function SubscribeForm({
     } catch (err) {
       setState('error')
       setErrMsg('Something broke. Try again in a moment.')
+      // Release the guard only on error so the user can retry. Success paths
+      // stay locked (the success UI replaces the form anyway).
+      inFlightRef.current = false
     }
   }
 
@@ -91,6 +103,30 @@ export function SubscribeForm({
 
   return (
     <form className="sp-form" onSubmit={handleSubmit} noValidate>
+      {/* Honeypot. Off-screen + aria/tab hidden — real users never see, focus,
+          or submit this. Most form-spam bots auto-fill every named input,
+          which becomes the spam signal the server short-circuits on. */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: '-9999px',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+        }}
+      >
+        <label htmlFor={`sp-hp-${fieldNum}`}>Leave this empty</label>
+        <input
+          id={`sp-hp-${fieldNum}`}
+          type="text"
+          name="company"
+          tabIndex={-1}
+          autoComplete="off"
+          value={hp}
+          onChange={(e) => setHp(e.target.value)}
+        />
+      </div>
       <div className={`sp-field ${validateClass}`}>
         <label className="sp-field-label" htmlFor={`sp-email-${fieldNum}`}>
           <span>Your email</span>

--- a/src/lib/submit-dedup.ts
+++ b/src/lib/submit-dedup.ts
@@ -1,0 +1,47 @@
+/**
+ * Tiny in-memory dedup for signup-style POST handlers.
+ *
+ * Each route instantiates its own cache (separate namespaces — a regular
+ * signup and a waitlist signup for the same email should NOT collide). The
+ * Map is module-scoped to the route file: warm Vercel lambdas share state
+ * across invocations, which is where slow-connection double-clicks land.
+ * Cold starts won't dedup, but that's a vanishingly small slice of real
+ * double-submits (same browser tab → same TCP connection → typically same
+ * warm lambda).
+ *
+ * Not a substitute for the client-side `useRef` synchronous guard — that
+ * catches the React-batching race before the request ever fires. This is
+ * defense in depth.
+ */
+
+type Cached = { result: unknown; at: number }
+
+export type SubmitDedup = {
+  get(key: string): unknown | null
+  remember(key: string, result: unknown): void
+}
+
+export function createSubmitDedup(ttlMs: number = 30_000): SubmitDedup {
+  const cache = new Map<string, Cached>()
+  return {
+    get(key: string): unknown | null {
+      const hit = cache.get(key)
+      if (!hit) return null
+      if (Date.now() - hit.at > ttlMs) {
+        cache.delete(key)
+        return null
+      }
+      return hit.result
+    },
+    remember(key: string, result: unknown): void {
+      cache.set(key, { result, at: Date.now() })
+      // Lazy eviction so the Map can't grow unbounded under sustained traffic.
+      if (cache.size > 1000) {
+        const cutoff = Date.now() - ttlMs
+        for (const [k, v] of cache) {
+          if (v.at < cutoff) cache.delete(k)
+        }
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Three defenses on the signup flow:

1. **Honeypot field** on both `SubscribeForm` and `ProductWaitinglistForm`. Hidden `company` text input that bots auto-fill but real users never see/tab into. Server short-circuits with a fake 200 success when populated.
2. **Synchronous double-submit guard** via `useRef`. The prior `state === 'submitting'` check could be raced by two clicks in the same event tick (React setState is async). Ref flips immediately, only released on error.
3. **Server-side dedup** in both `/api/form` and `/api/waitinglist-subscribe`. Module-scoped 30s TTL Map keyed by email — warm Vercel lambdas share state across invocations, which is where slow-connection double-clicks land.

## Why now

Day-one of the Resend cutover surfaced two issues:
- Three bot/scraper signups in 11 minutes (Resend's global suppression caught them, but better to filter at the front door)
- Real users on slow connections double-clicked through the success state, firing the welcome chain trigger + ops notification twice

## Test plan

- [ ] Vercel preview rebuild reaches Ready
- [ ] Sign up via `/subscribe` with a fresh address — verify single welcome 01 + single ops notification (no doubles)
- [ ] Hit the form, double-click rapidly — should see exactly one request go out, ref guard catches the second
- [ ] DevTools: manually populate the hidden `company` field, submit — should see a 200 response but no contact in Resend audience + no ops notification
- [ ] Same checks on a product waitlist signup at `/waitinglist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the newsletter and waitlist signup request paths; mistakes could block legitimate signups or suppress expected Resend events/notifications. Logic is straightforward and additive (fake-success honeypot + 30s dedup + client double-click guards), so overall blast radius is limited to these forms.
> 
> **Overview**
> Hardens newsletter and waitlist signup flows against spam and accidental double-submits.
> 
> Both client forms now include an off-screen honeypot field (sent as `hp`) and a synchronous `useRef` in-flight guard to prevent rapid double-clicks from issuing multiple requests.
> 
> Both API routes (`/api/form` and `/api/waitinglist-subscribe`) now short-circuit honeypot hits with a **fake 200 success** (no subscribe/alerts) and add **30s server-side dedup** via new `createSubmitDedup()` to return cached success responses instead of re-triggering Resend automation/ops notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b9e8010335640c427201f93388a16270304f5c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->