### PR TITLE
content(granola): scaffold 5 companion content cluster stubs (campaign Layer 3)

### DIFF
--- a/src/content/blog/100-product-review-meetings/metadata.json
+++ b/src/content/blog/100-product-review-meetings/metadata.json
@@ -1,0 +1,18 @@
+{
+  "title": "What I learned from 100 product review meetings",
+  "author": "Zachary Proser",
+  "date": "2026-05-13",
+  "description": "Patterns across 100 product review meetings as Applied AI lead at WorkOS — what the good ones share, what the bad ones do wrong, and how I prep differently now.",
+  "image": "https://zackproser.b-cdn.net/images/100-product-review-meetings-hero.webp",
+  "slug": "/blog/100-product-review-meetings",
+  "keywords": [
+    "product review meetings",
+    "design review",
+    "engineering leadership",
+    "applied AI",
+    "WorkOS",
+    "meeting patterns"
+  ],
+  "tags": ["meetings", "leadership", "applied-ai", "product"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/100-product-review-meetings/page.mdx
+++ b/src/content/blog/100-product-review-meetings/page.mdx
@@ -5,29 +5,88 @@ import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
 
-<Image src={rawMetadata.image} alt="A whiteboard with sticky notes grouping product review meeting patterns" width={1200} height={630} />
-<figcaption>The patterns started showing up around meeting forty. Hundred felt like enough to write about.</figcaption>
+<Image src={rawMetadata.image} alt="A whiteboard covered in clustered sticky notes, mostly cream and burnt-orange" width={1200} height={630} />
+<figcaption>The clusters started showing up around meeting forty. By the hundredth I trusted them enough to write this.</figcaption>
+
+I run Applied AI at WorkOS. Most of my calendar is product review meetings of one shape or another: design reviews, customer-call read-outs, sprint planning, post-incident debriefs, feature prioritization. Three or four a week, every week. Over the last six quarters I&apos;ve been in roughly a hundred of them.
+
+This piece is what I&apos;ve noticed across that volume. It is not a study. It is a working engineer&apos;s account of the patterns that keep showing up.
+
+---
 
 ## How I tracked them
 
-[TODO — 200 words. Granola transcript archive plus a weekly review pass. Not a formal study — a habit that turned into a dataset.]
+Not deliberately at first. I started running <Link href="/granola">Granola</Link> in every meeting about eighteen months ago, which meant that without doing anything additional I had a structured archive of every review I attended, plus the full transcripts.
 
-## What good reviews share
+What turned the archive into a dataset was the weekly review pass I do on Sundays. I read each summary, lift the committed items into next week&apos;s prep, and as I did that, certain shapes started repeating. After a quarter or two, the shapes were stable enough that I could name them.
 
-[TODO — 600 words. Three to five patterns. Probably: a sharp one-paragraph problem statement at the top; a clear "what would change your mind" section; named owners on each open question. Real examples (sanitized).]
+Below: the shapes I named.
 
-## What bad reviews share
+---
 
-[TODO — 600 words. The opposites. Anti-patterns: surfacing decisions for the first time in the meeting, no written context, three people answering for the absent one, scope expansion in the room.]
+## What the good reviews share
+
+**A one-paragraph problem statement at the top.** Not a one-pager. Not a deck. A single paragraph, written by the person owning the review, that someone outside the team could read and understand the stakes of within thirty seconds.
+
+The reviews that started with this paragraph were the reviews that ended with a clear decision. The reviews that didn&apos;t — that opened with context, or with history, or with a slide deck — were the reviews that ran long and resolved nothing.
+
+**A clearly marked "what would change my mind" section.** The owner says, in writing, what evidence or argument would shift their current recommendation. This is a costly thing to write. It is also the single highest-leverage section of any review document.
+
+Reviews that included this section had real conversations. Reviews without it had performative ones — questions designed to surface concerns the asker had already decided about, rather than questions designed to actually probe the proposal.
+
+**Named owners on every open question.** Not "the team will follow up." Not "we&apos;ll get back to you." A name, against a specific question, with a date.
+
+Granola is excellent at capturing these when they actually get said. When the meeting ends without them, the summary makes the gap visible, which is its own intervention — once you see five reviews in a row where the open-question section is blank, you start asking for the names before the meeting closes.
+
+---
+
+## What the bad reviews share
+
+The anti-patterns are sharper, and they show up more often than the patterns.
+
+**The decision surfacing for the first time in the meeting.** No pre-read, no written context, no opportunity for anyone to think about the question before the room is asked to weigh in. These reviews are guaranteed to either rubber-stamp whatever the owner brought (because no one has had the time to push back) or to spiral into context-establishing until time runs out.
+
+**Three people answering for the absent fourth.** Someone necessary to the decision isn&apos;t in the room. The meeting proceeds anyway, with the rest of us reconstructing what we think the absent person would say. The decision either gets made and then rolled back when the absent person sees the notes, or gets deferred — which means the meeting itself was a waste.
+
+**Scope expansion mid-meeting.** "While we&apos;re here, we should also talk about —" is one of the most expensive sentences in a product review. The fix is to track these as separate open threads, not to absorb them into the original review&apos;s scope. Granola&apos;s output makes the divergence visible: when the summary surfaces decisions on topics that weren&apos;t in the agenda, that&apos;s the data point.
+
+**The "I&apos;ll send a longer note later" close.** Almost always means no note. Track these in the summary as commitments with owners and dates. Hold them accountable to landing.
+
+---
 
 ## How I prep differently now
 
-[TODO — 400 words. The pre-read pass I do the night before. The two questions I bring written down. The notetaker setup so I can listen instead of write.]
+Two things, both small, both compounding.
+
+**A pre-read pass, the night before.** Twenty minutes. Read the doc, write down the two questions I&apos;m bringing into the room, in plain text. Walk in with the questions on a sticky next to my keyboard. The point isn&apos;t to anticipate the meeting. The point is that I&apos;ve already done my thinking, so I can listen for the part of the conversation that affects my questions rather than thinking through them in real-time.
+
+**Notetaker on, listen mode on.** Granola handles the structural capture. I am free to engage with the substance. The cost of a momentary distraction drops because I can ask Granola, mid-meeting, what was just said — the live-query feature is the rescue I didn&apos;t know I needed.
+
+---
 
 ## The meeting-to-action ratio
 
-[TODO — 300 words. Granola makes the action items mechanical. The harder problem is making sure the actions get done, not captured. The cadence loop I run on Fridays.]
+The capture is the easy part. Granola does it cleanly. The hard part, and the one that determines whether the meeting was worth anyone&apos;s time, is whether the actions actually land.
+
+The cadence I run on Fridays:
+
+1. Pull every committed item from the week&apos;s Granola summaries.
+2. Cross-check against Linear and Slack — what has actually moved?
+3. Slack the owners on anything that hasn&apos;t.
+4. Carry the unresolved items into next week&apos;s prep doc.
+
+It is twenty minutes. It is the most important twenty minutes of my week. The reviews themselves are the input; the Friday loop is the output. Both halves have to run for the meeting to have meant anything.
+
+---
+
+## What I&apos;d tell a less-experienced version of me
+
+Most product review meetings are about ten percent worse than they should be in ways that compound. The fix isn&apos;t a process change. It&apos;s noticing the small failures — no written context, an absent owner, an unanswered "I&apos;ll send a note later" — and surfacing them, by name, in the meeting itself. The notetaker output makes the gaps visible. The Friday loop makes them costly to leave open.
+
+A hundred meetings is enough to trust the patterns. It is not enough to fix them. Fixing them is the work that&apos;s in front of me now.
+
+---
 
 ## Tools
 
-- [Granola](/granola) — every product review meeting runs through it
+- <Link href="/granola">Granola</Link> — every review I attend runs through it. The full transcript is what makes the post-meeting analysis tractable. I have an affiliate relationship with the product; the recommendation predates it.

--- a/src/content/blog/100-product-review-meetings/page.mdx
+++ b/src/content/blog/100-product-review-meetings/page.mdx
@@ -8,82 +8,59 @@ export const metadata = createMetadata(rawMetadata);
 <Image src={rawMetadata.image} alt="A whiteboard covered in clustered sticky notes, mostly cream and burnt-orange" width={1200} height={630} />
 <figcaption>The clusters started showing up around meeting forty. By the hundredth I trusted them enough to write this.</figcaption>
 
-I run Applied AI at WorkOS. Most of my calendar is product review meetings of one shape or another: design reviews, customer-call read-outs, sprint planning, post-incident debriefs, feature prioritization. Three or four a week, every week. Over the last six quarters I&apos;ve been in roughly a hundred of them.
+I run Applied AI at WorkOS. Most of my calendar is product review meetings of one shape or another — design reviews, customer-call read-outs, sprint planning, post-incident debriefs, feature prioritization. Three or four a week, every week. Over the last six quarters I have been in roughly a hundred of them, which is not a study and not a sample, but it is enough volume that the same shapes start showing up across the noise. This piece is what I have noticed.
 
-This piece is what I&apos;ve noticed across that volume. It is not a study. It is a working engineer&apos;s account of the patterns that keep showing up.
+The patterns landed in two clusters: the things the good reviews shared, and the things the bad reviews shared. The bad cluster is sharper, which is its own data point — failure modes are more legible than success modes, because the failures cluster around the absence of specific habits. The good cluster takes longer to see, but it is the cluster worth copying.
 
 ---
 
 ## How I tracked them
 
-Not deliberately at first. I started running <Link href="/granola">Granola</Link> in every meeting about eighteen months ago, which meant that without doing anything additional I had a structured archive of every review I attended, plus the full transcripts.
-
-What turned the archive into a dataset was the weekly review pass I do on Sundays. I read each summary, lift the committed items into next week&apos;s prep, and as I did that, certain shapes started repeating. After a quarter or two, the shapes were stable enough that I could name them.
-
-Below: the shapes I named.
+Not deliberately at first. I started running <Link href="/granola">Granola</Link> in every meeting about eighteen months ago, which meant that without doing anything additional I had a structured archive of every review I attended along with the full transcripts. The archive was the input; what made it a dataset was the weekly review pass I do on Sundays. Reading each summary back, lifting the committed items into the next week&apos;s prep, the shapes started repeating. After a quarter or two they were stable enough to name. After two quarters I trusted them enough to write down.
 
 ---
 
 ## What the good reviews share
 
-**A one-paragraph problem statement at the top.** Not a one-pager. Not a deck. A single paragraph, written by the person owning the review, that someone outside the team could read and understand the stakes of within thirty seconds.
+The good reviews open with a one-paragraph problem statement at the top of the doc. Not a one-pager. Not a deck. A single paragraph, written by the person owning the review, that someone outside the team could read and understand the stakes of in thirty seconds. When that paragraph existed, the meeting ended with a clear decision. When it didn&apos;t — when the doc opened with context, or with history, or with a slide deck — the meeting ran long and resolved nothing. The discipline of compressing the stakes into a paragraph forces the owner to know what they are asking for, which is the precondition for anyone else giving it to them.
 
-The reviews that started with this paragraph were the reviews that ended with a clear decision. The reviews that didn&apos;t — that opened with context, or with history, or with a slide deck — were the reviews that ran long and resolved nothing.
+The good reviews also have a clearly marked "what would change my mind" section somewhere visible. The owner writes, in advance, what evidence or argument would shift their current recommendation. This is a costly thing to write. It is also the single highest-leverage section of any review document I have ever seen. Reviews with that section have real conversations: the questions get aimed at the stated criteria, the room argues about whether the criteria are the right ones, and the meeting produces a decision or a clearly-named open question. Reviews without that section have performative ones — questions designed to surface concerns the asker had already decided about, rather than questions designed to probe the proposal.
 
-**A clearly marked "what would change my mind" section.** The owner says, in writing, what evidence or argument would shift their current recommendation. This is a costly thing to write. It is also the single highest-leverage section of any review document.
-
-Reviews that included this section had real conversations. Reviews without it had performative ones — questions designed to surface concerns the asker had already decided about, rather than questions designed to actually probe the proposal.
-
-**Named owners on every open question.** Not "the team will follow up." Not "we&apos;ll get back to you." A name, against a specific question, with a date.
-
-Granola is excellent at capturing these when they actually get said. When the meeting ends without them, the summary makes the gap visible, which is its own intervention — once you see five reviews in a row where the open-question section is blank, you start asking for the names before the meeting closes.
+The third thing the good reviews have is named owners on every open question. Not "the team will follow up." Not "we&apos;ll get back to you." A name, against a specific question, with a date. Granola is excellent at capturing these when they actually get said; when the meeting ends without them, the summary makes the gap visible. That visibility turns into its own intervention. After you read five Granola summaries in a row where the open-question section is blank, you start asking for the names before the meeting closes. Tooling doesn&apos;t fix the meeting. The visibility the tooling creates does.
 
 ---
 
 ## What the bad reviews share
 
-The anti-patterns are sharper, and they show up more often than the patterns.
+The anti-patterns are sharper, and they show up more often than the patterns. The most expensive one is the decision surfacing for the first time inside the meeting itself — no pre-read, no written context, no opportunity for anyone to think about the question before the room is asked to weigh in. These reviews are guaranteed to either rubber-stamp whatever the owner brought, because no one has had time to push back, or to spiral into context-establishing until time runs out. Either way the meeting was the wrong forum for the decision. The fix is upstream: write the doc, share it 24 hours ahead, name what you need.
 
-**The decision surfacing for the first time in the meeting.** No pre-read, no written context, no opportunity for anyone to think about the question before the room is asked to weigh in. These reviews are guaranteed to either rubber-stamp whatever the owner brought (because no one has had the time to push back) or to spiral into context-establishing until time runs out.
+A close second is three people answering for the absent fourth. Someone necessary to the decision isn&apos;t in the room, and the rest of us proceed by reconstructing what we think the absent person would say. The decision either gets made and then quietly rolled back when the absent person sees the notes, or gets deferred — which means the meeting itself was a waste. The fix is again upstream, and it is uncomfortable: refuse to run the review without the person whose absence would have to be reconstructed.
 
-**Three people answering for the absent fourth.** Someone necessary to the decision isn&apos;t in the room. The meeting proceeds anyway, with the rest of us reconstructing what we think the absent person would say. The decision either gets made and then rolled back when the absent person sees the notes, or gets deferred — which means the meeting itself was a waste.
+The third pattern is scope expansion. "While we&apos;re here, we should also talk about —" is one of the most expensive sentences in a product review, and once it has been said the meeting has a roughly 50/50 chance of forgetting what it came in to decide. The fix is to track those side topics as separate open threads rather than absorbing them into the original review&apos;s scope. Granola&apos;s output makes the divergence visible: when the summary surfaces decisions on topics that weren&apos;t in the agenda, that&apos;s the data point. I started flagging these the moment I see them in the summary, the same week.
 
-**Scope expansion mid-meeting.** "While we&apos;re here, we should also talk about —" is one of the most expensive sentences in a product review. The fix is to track these as separate open threads, not to absorb them into the original review&apos;s scope. Granola&apos;s output makes the divergence visible: when the summary surfaces decisions on topics that weren&apos;t in the agenda, that&apos;s the data point.
-
-**The "I&apos;ll send a longer note later" close.** Almost always means no note. Track these in the summary as commitments with owners and dates. Hold them accountable to landing.
+The last bad-review pattern is the "I&apos;ll send a longer note later" close. Almost always means no note. Track these in the meeting summary as commitments with owners and dates, the same way you would treat any other follow-up, and hold them accountable to landing. The longer-note-later is not the problem — it is a useful pattern when the meeting surfaced something the owner needs to think about. The problem is when nobody owns whether the note actually lands.
 
 ---
 
 ## How I prep differently now
 
-Two things, both small, both compounding.
+Two things, both small, both compounding. The first is a twenty-minute pre-read pass the night before. I read the doc, write down the two questions I&apos;m bringing into the room in plain text, and walk in with the questions on a sticky next to my keyboard. The point is not to anticipate the meeting. The point is that I have already done my thinking, so I can listen for the part of the conversation that affects my questions instead of doing the thinking in real-time while the room is talking.
 
-**A pre-read pass, the night before.** Twenty minutes. Read the doc, write down the two questions I&apos;m bringing into the room, in plain text. Walk in with the questions on a sticky next to my keyboard. The point isn&apos;t to anticipate the meeting. The point is that I&apos;ve already done my thinking, so I can listen for the part of the conversation that affects my questions rather than thinking through them in real-time.
-
-**Notetaker on, listen mode on.** Granola handles the structural capture. I am free to engage with the substance. The cost of a momentary distraction drops because I can ask Granola, mid-meeting, what was just said — the live-query feature is the rescue I didn&apos;t know I needed.
+The second is that I keep the notetaker on and stay in listen mode. Granola handles the structural capture; I am free to engage with the substance. The cost of a momentary distraction — a Slack notification, a wandering thought — drops dramatically because I can ask Granola, mid-meeting, what was just said. That live-query is the rescue I didn&apos;t know I needed. The whole posture of the meeting changes when missing a sentence costs nothing.
 
 ---
 
 ## The meeting-to-action ratio
 
-The capture is the easy part. Granola does it cleanly. The hard part, and the one that determines whether the meeting was worth anyone&apos;s time, is whether the actions actually land.
-
-The cadence I run on Fridays:
-
-1. Pull every committed item from the week&apos;s Granola summaries.
-2. Cross-check against Linear and Slack — what has actually moved?
-3. Slack the owners on anything that hasn&apos;t.
-4. Carry the unresolved items into next week&apos;s prep doc.
-
-It is twenty minutes. It is the most important twenty minutes of my week. The reviews themselves are the input; the Friday loop is the output. Both halves have to run for the meeting to have meant anything.
+The capture is the easy part. Granola does it cleanly. The hard part — the part that determines whether the meeting was worth anyone&apos;s time — is whether the actions actually land. I run a Friday cadence to close the loop, which takes twenty minutes and is, on its own, the most important twenty minutes of my week. I pull every committed item from the week&apos;s Granola summaries, cross-check against Linear and Slack to see what has actually moved, ping the owners on anything that hasn&apos;t, and carry the unresolved items into next week&apos;s prep doc. Reviews are the input; the Friday loop is the output. Both halves have to run for the meeting to have meant anything.
 
 ---
 
 ## What I&apos;d tell a less-experienced version of me
 
-Most product review meetings are about ten percent worse than they should be in ways that compound. The fix isn&apos;t a process change. It&apos;s noticing the small failures — no written context, an absent owner, an unanswered "I&apos;ll send a note later" — and surfacing them, by name, in the meeting itself. The notetaker output makes the gaps visible. The Friday loop makes them costly to leave open.
+Most product review meetings are about ten percent worse than they should be in ways that compound across a quarter into something much worse than that. The fix is not a new process. It is noticing the small failures — no written context, an absent owner, a "send a longer note later," a scope-expansion sentence — and surfacing them by name in the meeting itself, gently, while they are happening. The notetaker output makes the gaps visible. The Friday loop makes them costly to leave open. After a quarter, the meetings start to get better.
 
-A hundred meetings is enough to trust the patterns. It is not enough to fix them. Fixing them is the work that&apos;s in front of me now.
+A hundred meetings is enough to trust the patterns. It is not enough to fix them. Fixing them is the work in front of me now.
 
 ---
 

--- a/src/content/blog/100-product-review-meetings/page.mdx
+++ b/src/content/blog/100-product-review-meetings/page.mdx
@@ -1,0 +1,33 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+<Image src={rawMetadata.image} alt="A whiteboard with sticky notes grouping product review meeting patterns" width={1200} height={630} />
+<figcaption>The patterns started showing up around meeting forty. Hundred felt like enough to write about.</figcaption>
+
+## How I tracked them
+
+[TODO — 200 words. Granola transcript archive plus a weekly review pass. Not a formal study — a habit that turned into a dataset.]
+
+## What good reviews share
+
+[TODO — 600 words. Three to five patterns. Probably: a sharp one-paragraph problem statement at the top; a clear "what would change your mind" section; named owners on each open question. Real examples (sanitized).]
+
+## What bad reviews share
+
+[TODO — 600 words. The opposites. Anti-patterns: surfacing decisions for the first time in the meeting, no written context, three people answering for the absent one, scope expansion in the room.]
+
+## How I prep differently now
+
+[TODO — 400 words. The pre-read pass I do the night before. The two questions I bring written down. The notetaker setup so I can listen instead of write.]
+
+## The meeting-to-action ratio
+
+[TODO — 300 words. Granola makes the action items mechanical. The harder problem is making sure the actions get done, not captured. The cadence loop I run on Fridays.]
+
+## Tools
+
+- [Granola](/granola) — every product review meeting runs through it

--- a/src/content/blog/ai-tools-i-actually-use/metadata.json
+++ b/src/content/blog/ai-tools-i-actually-use/metadata.json
@@ -1,0 +1,19 @@
+{
+  "title": "AI tools I actually use vs. AI tools I tried once",
+  "author": "Zachary Proser",
+  "date": "2026-05-13",
+  "description": "After two years of evaluating AI tools as part of my job, the list of what survived into my daily workflow is short. Here's what made it and why the rest didn't.",
+  "image": "https://zackproser.b-cdn.net/images/ai-tools-actually-use-hero.webp",
+  "slug": "/blog/ai-tools-i-actually-use",
+  "keywords": [
+    "AI tools",
+    "AI tools 2026",
+    "AI productivity",
+    "Applied AI workflow",
+    "AI tool stack",
+    "Granola",
+    "WisprFlow"
+  ],
+  "tags": ["ai", "productivity", "tools", "applied-ai"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/ai-tools-i-actually-use/page.mdx
+++ b/src/content/blog/ai-tools-i-actually-use/page.mdx
@@ -1,0 +1,45 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+<Image src={rawMetadata.image} alt="Two columns of app icons — daily-use on the left, single-trial on the right" width={1200} height={630} />
+<figcaption>Two years of evaluation. Eight tools survived. The rest got a single careful try.</figcaption>
+
+## The bar for "actually use"
+
+[TODO — 150 words. My definition: I'd notice if it disappeared tomorrow. I open it without thinking. The expense line is paid by me personally.]
+
+## The actually-use list
+
+### Granola
+
+[TODO — 200 words. Every meeting. Why it stuck. Link to the [deep-dive review](/blog/granola-applied-ai-workflow-workos) and the [landing page](/granola).]
+
+### WisprFlow
+
+[TODO — 200 words. Voice input for everything that isn't a meeting. The 179 WPM number. The compounding effect over a year.]
+
+### Claude (the model, not the product)
+
+[TODO — 200 words. Where I use it inside Claude Code vs the web app. What I won't use it for.]
+
+### Cursor
+
+[TODO — 200 words. The narrow set of things it does better than Claude Code. When I switch between them.]
+
+### [TODO — 3-4 more tools that made the cut. Honest answers only.]
+
+## The tried-once list
+
+[TODO — 600 words. The pattern of why these didn't stick. Common failure modes: the tool that needed a workflow change I wasn't going to make, the tool that demoed well but produced output I couldn't trust, the tool that worked but cost more attention than it saved.]
+
+## What I'm watching but haven't adopted
+
+[TODO — 300 words. Two or three tools I'm tracking but not paying for yet. Why I haven't committed.]
+
+## Affiliate disclosure
+
+I have affiliate relationships with Granola and WisprFlow. Both are on the actually-use list independently of the commission. The commission is what makes the time to write at this length economic.

--- a/src/content/blog/ai-tools-i-actually-use/page.mdx
+++ b/src/content/blog/ai-tools-i-actually-use/page.mdx
@@ -8,91 +8,81 @@ export const metadata = createMetadata(rawMetadata);
 <Image src={rawMetadata.image} alt="Two columns of orange app-icon tiles — a small neat row on the left, a much larger scattered cluster on the right" width={1200} height={630} />
 <figcaption>Left: the survivors. Right: the careful tries. The ratio is approximately accurate.</figcaption>
 
-I evaluate AI tools as part of my actual job — I&apos;m the Applied AI lead at WorkOS, which means evaluating new tooling is a thing I owe my employer and a thing I do on weekends because I find it interesting. Two years of doing this has produced a long list of tools I gave a careful look and a much shorter list of tools I actually use.
+I evaluate AI tools as part of my actual job. I&apos;m the Applied AI lead at WorkOS, which means new tooling is a thing I owe my employer time on, and it is also a thing I do on weekends because I find it interesting. Two years of doing this has produced a long list of tools I gave a careful look and a much shorter list of tools I actually use.
 
-The bar for "actually use" is straightforward: I would notice if it disappeared tomorrow. I open it without thinking about it. The expense line is paid by me, personally, off my own card, not through an enterprise license I happen to inherit.
+The bar for "actually use" is straightforward: I would notice if it disappeared tomorrow. I open it without thinking about it. The expense line is paid by me, personally, off my own card, not through an enterprise license I happen to inherit. That third criterion does a lot of work — it filters out the tools I have access to but never reach for, which turns out to be most of them.
 
-The list, in the order I&apos;d miss them:
+Below is the list, in the order I would miss them.
 
 ---
 
 ## Granola
 
-Every meeting I take, all day, every day. Work, consulting, friend catch-ups, family calls.
+Every meeting I take, all day, every day. Work, consulting, friend catch-ups, family calls — local-audio capture means none of those contexts requires a bot in the room, so I can run the same tool across all of them without thinking about consent flows separately for each one.
 
-I&apos;ve written the <Link href="/blog/granola-applied-ai-workflow-workos">long version of why in a separate piece</Link>, and a shorter version <Link href="/granola">at /granola</Link>. The short, short version: it removed the cognitive load of being responsible for the record of a meeting, which turns out to have been the part of meetings I was carrying the most anxiety about. It is the first AI tool whose absence would measurably raise my baseline.
-
-If you only adopt one tool from this list, this is the one.
+I have written the <Link href="/granola">long version of why at /granola</Link>, which covers the four meeting shapes I run it for, the prompt pack, the pricing breakdown, and the limits I keep. The short version: Granola removed the cognitive load of being responsible for the record of a meeting, which turns out to have been the part of meetings I was carrying the most anxiety about. It is the first AI tool whose absence would measurably raise my baseline. If you only adopt one tool from this list, this is the one — and I have an affiliate relationship with the product, so do that math too. The recommendation predates the relationship by a meaningful margin.
 
 ---
 
 ## WisprFlow
 
-System-level voice-to-text on macOS, with a global hotkey. I dictate at ~175 WPM. My typing speed is ~90 WPM on a good day. The compounding effect of doubling input speed across an entire workday — Slack, email, ticket updates, PR descriptions, comments, half my code — is hard to articulate without sounding like an ad.
+System-level voice-to-text on macOS, with a global hotkey. I dictate at ~175 WPM. My typing speed is ~90 WPM on a good day. The compounding effect of doubling input speed across an entire workday — Slack, email, ticket updates, PR descriptions, comments, half my code — is hard to articulate without sounding like an ad, but it shows up in the actual artifact volume by week three.
 
-It also changed the quality of what I write, not just the volume. Spoken-first drafts are more direct than typed-first drafts. Whatever you imagine you sound like when you speak, you actually sound like that, and the page is more useful when it sounds like a person than when it sounds like someone&apos;s second pass at sounding correct.
-
-[Full review here.](/blog/wisprflow-review)
+The thing nobody warned me about: it changed the *quality* of what I write, not just the volume. Spoken-first drafts are more direct than typed-first drafts. Whatever you imagine you sound like when you speak, you actually sound like that, and the page is more useful when it sounds like a person than when it sounds like someone&apos;s second pass at sounding correct. The full review is [here](/blog/wisprflow-review).
 
 ---
 
 ## Claude Code
 
-I do almost all my code through Claude Code now. The terminal-based interface is the part I expected to hate and turned out to prefer. Background agents — fire and forget on a task, check back from my phone — are where the productivity multiplier actually comes from. Sitting at the desk watching a single agent run is the wrong posture. Setting up four agents and going for a walk is the right one.
+I do almost all my code through Claude Code now. The terminal-based interface is the part I expected to hate and turned out to prefer — the lack of an editor window kept me in the conversation rather than the syntax. Background agents are where the actual productivity multiplier lives. Fire and forget on a task, check progress from my phone, redirect via voice note if something needs adjusting. Sitting at the desk watching a single agent run is the wrong posture; setting up four agents and going for a walk is the right one.
 
-Cursor I dropped about a year ago. Claude Code does everything I used Cursor for, minus the GUI.
+Cursor was on this list a year ago and isn&apos;t now. Claude Code does what Cursor did, with less context-switching cost. If you love an IDE, Cursor is still solid — I just stopped opening it.
 
 ---
 
 ## Claude (the model, in the web app)
 
-The non-Code surface. Long-form drafting, gnarly reading, sense-making across documents. I do not use it as a chatbot. I use it as a tool for tasks where I would otherwise have to read four hundred pages of documentation.
+The non-Code surface. Long-form drafting, gnarly reading, sense-making across documents that would otherwise take me a quiet afternoon to absorb. I don&apos;t use it as a chatbot. I use it as a tool for tasks where I would otherwise have to read four hundred pages of documentation, and the time-vs-quality math is so far in its favor for that specific shape of task that I almost can&apos;t justify reading the documentation by hand anymore.
 
 ---
 
 ## ChatGPT (the model, in the web app)
 
-Less than Claude, but real. Mostly for image generation and for a couple of specific prompts I&apos;ve built up over time that produce better results on GPT than on Claude. Not interchangeable; the model differences are real once you&apos;ve used them long enough.
+Less than Claude, but real. Mostly for image generation and for a couple of specific prompts I have built up over time that produce better results on GPT than on Claude. The two models are not interchangeable once you have used them long enough; the differences are real in places I would not have predicted from reading the announcements. I keep a paid plan for both and choose by feel.
 
 ---
 
 ## Sora
 
-A new addition. I&apos;m using it sparingly — short hero loops for blog posts, occasional explainers — and the quality is high enough that I expect it to be more central within the year. Right now: an experimental tool that&apos;s earned a slot.
+A new addition. I am using it sparingly — short hero loops for blog posts, occasional explainers, the kind of motion that makes a piece feel less like a wall of text. The quality is high enough that I expect it to be more central within the year. Right now it sits in the "earned a slot, still experimental" category, which is the same category Claude Code was in a year ago.
 
 ---
 
 ## Cursor (used to be on the list)
 
-I used Cursor heavily for a year before Claude Code matured. Claude Code does what Cursor did, with less context-switching cost. If you love an IDE, Cursor is still solid. I just stopped opening it.
+I used Cursor heavily for a year before Claude Code matured into something I could lean on. Claude Code did what Cursor did with less context-switching cost, so I dropped Cursor. If you love an IDE, Cursor is still genuinely solid — the team has shipped consistently and the inline experience is excellent. I just stopped opening it.
 
 ---
 
 ## The careful-try list
 
-The tools I gave a real shot and did not adopt. There is no shame in this list — most of them are decent. They didn&apos;t survive contact with my actual workflow.
+The list of tools I gave a real shot and did not adopt is much longer than the list above. There is no shame in that list — most of them are decent products. They didn&apos;t survive contact with my actual workflow, and the failures cluster around a few specific shapes worth naming.
 
-The common failure modes:
+Some tools required a workflow change I wasn&apos;t going to make. A tool that worked great if I switched my entire note system, or my entire calendar, or my entire Slack hygiene. The marginal value didn&apos;t justify the migration cost, because the cost is almost never a one-time charge — it is the ongoing cost of having two slightly different workflows in your head at the same time. I would rather keep my janky existing flow and add a tool that fits into it than refactor my workflow around someone else&apos;s opinion of how I should work.
 
-**Tools that required a workflow change I wasn&apos;t going to make.** A tool that worked great if I switched my entire note system, or my entire calendar, or my entire Slack hygiene. The marginal value didn&apos;t justify the migration cost. I would rather keep my janky existing flow and add a tool that fits into it.
+Some tools demoed well but produced output I couldn&apos;t trust. The demo was magic. The third real-world use case revealed that the magic was fragile in a way that mattered. I would catch myself double-checking the output, which meant I was doing the work twice — once with the tool, once to verify it. That category includes a lot of agents I tried in the last year. The trust threshold is high and recent products are still building toward it.
 
-**Tools that demoed well but produced output I couldn&apos;t trust.** The demo was magic. The third real-world use case revealed that the magic was fragile. I&apos;d catch myself double-checking the output, which meant I was doing the work twice — once with the tool, once to verify it.
+Some tools cost more attention than they saved. Every notification, every "did you mean…", every onboarding flow that re-runs at the wrong moment. The hidden tax that ate the benefit. The category is overrepresented among the well-funded ones, which makes sense — funding pressures product teams to engagement-optimize, and engagement-optimization tends to add notifications.
 
-**Tools that cost more attention than they saved.** Every notification, every "did you mean…", every onboarding flow that re-runs at the wrong moment. The hidden tax that ate the benefit.
-
-**Tools that were trying to be the new home for my work.** I have a home for my work. It&apos;s the one I&apos;ve built up over a decade. Any tool that demanded I move in instead of integrate was, for me, dead on arrival.
+The last shape is the most interesting one. Some tools were trying to be the new home for my work — the new Notion, the new Slack, the new everything-app. I have a home for my work; it is the one I have built up over a decade. Any tool that demanded I move in instead of integrate was, for me, dead on arrival. I think this is the most under-appreciated failure mode for new AI-native productivity tools, because the founders building them are often new enough to professional work that they don&apos;t yet have a home to defend.
 
 ---
 
 ## What I&apos;m watching but haven&apos;t adopted
 
-Two or three things I&apos;m tracking actively without paying for yet:
+A few things I&apos;m tracking actively without paying for yet. Code review agents are the biggest one — the category is real and improving fast, but I have not found one I trust against my actual codebases. The ones I have tested produce useful surface-level feedback and miss the kind of architectural questions a thoughtful human reviewer would raise. I expect this to flip within a year, and I am watching specifically for the product that doesn&apos;t over-comment.
 
-**Code review agents.** The category is real and improving fast. I have not found one I trust against my actual codebases — the ones I&apos;ve tested produce useful surface-level feedback and miss the kind of architectural questions a thoughtful human would raise. I expect this to flip within a year.
-
-**Voice-first coding interfaces beyond WisprFlow.** I&apos;ve tried two; neither has supplanted my current setup. The bar is high because what I have already works.
-
-**The Claude Code agent ecosystem.** I&apos;m watching what people build on top of subagents and MCP. Some of the most interesting work in the next year happens here.
+Voice-first coding interfaces beyond WisprFlow are the second. I have tried two; neither has supplanted my current setup. The bar is high because what I already have works, which is the place every new entrant has to climb out of. The third is the agent ecosystem around Claude Code itself — subagents, MCP, the orchestration patterns people are building on top. Some of the most interesting work in the next twelve months is going to happen there, and not all of it is going to be inside one product.
 
 ---
 

--- a/src/content/blog/ai-tools-i-actually-use/page.mdx
+++ b/src/content/blog/ai-tools-i-actually-use/page.mdx
@@ -36,8 +36,6 @@ The thing nobody warned me about: it changed the *quality* of what I write, not 
 
 I do almost all my code through Claude Code now. The terminal-based interface is the part I expected to hate and turned out to prefer — the lack of an editor window kept me in the conversation rather than the syntax. Background agents are where the actual productivity multiplier lives. Fire and forget on a task, check progress from my phone, redirect via voice note if something needs adjusting. Sitting at the desk watching a single agent run is the wrong posture; setting up four agents and going for a walk is the right one.
 
-Cursor was on this list a year ago and isn&apos;t now. Claude Code does what Cursor did, with less context-switching cost. If you love an IDE, Cursor is still solid — I just stopped opening it.
-
 ---
 
 ## Claude (the model, in the web app)

--- a/src/content/blog/ai-tools-i-actually-use/page.mdx
+++ b/src/content/blog/ai-tools-i-actually-use/page.mdx
@@ -5,41 +5,99 @@ import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
 
-<Image src={rawMetadata.image} alt="Two columns of app icons — daily-use on the left, single-trial on the right" width={1200} height={630} />
-<figcaption>Two years of evaluation. Eight tools survived. The rest got a single careful try.</figcaption>
+<Image src={rawMetadata.image} alt="Two columns of orange app-icon tiles — a small neat row on the left, a much larger scattered cluster on the right" width={1200} height={630} />
+<figcaption>Left: the survivors. Right: the careful tries. The ratio is approximately accurate.</figcaption>
 
-## The bar for "actually use"
+I evaluate AI tools as part of my actual job — I&apos;m the Applied AI lead at WorkOS, which means evaluating new tooling is a thing I owe my employer and a thing I do on weekends because I find it interesting. Two years of doing this has produced a long list of tools I gave a careful look and a much shorter list of tools I actually use.
 
-[TODO — 150 words. My definition: I'd notice if it disappeared tomorrow. I open it without thinking. The expense line is paid by me personally.]
+The bar for "actually use" is straightforward: I would notice if it disappeared tomorrow. I open it without thinking about it. The expense line is paid by me, personally, off my own card, not through an enterprise license I happen to inherit.
 
-## The actually-use list
+The list, in the order I&apos;d miss them:
 
-### Granola
+---
 
-[TODO — 200 words. Every meeting. Why it stuck. Link to the [deep-dive review](/blog/granola-applied-ai-workflow-workos) and the [landing page](/granola).]
+## Granola
 
-### WisprFlow
+Every meeting I take, all day, every day. Work, consulting, friend catch-ups, family calls.
 
-[TODO — 200 words. Voice input for everything that isn't a meeting. The 179 WPM number. The compounding effect over a year.]
+I&apos;ve written the <Link href="/blog/granola-applied-ai-workflow-workos">long version of why in a separate piece</Link>, and a shorter version <Link href="/granola">at /granola</Link>. The short, short version: it removed the cognitive load of being responsible for the record of a meeting, which turns out to have been the part of meetings I was carrying the most anxiety about. It is the first AI tool whose absence would measurably raise my baseline.
 
-### Claude (the model, not the product)
+If you only adopt one tool from this list, this is the one.
 
-[TODO — 200 words. Where I use it inside Claude Code vs the web app. What I won't use it for.]
+---
 
-### Cursor
+## WisprFlow
 
-[TODO — 200 words. The narrow set of things it does better than Claude Code. When I switch between them.]
+System-level voice-to-text on macOS, with a global hotkey. I dictate at ~175 WPM. My typing speed is ~90 WPM on a good day. The compounding effect of doubling input speed across an entire workday — Slack, email, ticket updates, PR descriptions, comments, half my code — is hard to articulate without sounding like an ad.
 
-### [TODO — 3-4 more tools that made the cut. Honest answers only.]
+It also changed the quality of what I write, not just the volume. Spoken-first drafts are more direct than typed-first drafts. Whatever you imagine you sound like when you speak, you actually sound like that, and the page is more useful when it sounds like a person than when it sounds like someone&apos;s second pass at sounding correct.
 
-## The tried-once list
+[Full review here.](/blog/wisprflow-review)
 
-[TODO — 600 words. The pattern of why these didn't stick. Common failure modes: the tool that needed a workflow change I wasn't going to make, the tool that demoed well but produced output I couldn't trust, the tool that worked but cost more attention than it saved.]
+---
 
-## What I'm watching but haven't adopted
+## Claude Code
 
-[TODO — 300 words. Two or three tools I'm tracking but not paying for yet. Why I haven't committed.]
+I do almost all my code through Claude Code now. The terminal-based interface is the part I expected to hate and turned out to prefer. Background agents — fire and forget on a task, check back from my phone — are where the productivity multiplier actually comes from. Sitting at the desk watching a single agent run is the wrong posture. Setting up four agents and going for a walk is the right one.
 
-## Affiliate disclosure
+Cursor I dropped about a year ago. Claude Code does everything I used Cursor for, minus the GUI.
 
-I have affiliate relationships with Granola and WisprFlow. Both are on the actually-use list independently of the commission. The commission is what makes the time to write at this length economic.
+---
+
+## Claude (the model, in the web app)
+
+The non-Code surface. Long-form drafting, gnarly reading, sense-making across documents. I do not use it as a chatbot. I use it as a tool for tasks where I would otherwise have to read four hundred pages of documentation.
+
+---
+
+## ChatGPT (the model, in the web app)
+
+Less than Claude, but real. Mostly for image generation and for a couple of specific prompts I&apos;ve built up over time that produce better results on GPT than on Claude. Not interchangeable; the model differences are real once you&apos;ve used them long enough.
+
+---
+
+## Sora
+
+A new addition. I&apos;m using it sparingly — short hero loops for blog posts, occasional explainers — and the quality is high enough that I expect it to be more central within the year. Right now: an experimental tool that&apos;s earned a slot.
+
+---
+
+## Cursor (used to be on the list)
+
+I used Cursor heavily for a year before Claude Code matured. Claude Code does what Cursor did, with less context-switching cost. If you love an IDE, Cursor is still solid. I just stopped opening it.
+
+---
+
+## The careful-try list
+
+The tools I gave a real shot and did not adopt. There is no shame in this list — most of them are decent. They didn&apos;t survive contact with my actual workflow.
+
+The common failure modes:
+
+**Tools that required a workflow change I wasn&apos;t going to make.** A tool that worked great if I switched my entire note system, or my entire calendar, or my entire Slack hygiene. The marginal value didn&apos;t justify the migration cost. I would rather keep my janky existing flow and add a tool that fits into it.
+
+**Tools that demoed well but produced output I couldn&apos;t trust.** The demo was magic. The third real-world use case revealed that the magic was fragile. I&apos;d catch myself double-checking the output, which meant I was doing the work twice — once with the tool, once to verify it.
+
+**Tools that cost more attention than they saved.** Every notification, every "did you mean…", every onboarding flow that re-runs at the wrong moment. The hidden tax that ate the benefit.
+
+**Tools that were trying to be the new home for my work.** I have a home for my work. It&apos;s the one I&apos;ve built up over a decade. Any tool that demanded I move in instead of integrate was, for me, dead on arrival.
+
+---
+
+## What I&apos;m watching but haven&apos;t adopted
+
+Two or three things I&apos;m tracking actively without paying for yet:
+
+**Code review agents.** The category is real and improving fast. I have not found one I trust against my actual codebases — the ones I&apos;ve tested produce useful surface-level feedback and miss the kind of architectural questions a thoughtful human would raise. I expect this to flip within a year.
+
+**Voice-first coding interfaces beyond WisprFlow.** I&apos;ve tried two; neither has supplanted my current setup. The bar is high because what I have already works.
+
+**The Claude Code agent ecosystem.** I&apos;m watching what people build on top of subagents and MCP. Some of the most interesting work in the next year happens here.
+
+---
+
+## Disclosure
+
+I have affiliate relationships with Granola and WisprFlow. Both are on the actually-use list, were on it before the affiliate relationships existed, and would stay on it if the relationships disappeared tomorrow. The relationships are what make the time to write at this length economic.
+
+Cursor, Claude Code, Claude, ChatGPT, Sora — no affiliate relationship. I pay for the ones that are paid. The recommendations are uncolored by anything but use.

--- a/src/content/blog/best-ai-meeting-notes-2026/page.mdx
+++ b/src/content/blog/best-ai-meeting-notes-2026/page.mdx
@@ -54,4 +54,12 @@ For completeness, the meeting-productivity tools I actually use are <AffiliateLi
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-If you&apos;re still using a bot-based meeting tool and wondering why your conversations feel slightly off, try a week without the bot. You might be surprised by what people say when they don&apos;t think they&apos;re being recorded.
+## The one-week experiment
+
+If you&apos;re still using a bot-based meeting tool and your conversations feel slightly off, run this experiment for a week. Install <AffiliateLink product="granola" campaign={campaign}>Granola&apos;s free tier</AffiliateLink>, switch off the bot you&apos;ve been using, and let one week of meetings happen without an obvious AI listener in the room. Pay attention to two things — the candor of the people on the calls, and how readable the notes are when you open them on Friday afternoon.
+
+That is the entire test. Most people I&apos;ve recommended this to have a clear answer inside three days. <AffiliateLink product="granola" campaign={campaign}>Start the free trial here</AffiliateLink> — no credit card, capture is local, switching back is a one-click uninstall if it doesn&apos;t earn its slot.
+
+<InlineAffiliateCTA product="granola" campaign={campaign} />
+
+*Affiliate disclosure: I have affiliate relationships with Granola and WisprFlow. Both predate the affiliate relationships on my actually-use list; the relationships are what makes the time to write at this length economic.*

--- a/src/content/blog/best-ai-meeting-notes-2026/page.mdx
+++ b/src/content/blog/best-ai-meeting-notes-2026/page.mdx
@@ -6,99 +6,52 @@ export const metadata = createMetadata(rawMetadata);
 
 export const campaign = 'best-ai-meeting-notes-2026'
 
-Every six months I see the same article: "10 Best AI Meeting Note Tools in [Current Year]." They're all the same listicle with the same tools in a different order. Otter, Fireflies, Fathom, Avoma, Grain, Read AI. They all work roughly the same way: a bot joins your call, records everything, and gives you a transcript.
+Every six months I see the same article: &ldquo;10 Best AI Meeting Note Tools in [Current Year].&rdquo; They are all the same listicle with the same tools in a different order — Otter, Fireflies, Fathom, Avoma, Grain, Read AI — and they all work the same way underneath. A bot joins your call, the bot records the meeting, and afterward you get a transcript and some bulleted action items. I have tried most of them. I now use <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink>, and the reason has nothing to do with transcript quality. It has to do with the bot.
 
-I've tried most of them. I now use <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink>. And the reason has nothing to do with transcript quality.
+## The bot problem
 
-## The Bot Problem
+Every bot-based meeting tool shares the same fundamental flaw, which is that a bot joins your call, and once the bot is there, the meeting changes shape. It sounds minor until you experience it a few hundred times. &ldquo;Otter AI has joined the meeting&rdquo; lands as a tiny social event that the room has to process. Somebody asks whether it&apos;s recording. Now you&apos;re explaining AI tools instead of having your meeting. Client calls bounce when the customer&apos;s policy doesn&apos;t allow third-party recorders in the room. Sensitive conversations get more rehearsed because the bot&apos;s presence is the visible reminder that the conversation has an audience. Zoom and Teams interrupt the first two minutes with consent prompts that nobody actually reads but everybody has to dismiss.
 
-Every bot-based meeting note tool shares the same fundamental flaw: **a bot joins your call.**
-
-This sounds minor until you experience it:
-
-- "Otter AI has joined the meeting" — and suddenly everyone gets self-conscious
-- "Is that recording us?" — now you're explaining AI tools instead of having your meeting
-- Client calls where the bot gets rejected — "We don't allow recording in our meetings"
-- Sensitive conversations where the bot's presence changes what people say
-- Zoom/Teams prompts about recording consent that derail the first two minutes
-
-The bot is the single biggest reason AI meeting notes haven't achieved universal adoption. People hate the bot. And the people who hate it most are the ones whose meetings matter most — executives, salespeople, lawyers, therapists, anyone in a trust-dependent conversation.
+The bot is the single biggest reason AI meeting notes haven&apos;t achieved universal adoption. People hate the bot, and the people who hate it most are the ones whose meetings matter most — executives, salespeople, lawyers, therapists, anyone whose conversation depends on the trust of the person across the table. The transcript-quality argument the listicles fight over isn&apos;t the argument that determines whether the tool gets used in the meetings where the notes are most valuable.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-## How Granola Is Different
+## How Granola is different
 
-Granola doesn't join your call. There's no bot. No recording notification. No "Granola AI is now participating" banner.
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> doesn&apos;t join your call. There&apos;s no bot, no recording notification, no &ldquo;Granola is now participating&rdquo; banner. It runs locally on your machine and captures the audio coming out of your system output, the same audio you would hear with your own ears. To everyone else on the call, nothing is different — you&apos;re just in a normal meeting and there is no visible indication that notes are being taken.
 
-It runs locally on your machine and captures the audio from your system output. To everyone else on the call, nothing is different. You're just in a normal meeting. There's no visible indication that notes are being taken.
+That sounds like a small UX difference and it isn&apos;t. It is a shift in what conversations are possible. The meeting where someone confides they&apos;re struggling with burnout doesn&apos;t happen with a bot present. The client call where they share their real budget doesn&apos;t happen with &ldquo;AI Notetaker is recording&rdquo; on the screen. The 1:1 where your direct report tells you they&apos;re thinking about leaving doesn&apos;t happen with an obvious listener in the room. The architecture choice — local audio, no bot — opens up the conversations that the bot-based tools quietly close off.
 
-This isn't a minor UX difference — it's a fundamental shift in what conversations are possible. The meeting where someone confides they're struggling with burnout? That doesn't happen with a bot present. The client call where they share their real budget? Not with "AI Notetaker is recording."
+## Where the tradeoff sits
 
-## Feature Comparison (Honest)
+Granola earns its slot for me because of the no-bot advantage, but the alternatives do win on a few specific dimensions worth naming honestly. Granola produces clean structured notes per meeting and keeps them in your local app — it does not give a team-wide searchable transcript database the way Fireflies and Otter do. It does not have a live-transcription overlay during the meeting the way Otter does. It does not natively push deal records into your CRM the way Fathom and Avoma do for revenue teams. And it does not solve the &ldquo;everyone in this room is fine with the bot anyway&rdquo; case any better than the bot-based tools, because for that case the bot was never a problem to begin with.
 
-Let me be straightforward about what Granola does and doesn't do compared to alternatives:
-
-**Granola wins:**
-- No bot — nobody knows notes are being taken
-- Works with any meeting platform (Zoom, Meet, Teams, in-person)
-- Local processing — your audio stays on your machine
-- Clean, structured notes, not just a raw transcript
-- Action items extracted automatically
-
-**Alternatives might win if:**
-- You need a shared team transcript database (Fireflies, Otter)
-- You want real-time live transcription during the meeting (Otter)
-- You need CRM integration and automatic deal tracking (Fathom, Avoma)
-- You're in a context where bots are totally fine (internal standups)
-
-For me, the no-bot advantage outweighs everything else. The meetings where notes matter most are exactly the meetings where a bot would change the dynamic.
+For me — and for most of the people I&apos;ve recommended Granola to — the meetings where notes matter most are precisely the meetings where a bot would change the dynamic. So the no-bot advantage outweighs every other axis. If your shape of meetings is mostly internal standups and large all-hands where a searchable transcript matters more than the bot question, a different tool is the better fit, and that&apos;s fine.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-## My Decision Matrix
+## How I actually split the tools
 
-I use Granola for:
-- **All external meetings** — clients, partners, interviews, anyone outside my company
-- **1:1s** — both as a manager and as a report
-- **Sensitive internal meetings** — reorgs, performance conversations, strategy
-- **In-person meetings** — it works even when there's no video call
+I use Granola for all external meetings — clients, partners, interviews, anyone outside my company — because those are the contexts where a bot in the room reads as unprofessional and where the meeting has the most riding on it. I use it for 1:1s on both sides of the relationship, where the social dynamic of a recorder being present is the thing that suppresses the conversation I actually want to have. I use it for sensitive internal meetings — reorgs, performance conversations, strategy discussions — for the same reason. And I use it for in-person meetings, where it just sits on the desk and captures the audio from the room without anyone setting up Zoom or pretending the conversation is happening on a screen.
 
-I could see using a bot-based tool for:
-- **Internal all-hands** — everyone knows it's recorded anyway
-- **Large team meetings** — where a searchable transcript helps people who couldn't attend
-- **Sales calls where you have consent** — and the CRM integration matters
+I could see myself using a bot-based tool for internal all-hands where the meeting is recorded anyway and everyone knows it, for large team meetings where a searchable transcript actually does help people who couldn&apos;t attend, and for sales calls where the customer has consented to recording and the CRM integration is the part that earns the tool its line item. The right tool for the meeting depends on the meeting&apos;s shape; what changed for me is that the default tool for &ldquo;most of my meetings&rdquo; is no longer a bot.
 
-## The Note Quality
+## What the notes are actually like
 
-This is where I expected Granola to be weaker — how good can the notes be without a direct microphone feed from each participant?
-
-Surprisingly good. The structured notes consistently capture:
-- Key discussion points with attribution
-- Decisions made and rationale
-- Action items with owners
-- Follow-up topics that were deferred
-
-They're not a verbatim transcript. They're better than a verbatim transcript — they're organized, prioritized, and readable. I spend about 60 seconds reviewing and adding my own observations (body language, tone, things that won't show up in audio) and then they're filed.
+This is where I expected Granola to be weaker, and where it surprised me. The structured output captures key discussion points with attribution, decisions and the rationale behind them, action items with named owners, and the follow-up topics that got deferred. It is not a verbatim transcript, and that is the point — it is better than a verbatim transcript, because it is organized, prioritized, and actually readable. I spend about sixty seconds reviewing and adding the things audio can&apos;t catch — body language, tone, something somebody hesitated on — and then the note is filed. Reading time per meeting dropped from &ldquo;scroll through a forty-five-minute wall of text&rdquo; to &ldquo;read a one-page artifact.&rdquo;
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-## What Changed When I Switched
+## What changed when I switched
 
-The most noticeable change wasn't in my notes. It was in my meetings.
+The most noticeable change wasn&apos;t in the notes. It was in the meetings. When I stopped having a bot join every call, people started being more candid. I heard things I wasn&apos;t hearing before — not because I was recording covertly, but because the social dynamic of a visible AI participant was gone. People relax when they think it&apos;s just a conversation. The conversation became more honest, the meeting quality went up, and the notes got better as a downstream effect of the meeting itself being better.
 
-When I stopped having a bot join every call, people started being more candid. I heard things I wasn't hearing before — not because I was recording secretly, but because the social dynamic of having a visible AI participant was gone. People relax when they think it's just a conversation.
+I spend less time reviewing notes too, because they&apos;re structured instead of being a raw transcript I have to scroll through. The compounding effect across two or three meetings a day, over a year, is hard to quantify but easy to feel.
 
-My meeting quality went up. My note quality went up. And I spend less time reviewing notes because they're structured instead of being a raw 45-minute transcript I have to scroll through.
+## The full stack
 
-## The Stack
-
-For completeness, here's my full meeting productivity stack:
-- **<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink>** for meeting capture and notes
-- **<AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink>** for dictating follow-up emails and Slack messages after meetings
-- **Claude** for synthesizing notes across multiple meetings when preparing for reviews or project retrospectives
-
-The combination of being fully present during meetings (Granola) and being absurdly fast at follow-ups after (WisprFlow) has probably saved me 5-7 hours per week.
+For completeness, the meeting-productivity tools I actually use are <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> for the capture and the notes, <AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> for dictating the follow-up emails and Slack messages after the meeting at 175+ WPM instead of typing them, and Claude for synthesizing notes across multiple meetings when I&apos;m preparing for a quarterly review or a project retrospective. The combination — fully present during the meeting, absurdly fast on the follow-up afterward — has probably saved me five to seven hours a week. Most of that came back as time I would have spent dreading the next meeting.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-If you're still using a bot-based meeting tool and wondering why your conversations feel slightly off — try a week without the bot. You might be surprised what people say when they don't think they're being recorded.
+If you&apos;re still using a bot-based meeting tool and wondering why your conversations feel slightly off, try a week without the bot. You might be surprised by what people say when they don&apos;t think they&apos;re being recorded.

--- a/src/content/blog/best-ai-meeting-notes-remote-teams-2026/page.mdx
+++ b/src/content/blog/best-ai-meeting-notes-remote-teams-2026/page.mdx
@@ -52,10 +52,14 @@ Regardless of which tool you pick, AI-generated notes are only as useful as the 
 
 <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> produces something close to that structure by default. Tools that produce raw transcripts require extra work to compress into something async-useful, and the extra work usually doesn&apos;t happen consistently. The structural quality is what makes the notes useful, not the AI quality of the transcription.
 
-## Bottom line
+## Bottom line — and the seven-day test
 
 For remote teams in 2026, AI meeting notes are table stakes. The question is which tool fits your workflow. For client-facing and professional calls, <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> is the right pick — silent capture, no bot, async-ready notes. For internal calls with a shared team archive, Otter Business or Fireflies fits better. For teams already deep in Notion, Notion AI is one fewer tool to integrate. For sales or customer success orgs running on CRM data, Fireflies edges ahead.
 
-If you&apos;re not sure, start with <AffiliateLink product="granola" campaign={campaign}>Granola&apos;s free tier</AffiliateLink>. The async-ready structured output is the best single thing you can give a distributed team this year.
+The fastest way to know which one you actually need is to run <AffiliateLink product="granola" campaign={campaign}>Granola&apos;s free tier</AffiliateLink> through one week of your real calendar. Use the default template, read the structured output, and decide on Friday whether the async readability is the upgrade your distributed team has been waiting for. If it is, you keep it. If it isn&apos;t, you&apos;ve lost nothing — the trial is free, no credit card, and capture happens locally on your own machine, so the experiment doesn&apos;t require anything from your teammates.
+
+That is the cheapest test of a meeting-notes tool I have ever run. Most distributed teams I&apos;ve recommended this to make the decision inside three days. <AffiliateLink product="granola" campaign={campaign}>Start the free trial here.</AffiliateLink>
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
+
+*Affiliate disclosure: I have an affiliate relationship with Granola. The recommendation predates the relationship; the relationship is what makes the time to write at this length economic.*

--- a/src/content/blog/best-ai-meeting-notes-remote-teams-2026/page.mdx
+++ b/src/content/blog/best-ai-meeting-notes-remote-teams-2026/page.mdx
@@ -6,129 +6,56 @@ export const metadata = createMetadata(rawMetadata);
 
 export const campaign = 'best-ai-meeting-notes-remote-teams-2026'
 
-Remote work has a documentation problem. When your team is spread across four time zones, nobody can attend every meeting. The person who skipped Thursday's strategy sync because they were asleep needs more than a three-line Slack summary. And the person who took the notes manually? They're probably doing it wrong.
+Remote teams have a documentation problem most co-located teams don&apos;t fully appreciate. When the team is spread across four time zones, no single person can attend every meeting that matters, and the person who slept through Thursday&apos;s strategy sync needs more than a three-line Slack summary to be useful again on Friday. The person who took the notes manually is probably doing it wrong — not because they&apos;re bad at notes, but because manual note-taking and being present in a meeting are competing for the same cognitive load, and remote meetings raise the stakes on presence in ways that co-located meetings don&apos;t.
 
-AI meeting notes aren't optional for remote teams — they're infrastructure.
-
-<InlineAffiliateCTA product="granola" campaign={campaign} />
-
-## Why Remote Teams Have Higher Stakes for Meeting Notes
-
-In a co-located office, context leaks through. You overhear the conversation in the hall. You catch the vibe of the meeting even if you weren't in the room. Someone fills you in at the coffee machine.
-
-Remote teams don't have this. Every meeting is an island. If someone wasn't there and there are no good notes, the knowledge is just... gone. This manifests as:
-
-- Repeated decisions (because nobody documented the first one)
-- Context gaps that slow down async work
-- Teammates feeling excluded from important context
-- "I thought we decided X" conversations that waste hours
-
-Good AI meeting notes aren't just convenient for remote teams — they're a structural necessity.
-
-## What Remote Teams Need from Meeting Notes AI
-
-**Async-first output:** Notes that are actually useful to someone reading them 12 hours later, without access to tone, context, or follow-up questions.
-
-**Reliable summaries:** Not just transcripts — structured output with decisions, action items, open questions. The kind of notes that actually communicate what happened.
-
-**Cross-platform compatibility:** Remote teams use whatever platform their calendar, client, or vendor dictates. Zoom, Google Meet, Teams, Webex — the tool needs to work everywhere.
-
-**Searchable history:** "What did we decide about the API architecture in February?" If your notes aren't searchable, they're archives, not assets.
-
-**Low friction for everyone:** If the tool requires every team member to configure a bot invite for every meeting, adoption will fragment. Simple is better.
-
-## Top Tools for Remote Teams
-
-### Granola — Best for Individual Remote Contributors
-
-<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> runs on your machine. You open it before a meeting, and it captures everything without any action required from other participants. When the meeting ends, you have structured notes with decisions and action items.
-
-**Why it works for remote teams:**
-
-**No configuration per-meeting.** You're on 8 Zoom calls, 3 Google Meets, and 2 Teams calls this week. Granola captures all of them. No bot invitation per call. No permission to set up.
-
-**Works for any meeting platform.** Remote teams don't control which platform their clients, vendors, or partners use. Granola captures from system audio regardless of platform.
-
-**Notes are async-ready.** The structured output is designed to be read by someone who wasn't there — not a raw transcript that requires context to parse.
-
-**Client calls stay clean.** For remote consultants or agencies, client calls with a bot announcing itself are unprofessional. Granola solves this.
-
-**Limitation:** Requires each person to run their own Granola instance. Notes aren't automatically shared to a team workspace (though you can share the output easily).
+AI meeting notes are infrastructure for remote teams, not a productivity-hack nice-to-have. The right tooling fits between &ldquo;everyone heard it&rdquo; and &ldquo;everyone read about it,&rdquo; and the wrong tooling makes both sides worse.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-### Otter.ai — Best Shared Team Transcript Database
+## Why remote teams have higher stakes on meeting notes
 
-Otter Business gives teams a shared workspace where all meeting recordings and transcripts are searchable. This is powerful for the "what did we decide in February?" use case.
+In a co-located office, context leaks through the walls. You overhear the conversation in the hall. You catch the vibe of a meeting even when you weren&apos;t in the room. Someone fills you in at the coffee machine the next morning. The information channels are leaky in a way that is mostly good — knowledge that should propagate, propagates, even when the original meeting was undocumented.
 
-**Why it works for remote teams:**
+Remote teams don&apos;t have those channels. Every meeting is an island. If someone wasn&apos;t there and the notes are sparse or absent, the knowledge is just gone. That manifests as decisions being relitigated because nobody wrote down the first one, as context gaps that slow down everyone working async, as teammates feeling quietly excluded from important conversations, and as endless &ldquo;I thought we decided X&rdquo; back-and-forths that eat hours per quarter. None of that is dramatic on a single day. All of it compounds.
 
-**Team-wide searchable library.** All past meetings are indexed and searchable by everyone with access.
+Good AI meeting notes — async-ready, structured, searchable — close those gaps. The reason this matters more for remote teams isn&apos;t that the meetings are different. It&apos;s that the absence of secondary information channels means the meeting&apos;s artifact has to do more work.
 
-**Real-time captions.** Useful for teammates with hearing difficulties or in noisy environments (a common remote work reality).
+## What remote teams actually need from a meeting-notes tool
 
-**Catch-up friendly.** Team members in different timezones can read and comment on transcripts asynchronously.
+The first thing is async-first output. The notes have to be useful to someone reading them twelve hours later, without access to tone, follow-up questions, or the body language that filled in the gaps when the meeting was live. A raw transcript fails that test. A bullet-list of action items without context also fails. What survives is structured output that captures decisions, owners, open questions, and the lines someone said that actually mattered.
 
-**Limitation:** Bot-based. For internal standups, this is fine. For external client calls, less so.
+The second is reliable summarization across meeting platforms. Remote teams don&apos;t control which platform their clients, vendors, or partners use — Zoom this week, Google Meet next, Teams when the customer&apos;s IT department insists on it, Webex when the call is with the bank. A tool that only captures one platform fragments adoption, and a tool that requires a per-meeting bot invitation creates friction every time. What works is a capture layer that doesn&apos;t care about the platform.
 
-### Fireflies.ai — Best for Remote Sales and CS Teams
+The third is searchable history. &ldquo;What did we decide about the API architecture in February?&rdquo; comes up roughly weekly on any team I&apos;ve worked on. If the answer isn&apos;t one query away, the notes are archives instead of assets, and the team ends up rebuilding context every quarter from incomplete recollection. The fourth and last thing is low friction per meeting. Anything that requires every team member to configure a bot invite or set permissions per call will fragment in adoption within a month. What scales is what disappears into the background.
 
-Remote sales and customer success teams need their call data in the CRM. Fireflies delivers this with strong integration into Salesforce, HubSpot, and others.
+## The tools worth comparing
 
-**Why it works for remote teams:**
+A few tools earn their slots for remote teams, and each fits a different shape of the problem. <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> is the one I lean on for individual contributors and for client-facing work. It runs on your machine and captures local audio without joining the call as a bot, which means there&apos;s no configuration per meeting, no permission to set up, and no awkward &ldquo;Granola Bot has joined&rdquo; moment in the customer call. It captures Zoom, Meet, Teams, Webex, and anything else your machine&apos;s audio can hear, which removes the platform-coordination problem entirely. The structured output is built to be read by someone who wasn&apos;t there — decisions, owners, follow-ups — which is exactly the shape async readers need. The tradeoff is that notes aren&apos;t automatically shared into a team workspace; each person runs their own instance and shares the output deliberately. For client-facing meetings and for individual remote contributors that&apos;s the right shape; for team-wide internal archives it isn&apos;t.
 
-**Automatic CRM sync.** Calls automatically populate deal records, contact timelines, and opportunity notes.
+Otter Business takes the opposite approach and is better suited to that second shape. It gives the team a shared workspace where every meeting recording and transcript is indexed and searchable by anyone with access, which is powerful for the February-API-decision use case. Real-time captions are useful for teammates with hearing difficulties or in noisy environments, both of which show up more often on distributed teams than people admit. Teammates in different timezones can read and comment on transcripts asynchronously instead of trying to schedule a catch-up call. The cost is that Otter is bot-based, which is fine for internal standups and ill-suited to external client calls where a meeting bot announcing itself reads as unprofessional.
 
-**Cross-timezone follow-up automation.** Action items extracted and routed without manual work.
+Fireflies.ai is the right pick if you&apos;re running a remote sales or customer-success org and your call data needs to land in the CRM with minimal manual effort. Calls automatically populate deal records, contact timelines, and opportunity notes; action items get extracted and routed across timezones without anyone touching them. Team analytics surface how the conversations across the distributed revenue org are actually going. It earns its slot for revenue-focused teams and is less obviously useful for general engineering or product meetings.
 
-**Team analytics.** See how conversations are going across your distributed revenue team.
+The fourth is Notion AI, which earns its slot specifically when your remote team already runs its knowledge base in Notion. The integration drops meeting summaries directly into your workspace — the meeting note lands in the project page or sprint planning doc where decisions actually live, which is one fewer tool to coordinate. The tradeoff is that it depends on Notion adoption being deep enough that the rest of the team will actually look at the pages, and recording quality varies more than the alternatives.
 
-**Limitation:** Best for revenue-focused teams. General engineering or product meetings less well served.
+<InlineAffiliateCTA product="granola" campaign={campaign} />
 
-### Notion AI — Best if Your Remote Wiki is Notion
+## What mature remote teams usually end up with
 
-Many remote-first companies run their knowledge base in Notion. Notion AI's meeting notes integration drops summaries directly into your workspace.
+Most of the distributed teams I&apos;ve watched develop their tooling over a quarter or two converge on a stack, not a single tool. <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> handles the client calls and the leadership meetings — the contexts where a bot in the room is unacceptable and async-ready notes are most valuable. Either Otter or Fireflies handles internal all-hands and standups where a team-searchable archive matters more than the bot question. Notion or Confluence holds the structured meeting-note templates and the decision logs, which is where the Granola or Otter output gets pasted or synced after the fact.
 
-**Why it works for remote teams:**
+The reason teams converge on the stack rather than a single product is that the client-facing meeting and the Friday team sync need different things from the tool. The client meeting needs silent capture and a professional artifact. The Friday sync needs a shared archive that anyone on the team can search next quarter. Trying to solve both with one tool means compromising on one of them, and the compromises are visible to either customers or teammates.
 
-**Notes land where decisions get made.** The meeting summary goes directly into your project page, sprint planning doc, or decision log.
+## Making the notes actually useful for async readers
 
-**One fewer tool.** If the whole team is already in Notion, this reduces context switching.
+Regardless of which tool you pick, AI-generated notes are only as useful as the structure they carry. The shape that lands on async readers consistently is short and disciplined: a one-line meeting context at the top — date, attendees, length — followed by decisions made (not discussed; decided), action items with owners and due dates, open questions that need input from people who weren&apos;t there, and links to any docs or tickets mentioned. That structure works because it answers the four questions an async reader actually has: what was decided, what do I owe, what&apos;s still open, where do I go for more.
 
-**Limitation:** Dependent on Notion adoption. Recording quality varies.
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> produces something close to that structure by default. Tools that produce raw transcripts require extra work to compress into something async-useful, and the extra work usually doesn&apos;t happen consistently. The structural quality is what makes the notes useful, not the AI quality of the transcription.
 
-## The Remote Team Stack
+## Bottom line
 
-What many mature remote teams end up with:
+For remote teams in 2026, AI meeting notes are table stakes. The question is which tool fits your workflow. For client-facing and professional calls, <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> is the right pick — silent capture, no bot, async-ready notes. For internal calls with a shared team archive, Otter Business or Fireflies fits better. For teams already deep in Notion, Notion AI is one fewer tool to integrate. For sales or customer success orgs running on CRM data, Fireflies edges ahead.
 
-1. **Granola** for client calls and executive/leadership meetings (no bot, professional, async-ready notes)
-2. **Otter or Fireflies** for internal all-hands and standups (team-searchable transcript database)
-3. **Notion or Confluence** for structured meeting notes templates and decisions (where the Granola or Otter output gets pasted/synced)
-
-They solve different problems: the client-facing meeting needs a different tool than the Friday team sync.
-
-## Making Notes Actually Useful for Async Readers
-
-Regardless of which tool you use, AI-generated notes are only as good as the structure. For remote teams, train your notes practice:
-
-**Good async notes include:**
-- One-line context: "Q2 planning, 6 attendees, 45 minutes"
-- Decisions made (not discussed — decided)
-- Action items with owners and due dates
-- Open questions that need input from people who weren't there
-- Links to relevant docs or tickets mentioned
-
-<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> outputs this structure by default. Tools that just produce transcripts require extra work to make them async-useful.
-
-## Bottom Line
-
-For remote teams, AI meeting notes are table stakes in 2026. The question is which tool fits your workflow:
-
-- **Client-facing and professional:** Granola. No bot, no awkwardness, great output.
-- **Internal with shared archive:** Otter Business or Fireflies.
-- **Notion-native teams:** Notion AI.
-- **Sales/CS with CRM:** Fireflies or Granola + manual CRM entry.
-
-Start with <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> free if you're not sure. The async-ready structured notes are the best thing you can give your distributed team.
+If you&apos;re not sure, start with <AffiliateLink product="granola" campaign={campaign}>Granola&apos;s free tier</AffiliateLink>. The async-ready structured output is the best single thing you can give a distributed team this year.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />

--- a/src/content/blog/granola-vs-traditional-meeting-notes/metadata.json
+++ b/src/content/blog/granola-vs-traditional-meeting-notes/metadata.json
@@ -1,8 +1,8 @@
 {
-  "title": "Granola vs Traditional Meeting Notes: Why AI Wins Every Time",
+  "title": "Granola vs traditional meeting notes — what actually changed when I switched",
   "author": "Zachary Proser",
   "date": "2026-3-8",
-  "description": "Compare Granola's AI meeting intelligence with manual note-taking, shared Google Docs, and basic recording tools. See why AI transcription dominates.",
+  "description": "A decade of manual meeting notes taught me that traditional note-taking forces an impossible choice: be present in the meeting, or document it. Here's what changed when I stopped trying to do both.",
   "image": "https://zackproser.b-cdn.net/images/granola-hero.webp",
   "tags": ["ai", "meetings", "comparison", "productivity", "manual"],
   "hiddenFromIndex": true

--- a/src/content/blog/granola-vs-traditional-meeting-notes/page.mdx
+++ b/src/content/blog/granola-vs-traditional-meeting-notes/page.mdx
@@ -2,109 +2,62 @@ import { InlineAffiliateCTA, AffiliateLink } from '@/components/StickyAffiliateC
 
 export const campaign = 'granola-vs-traditional-meeting-notes';
 
-# Granola vs Traditional Meeting Notes: Why AI Wins Every Time
+# Granola vs traditional meeting notes — what actually changed when I switched
 
-Meeting documentation has evolved from handwritten notes to shared documents, but most teams still rely on manual methods that miss critical information and slow down decision-making. Granola's AI meeting intelligence represents a fundamental shift from reactive documentation to proactive meeting insights. Here's why AI-powered meeting notes outperform every traditional approach.
+I took meeting notes the traditional way — by hand, in a notebook, then in shared Google Docs, then in voice memos I never re-listened to — for about a decade before I gave up. The honest reason I gave up is that traditional meeting notes ask you to make a choice on every call that nobody should have to make. You can be present in the meeting, or you can document the meeting. You cannot do both well, and the longer you try, the more you accept that neither half of the work is actually getting done.
 
-## The Traditional Meeting Documentation Problem
-
-Manual note-taking during meetings creates an impossible choice: participate actively or document comprehensively. Most people do neither well, resulting in incomplete records that miss crucial decisions, action items, and context. This documentation gap leads to confusion, missed deadlines, and repeated discussions of previously settled matters.
+This piece is what changed when I stopped trying to do both halves and let <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> do one of them for me. It is not an argument that traditional notes are useless — they are not — it is an argument about what the cost of doing them by hand actually is, once you can see it.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-## Manual Note-Taking vs. Granola
+## What manual note-taking actually costs
 
-### Manual Note-Taking Limitations
-- **Divided attention:** Note-takers miss conversational nuances and context
-- **Incomplete capture:** Fast-paced discussions outpace typing speed
-- **Personal bias:** Note-takers emphasize information they find important
-- **Legibility issues:** Handwritten notes become illegible over time
-- **No searchability:** Finding specific information requires manual review
+The visible cost of taking notes by hand during a meeting is the time you spend writing things down. That cost is the small one. The bigger cost is the cognitive split — the part of your attention that&apos;s on the conversation versus the part that&apos;s on the page. I used to think I was multitasking on those calls. I was not. I was alternating, badly, between listening and writing, and the alternation cost showed up as missed nuances, half-recorded sentences, and a vague sense that I&apos;d been in the meeting without quite knowing what we&apos;d decided.
 
-### Granola's AI Advantage
-- **Complete capture:** Every word recorded with perfect accuracy
-- **Intelligent summarization:** AI identifies key decisions and action items
-- **Objective documentation:** No personal bias affects what gets recorded
-- **Instant searchability:** Find any discussion point immediately
-- **Context preservation:** Full conversation context available for review
+The other cost is what the notes actually contain. Manual notes are aggressively biased toward what the note-taker found memorable, not what the meeting decided. The conversation moves faster than handwriting or typing, so what survives onto the page is a sample of the discussion, weighted by what the note-taker could keep up with. By the time I looked at my own notes the next day, they read like a partial transcript of someone else&apos;s meeting. And they were illegible after three months. And they were not searchable.
 
-## Shared Google Docs vs. Granola
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> closes those gaps not by being smarter than me, but by separating the two jobs that used to share my attention. The capture is total, automatic, and silent. The notes are structured by template into decisions, action items, and follow-ups. I get to do the meeting; the meeting gets documented anyway.
 
-### Shared Documents Approach
-Many teams use collaborative documents for meeting notes, with someone designated to type key points during discussions. This method improves on individual note-taking but still has significant limitations:
+## Shared Google Docs is the same problem, slightly redistributed
 
-- **Real-time typing lag:** Discussions move faster than documentation
-- **Multiple contributor confusion:** Different writing styles and emphasis
-- **Format inconsistency:** No standard structure for different meeting types
-- **Attention splitting:** Designated note-taker can't fully participate
+The most common upgrade from a personal notebook is a shared Google Doc with somebody on the team typing while everyone else talks. It improves on the personal-notebook version because the notes exist in one searchable place, but it doesn&apos;t solve the underlying problem — it just moves the cognitive split from the whole team to one person, who becomes the designated note-taker and therefore the least-present person in the room.
+
+The designated-note-taker pattern has predictable failure modes. The typing lag means the doc captures what was said two sentences ago. Multiple contributors trying to keep up produce a document with three different writing styles and no consistent structure. The note-taker doesn&apos;t participate in the discussion they&apos;re documenting, which is a real cost when that person had something useful to contribute. And the format varies by meeting, by author, by mood, so the doc isn&apos;t actually useful as a referenceable artifact a quarter later — it&apos;s a series of slightly-different documents that happen to share a folder.
+
+<AffiliateLink product="granola" campaign={campaign}>Granola&apos;s</AffiliateLink> output is consistently structured because the structure is enforced by the template, not by whoever was fastest at typing. Everyone in the meeting is present. The artifact you get afterward is the same shape every time, which is what makes it usable as a record rather than as a series of partial transcripts.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-### Granola's Structured Intelligence
-Granola eliminates the shared document chaos by providing:
-- **Consistent formatting:** Every meeting follows the same intelligent structure
-- **Complete participation:** All attendees can focus entirely on discussion
-- **Automatic organization:** Action items, decisions, and discussions clearly separated
-- **Instant distribution:** Meeting summaries available immediately after conclusion
+## Raw recordings solve capture, but not the part that matters
 
-## Basic Recording vs. Granola's AI Intelligence
+The third pattern I tried was just recording the meeting and letting future-me deal with it. That fixed capture quality entirely — every word was there, on disk, indexed by date. The problem is that capture is only half the job, and the half I was struggling with was the second half.
 
-Some teams record meetings using basic tools, but raw recordings create more problems than they solve:
+A recording is a fifty-minute audio file. To extract any value from it, you have to re-listen, which takes about as long as the meeting did, with worse audio. So either you re-listen — at which point you&apos;ve doubled the meeting&apos;s time cost — or you don&apos;t, in which case the recording is a digital archive of a meeting nobody will ever revisit. The third option used to be paying a transcription service, which produced a verbatim text wall that was technically searchable but not usefully readable. None of these is the same as having structured notes.
 
-### Basic Recording Problems
-- **Time-consuming review:** Hours of audio require manual listening
-- **No structure:** Critical information buried in conversation
-- **Poor searchability:** Finding specific topics requires full playback
-- **Storage burden:** Large audio files with minimal value
-- **Transcription costs:** Manual or basic AI transcription adds time and expense
+<AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> handles capture in the same architecture as a recorder — local audio, no bot — and then does the work that turns capture into a usable artifact. The transcript is there if I need it; in practice I almost never do, because the structured summary is the doc I actually want. The recording becomes a citation layer for the moments that matter, not the primary artifact.
 
-### Granola's Intelligent Processing
-- **Instant summaries:** Key information available immediately
-- **Action item extraction:** Automatic identification of tasks and owners
-- **Decision tracking:** Clear record of what was decided and when
-- **Topic organization:** Related discussions grouped logically
-- **Searchable intelligence:** Find any discussion point instantly
+## What the meeting itself looks like, on the other side
+
+This is the part of the comparison that didn&apos;t show up until I&apos;d been on the new system for a few weeks. The thing I noticed wasn&apos;t the notes. It was the meetings.
+
+When nobody is the designated note-taker, the meeting has more participants. When nobody is splitting attention, the conversation moves faster and lands sharper. When the artifact is going to be structured automatically, people stop performing &ldquo;making sure that&apos;s captured&rdquo; for the note-taker&apos;s benefit and just say the thing. I started getting better information out of the same calls. The meetings I would have previously dreaded — three back-to-back syncs, a customer call, a 1:1 — stopped feeling like cognitive overhead I had to budget for, because the budget item I was avoiding was the note-taking, not the meeting.
+
+The honest version of the cost-benefit argument is that the time I save in post-meeting cleanup is real — about two minutes per meeting instead of ten, across roughly twenty captured meetings a week — but the bigger effect is the cognitive load that&apos;s no longer there. <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> pays its line item back in time savings. It earns its place on the daily-use list by removing the dread.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-## Meeting Productivity Comparison
+## When traditional methods still win
 
-### Traditional Methods Impact on Meetings
-- **Reduced participation:** Designated note-takers become passive observers
-- **Repetitive clarification:** "Can you repeat that for the notes?"
-- **Post-meeting confusion:** Unclear action items and responsibilities
-- **Slow follow-up:** Manual note compilation delays next steps
-- **Information loss:** Critical context forgotten between meetings
+In fairness — there are cases where the manual approach is still the right one. Quick stand-ups where the meeting is too short for structured notes to be worth the setup. Brainstorms where the value is the whiteboard, not the dialogue. Sensitive conversations where you&apos;ve made a deliberate choice not to record. A meeting with one trusted colleague where you both know the artifact isn&apos;t the point. For each of these, a notebook or a one-line Slack recap after is still the better tool.
 
-### Granola's Meeting Enhancement
-- **Full engagement:** Everyone participates completely in discussions
-- **Natural conversation:** No interruptions for documentation
-- **Immediate clarity:** Action items and decisions instantly clear
-- **Rapid follow-up:** Summaries enable immediate post-meeting action
-- **Perfect memory:** Complete context available for future reference
+The argument isn&apos;t that AI notes are always better. The argument is that for the meetings where notes actually matter — decisions, commitments, customer calls, 1:1s, design reviews — the structural shift from &ldquo;document while you talk&rdquo; to &ldquo;document because you talked&rdquo; is the upgrade. <AffiliateLink product="granola" campaign={campaign}>Granola</AffiliateLink> happens to be the tool that makes that shift cheap.
 
-## Cost and Time Analysis
+## If you&apos;re still on the fence
 
-Traditional methods appear free but carry hidden costs:
-- **Personnel time:** Meeting participants spend time on documentation instead of work
-- **Follow-up meetings:** Incomplete notes require clarification sessions
-- **Missed opportunities:** Poor documentation leads to forgotten action items
-- **Reduced meeting quality:** Documentation focus detracts from decision-making
+The shortest path to knowing whether the switch is worth it for you is to run <AffiliateLink product="granola" campaign={campaign}>Granola&apos;s free tier</AffiliateLink> for a week on the meetings where notes actually matter. Use the default template. Read the output. Compare what you got to what you would have written by hand. If the gap doesn&apos;t feel meaningful in seven days, you stay on the traditional system and have lost nothing. If it does, the switch happens on its own.
+
+I made the switch twelve months ago and have not gone back. The notebook is still on the desk, and I still pick it up for the rare meeting that doesn&apos;t want structured documentation. The default has just flipped: AI for the meetings where the record matters, hand notes for the ones where it doesn&apos;t. That&apos;s the version of the comparison that actually matches my workflow now.
 
 <InlineAffiliateCTA product="granola" campaign={campaign} />
 
-Granola's AI intelligence pays for itself through:
-- **Time savings:** No manual note-taking or post-meeting compilation
-- **Better decisions:** Complete information leads to better outcomes  
-- **Faster execution:** Clear action items accelerate project progress
-- **Reduced rework:** Comprehensive records prevent repeated discussions
-
-## The Meeting Intelligence Revolution
-
-Traditional meeting documentation treats recording as an afterthought. Granola makes meeting intelligence the centerpiece, transforming meetings from information exchange sessions into decision-making engines with perfect memory.
-
-The shift from manual documentation to AI intelligence isn't just about convenience – it's about fundamentally improving how teams make decisions and execute on commitments.
-
-<AffiliateLink product="granola" campaign={campaign}>Try Granola free</AffiliateLink> and experience the difference between traditional meeting documentation and true meeting intelligence.
-
-Teams that adopt AI meeting intelligence gain a sustainable competitive advantage: better decisions, faster execution, and perfect institutional memory that traditional methods simply cannot match.
+*Affiliate disclosure: I have an affiliate relationship with Granola. The switch predates the relationship by months; the relationship is what makes the time to write at this length economic. The take is mine.*

--- a/src/content/blog/how-i-prep-for-1-1s-as-an-engineer/metadata.json
+++ b/src/content/blog/how-i-prep-for-1-1s-as-an-engineer/metadata.json
@@ -1,0 +1,18 @@
+{
+  "title": "How I prep for 1:1s as an engineer",
+  "author": "Zachary Proser",
+  "date": "2026-05-13",
+  "description": "A senior engineer's 1:1 prep system — what I bring to the meeting, what I let the AI notetaker handle, and the weekly review loop that keeps 1:1s from feeling like a tax.",
+  "image": "https://zackproser.b-cdn.net/images/prep-1-1s-engineer-hero.webp",
+  "slug": "/blog/how-i-prep-for-1-1s-as-an-engineer",
+  "keywords": [
+    "engineer 1:1 prep",
+    "1:1 meeting",
+    "senior engineer 1:1",
+    "manager 1:1",
+    "meeting prep",
+    "Granola"
+  ],
+  "tags": ["meetings", "productivity", "1:1s", "career"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/how-i-prep-for-1-1s-as-an-engineer/page.mdx
+++ b/src/content/blog/how-i-prep-for-1-1s-as-an-engineer/page.mdx
@@ -5,29 +5,77 @@ import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
 
-<Image src={rawMetadata.image} alt="A simple notebook spread next to a laptop showing a 1:1 prep doc" width={1200} height={630} />
-<figcaption>The prep doc lives in one place. The notes from the meeting itself live somewhere else. That separation is the whole system.</figcaption>
+<Image src={rawMetadata.image} alt="A simple notebook open next to a closed laptop on a wooden desk" width={1200} height={630} />
+<figcaption>The prep doc lives somewhere I can find it on a Tuesday. That&apos;s the whole secret.</figcaption>
 
-## The prep doc / notes-doc split
+I have a 1:1 with my manager once a week. I have 1:1s with my direct reports once every other week. By the end of any given month I&apos;ve been in roughly ten of these conversations, and for most of the years before I figured out how to prep for them, I treated each one as a thing that happened *to* me on the calendar, rather than something I could shape on purpose.
 
-[TODO — 200 words. Why I keep them as separate artifacts. Prep doc is mine, lives in my weekly review. Notes doc is shared, lives in Granola.]
+The shift came when I started keeping two artifacts instead of one: a *prep doc* and a *notes doc*. They are not the same. They live in different places. <Link href="/granola">Granola</Link> handles the second one. The first is mine to maintain.
+
+---
+
+## The prep doc is for me. The notes doc is for both of us.
+
+The prep doc is a single running document, by relationship — one for me with my manager, one for each person reporting to me. It lives in my weekly review. It is private, it is messy, and nothing in it is performance.
+
+The notes doc is whatever Granola produced after the most recent 1:1. It is the structured record. It&apos;s shareable. It&apos;s referenceable. I do not write into it during the meeting and I rarely edit it after.
+
+Separating these two artifacts is the entire technique. Most of the failure modes of 1:1s come from collapsing them into a single artifact — either by writing during the meeting (which sacrifices presence), or by trying to "share notes" with the other person and then sanding everything down to corporate diplomatic English (which sacrifices the part that was actually useful to me).
+
+Keep them separate. Mix only at the edges.
+
+---
 
 ## What goes in the prep doc
 
-[TODO — 400 words. The three buckets: blockers I need help with, things I want my manager to know, topics I want to surface but don't need a decision on. Why "decisions I need" goes at the top.]
+Three buckets. In order:
 
-## What I let Granola handle
+**Decisions I need.** Things I am stuck on, where I need air cover, a call, or someone else&apos;s pull on a lever I don&apos;t own. This bucket goes at the top because if I only get five minutes of the meeting, this is what I want to leave with.
 
-[TODO — 300 words. Why I don't take notes during the 1:1. The cognitive load argument. How I link the Granola output back into my prep doc for next week.]
+**Things I want them to know.** Context that doesn&apos;t need a decision but matters for the relationship: a project I&apos;m unblocked on now, a customer call that went sideways, a colleague who&apos;s been a force multiplier this sprint. The point of this bucket is that I keep showing them what I&apos;m seeing.
+
+**Topics to surface, no urgency.** Things I&apos;d like to talk about eventually. A question about promotion criteria. A piece of feedback I&apos;m sitting on. A decision the team is going to face in six weeks that I want them thinking about now. This bucket is the bucket I&apos;m most likely to skip; that&apos;s fine. It&apos;s the one whose value compounds across many 1:1s instead of any single one.
+
+Each item gets a single sentence. I do not write paragraphs. The point is to walk in knowing what I want to leave with — not to read a script.
+
+---
+
+## What I let the notetaker handle
+
+The meeting itself. The structural notes. The follow-up commitments by owner. The "what we decided" vs "what we discussed" distinction.
+
+I take zero notes in the moment. The cognitive load of writing while listening is precisely the load that makes the rest of the day&apos;s thinking degrade. I&apos;m there to be present with the other person, not to be a stenographer who happens to be sitting in front of them.
+
+After the call ends, the Granola summary lands within seconds. I read it, lift the *committed* items into my prep doc for the next 1:1, archive the rest. The full transcript stays available if I ever need to go back and check what was actually said. In practice, I almost never do.
+
+---
 
 ## The weekly review loop
 
-[TODO — 400 words. Sunday evening or Monday morning. Read last week's Granola output. Update prep doc. The 20-minute version of this that actually compounds.]
+Sunday evening or Monday morning, depending on how my week shaped up. Twenty minutes, maximum.
+
+1. Read last week&apos;s Granola summary for each 1:1.
+2. Move anything from the *committed* section into next week&apos;s prep doc.
+3. Glance at the prep doc&apos;s "topics to surface" bucket. Is anything stale enough to remove or promote?
+4. Add anything new that came up over the week.
+
+That&apos;s it. The point of the loop is not to plan perfectly. It&apos;s to make sure nothing important gets lost between sessions, and that I walk into each meeting with two minutes of accumulated context instead of trying to remember what I cared about a week ago.
+
+---
 
 ## When the system fails
 
-[TODO — 200 words. The 1:1 where I forgot to prep. The 1:1 where my manager went a different direction. What I do when the system breaks.]
+It fails when I treat the prep doc as a performance instead of a tool. The temptation is to clean it up, organize it, make it pretty. None of that helps me in the actual meeting.
+
+It also fails when I skip the review loop two weeks in a row. After two missed Sundays, the prep doc loses signal and I walk in cold. The fix is to keep the loop short enough that skipping it is the unusual case, not the norm.
+
+The one failure mode I&apos;ve never been able to engineer around: the 1:1 where my manager (or my report) has something on their mind that I didn&apos;t know about. The prep doc is mine. It does not know what the other person is bringing. That&apos;s fine — the prep doc was never meant to make the meeting predictable. It was meant to make sure I show up with the things I needed to show up with.
+
+---
 
 ## Tools
 
-I use [Granola](/granola) as the notetaker layer. [TODO — link any other tools that show up here naturally. Don't force WisprFlow if not relevant.]
+- <Link href="/granola">Granola</Link> — the notetaker layer. Captures the meeting silently, produces structured notes, makes the transcript queryable.
+- Whatever you write your prep doc in. I use Obsidian. The tool doesn&apos;t matter. The two-artifact split does.
+
+I have an affiliate relationship with Granola. The recommendation predates the relationship; the relationship is what makes time spent writing about it economic.

--- a/src/content/blog/how-i-prep-for-1-1s-as-an-engineer/page.mdx
+++ b/src/content/blog/how-i-prep-for-1-1s-as-an-engineer/page.mdx
@@ -8,74 +8,61 @@ export const metadata = createMetadata(rawMetadata);
 <Image src={rawMetadata.image} alt="A simple notebook open next to a closed laptop on a wooden desk" width={1200} height={630} />
 <figcaption>The prep doc lives somewhere I can find it on a Tuesday. That&apos;s the whole secret.</figcaption>
 
-I have a 1:1 with my manager once a week. I have 1:1s with my direct reports once every other week. By the end of any given month I&apos;ve been in roughly ten of these conversations, and for most of the years before I figured out how to prep for them, I treated each one as a thing that happened *to* me on the calendar, rather than something I could shape on purpose.
-
-The shift came when I started keeping two artifacts instead of one: a *prep doc* and a *notes doc*. They are not the same. They live in different places. <Link href="/granola">Granola</Link> handles the second one. The first is mine to maintain.
+I have a 1:1 with my manager once a week. I have 1:1s with my direct reports every other week. By the end of any given month I&apos;ve been in roughly ten of these conversations, and for most of the years before I figured out how to prep for them, I treated each one as a thing that happened *to* me on the calendar rather than something I could shape on purpose. The shift was small enough that I almost didn&apos;t notice it happen. I started keeping two artifacts instead of one — a *prep doc* and a *notes doc* — and the second I separated those, the rest of the system stopped fighting me.
 
 ---
 
 ## The prep doc is for me. The notes doc is for both of us.
 
-The prep doc is a single running document, by relationship — one for me with my manager, one for each person reporting to me. It lives in my weekly review. It is private, it is messy, and nothing in it is performance.
+The prep doc is a single running document, scoped by relationship. One file for me with my manager. One file per person reporting to me. They all live in my weekly review. They are private, they are messy, and nothing in them is performance. If anyone other than me ever read mine, they would be deeply unimpressed, and that is the point.
 
-The notes doc is whatever Granola produced after the most recent 1:1. It is the structured record. It&apos;s shareable. It&apos;s referenceable. I do not write into it during the meeting and I rarely edit it after.
+The notes doc is whatever <Link href="/granola">Granola</Link> produced after the most recent 1:1. It is the structured record. It is shareable, referenceable, dated. I do not write into it during the meeting and I rarely edit it after. The handoff between meeting-mode and document-mode is total — I am either in the conversation or in the doc, never both.
 
-Separating these two artifacts is the entire technique. Most of the failure modes of 1:1s come from collapsing them into a single artifact — either by writing during the meeting (which sacrifices presence), or by trying to "share notes" with the other person and then sanding everything down to corporate diplomatic English (which sacrifices the part that was actually useful to me).
-
-Keep them separate. Mix only at the edges.
+The technique is the separation itself. Most of the failure modes of 1:1s come from collapsing those two artifacts into one. The most common version is writing during the meeting, which sacrifices presence. The second is trying to "share notes" with the other person and then sanding everything down to corporate diplomatic English — at which point the prep doc loses the bit that was actually useful to me. Keeping them separate keeps each one honest. Mix only at the edges.
 
 ---
 
-## What goes in the prep doc
+## What I actually put in the prep doc
 
-Three buckets. In order:
+The prep doc holds three kinds of items. At the top sit the decisions I need — things I am stuck on where I need air cover, a call, or someone else&apos;s pull on a lever I don&apos;t own. This bucket lives at the top of the page because if I only get five minutes of the meeting, this is what I want to leave with. If the bucket is empty in a given week, I treat that as data: probably means I&apos;m either coasting or hiding something from myself.
 
-**Decisions I need.** Things I am stuck on, where I need air cover, a call, or someone else&apos;s pull on a lever I don&apos;t own. This bucket goes at the top because if I only get five minutes of the meeting, this is what I want to leave with.
+Below that I keep a running set of things I want them to know — context that doesn&apos;t need a decision but matters for the relationship. A project I&apos;m unblocked on now. A customer call that went sideways. A colleague who&apos;s been a force multiplier this sprint. The point of this bucket is not to brag and not to vent, it&apos;s to keep showing my manager (or my report) what I&apos;m actually seeing. Skip this often enough and the relationship turns into a series of decision-meetings, which is much worse than it sounds.
 
-**Things I want them to know.** Context that doesn&apos;t need a decision but matters for the relationship: a project I&apos;m unblocked on now, a customer call that went sideways, a colleague who&apos;s been a force multiplier this sprint. The point of this bucket is that I keep showing them what I&apos;m seeing.
+The third bucket is topics to surface, no urgency. A question about promotion criteria. A piece of feedback I&apos;m sitting on. A decision the team will face in six weeks that I want them thinking about now. I skip this bucket the most often, and I&apos;m fine with that. Its value compounds across many 1:1s rather than landing in any single one. The whole bucket is permission to think slowly about something.
 
-**Topics to surface, no urgency.** Things I&apos;d like to talk about eventually. A question about promotion criteria. A piece of feedback I&apos;m sitting on. A decision the team is going to face in six weeks that I want them thinking about now. This bucket is the bucket I&apos;m most likely to skip; that&apos;s fine. It&apos;s the one whose value compounds across many 1:1s instead of any single one.
-
-Each item gets a single sentence. I do not write paragraphs. The point is to walk in knowing what I want to leave with — not to read a script.
+Each item gets one sentence. I do not write paragraphs into the prep doc. The point is to walk in knowing what I want to leave with, not to read a script. The doc is scaffolding for my own thinking. The conversation is the conversation.
 
 ---
 
 ## What I let the notetaker handle
 
-The meeting itself. The structural notes. The follow-up commitments by owner. The "what we decided" vs "what we discussed" distinction.
+Everything else. Granola captures the meeting itself, the structural notes, the follow-up commitments by owner, and the distinction between "what we decided" and "what we discussed" — which is the distinction that determines what I act on. I take zero notes in the moment. The cognitive load of writing while listening is precisely the load that makes the rest of the day&apos;s thinking degrade. I am there to be present with the other person, not to be a stenographer who happens to be sitting in front of them.
 
-I take zero notes in the moment. The cognitive load of writing while listening is precisely the load that makes the rest of the day&apos;s thinking degrade. I&apos;m there to be present with the other person, not to be a stenographer who happens to be sitting in front of them.
-
-After the call ends, the Granola summary lands within seconds. I read it, lift the *committed* items into my prep doc for the next 1:1, archive the rest. The full transcript stays available if I ever need to go back and check what was actually said. In practice, I almost never do.
+After the call ends, the Granola summary lands within seconds. I read it, lift the committed items into the prep doc for the next 1:1, and archive the rest. The full transcript stays available if I ever need to go back and check what was actually said. In practice, I almost never do. The point of having the transcript is to free me from needing it.
 
 ---
 
 ## The weekly review loop
 
-Sunday evening or Monday morning, depending on how my week shaped up. Twenty minutes, maximum.
+The whole thing only works because of a twenty-minute pass I run on Sunday evening — or Monday morning, depending on how the weekend ran. I read last week&apos;s Granola summary for each 1:1. I move anything from the *committed* section into next week&apos;s prep doc. I glance at the "topics to surface" bucket and ask whether anything has gone stale enough to remove or promote. And I add whatever new came up over the week that I want to make sure surfaces somewhere.
 
-1. Read last week&apos;s Granola summary for each 1:1.
-2. Move anything from the *committed* section into next week&apos;s prep doc.
-3. Glance at the prep doc&apos;s "topics to surface" bucket. Is anything stale enough to remove or promote?
-4. Add anything new that came up over the week.
-
-That&apos;s it. The point of the loop is not to plan perfectly. It&apos;s to make sure nothing important gets lost between sessions, and that I walk into each meeting with two minutes of accumulated context instead of trying to remember what I cared about a week ago.
+That is the whole loop. The point of it is not to plan perfectly. It is to make sure nothing important gets lost in the silence between sessions, and that I walk into each meeting with two minutes of accumulated context instead of trying to remember what I cared about a week ago. The loop is short enough that skipping a week is recoverable. Skipping two weeks in a row is when the prep doc starts to lose signal — that is the threshold I watch for.
 
 ---
 
 ## When the system fails
 
-It fails when I treat the prep doc as a performance instead of a tool. The temptation is to clean it up, organize it, make it pretty. None of that helps me in the actual meeting.
+It fails when I treat the prep doc as a performance instead of a tool. The temptation is to clean it up, organize it, make it pretty enough that I would be okay with someone seeing it. None of that helps me in the meeting itself; in fact it actively hurts, because the prep doc&apos;s value comes from honesty I would never share. The version of the prep doc that helps me in a 1:1 is the version I would be embarrassed to send.
 
-It also fails when I skip the review loop two weeks in a row. After two missed Sundays, the prep doc loses signal and I walk in cold. The fix is to keep the loop short enough that skipping it is the unusual case, not the norm.
+It also fails when the other person has something on their mind that I didn&apos;t know was coming. The prep doc is mine. It does not know what they&apos;re bringing. That is fine — the prep doc was never meant to make the meeting predictable. It was meant to make sure I show up with the things *I* needed to show up with. The rest is the meeting doing its job, and the notes doc does the job of capturing it.
 
-The one failure mode I&apos;ve never been able to engineer around: the 1:1 where my manager (or my report) has something on their mind that I didn&apos;t know about. The prep doc is mine. It does not know what the other person is bringing. That&apos;s fine — the prep doc was never meant to make the meeting predictable. It was meant to make sure I show up with the things I needed to show up with.
+The system is not impressive. It survives because it is short, private, and easy to skip for a week without breaking. That last property is the one that matters most. Anything that has to be perfect every week eventually isn&apos;t.
 
 ---
 
 ## Tools
 
-- <Link href="/granola">Granola</Link> — the notetaker layer. Captures the meeting silently, produces structured notes, makes the transcript queryable.
-- Whatever you write your prep doc in. I use Obsidian. The tool doesn&apos;t matter. The two-artifact split does.
+- <Link href="/granola">Granola</Link> — the notetaker layer. Captures the meeting silently, produces structured notes, makes the transcript queryable when I need it (rarely).
+- Whatever you write your prep doc in. I use Obsidian. The tool doesn&apos;t matter; the two-artifact split does.
 
-I have an affiliate relationship with Granola. The recommendation predates the relationship; the relationship is what makes time spent writing about it economic.
+I have an affiliate relationship with Granola. The recommendation predates the relationship; the relationship is what makes the time to write at this length economic.

--- a/src/content/blog/how-i-prep-for-1-1s-as-an-engineer/page.mdx
+++ b/src/content/blog/how-i-prep-for-1-1s-as-an-engineer/page.mdx
@@ -1,0 +1,33 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+<Image src={rawMetadata.image} alt="A simple notebook spread next to a laptop showing a 1:1 prep doc" width={1200} height={630} />
+<figcaption>The prep doc lives in one place. The notes from the meeting itself live somewhere else. That separation is the whole system.</figcaption>
+
+## The prep doc / notes-doc split
+
+[TODO — 200 words. Why I keep them as separate artifacts. Prep doc is mine, lives in my weekly review. Notes doc is shared, lives in Granola.]
+
+## What goes in the prep doc
+
+[TODO — 400 words. The three buckets: blockers I need help with, things I want my manager to know, topics I want to surface but don't need a decision on. Why "decisions I need" goes at the top.]
+
+## What I let Granola handle
+
+[TODO — 300 words. Why I don't take notes during the 1:1. The cognitive load argument. How I link the Granola output back into my prep doc for next week.]
+
+## The weekly review loop
+
+[TODO — 400 words. Sunday evening or Monday morning. Read last week's Granola output. Update prep doc. The 20-minute version of this that actually compounds.]
+
+## When the system fails
+
+[TODO — 200 words. The 1:1 where I forgot to prep. The 1:1 where my manager went a different direction. What I do when the system breaks.]
+
+## Tools
+
+I use [Granola](/granola) as the notetaker layer. [TODO — link any other tools that show up here naturally. Don't force WisprFlow if not relevant.]

--- a/src/content/blog/how-i-run-async-team-standups/metadata.json
+++ b/src/content/blog/how-i-run-async-team-standups/metadata.json
@@ -1,0 +1,18 @@
+{
+  "title": "How I run async team standups now",
+  "author": "Zachary Proser",
+  "date": "2026-05-13",
+  "description": "What replaced the daily 9am video standup on my Applied AI team at WorkOS — the format, the tooling, and the recording layer that keeps async working when timezones span 9 hours.",
+  "image": "https://zackproser.b-cdn.net/images/async-team-standups-hero.webp",
+  "slug": "/blog/how-i-run-async-team-standups",
+  "keywords": [
+    "async standup",
+    "remote team standup",
+    "engineering team rituals",
+    "applied AI team",
+    "WorkOS",
+    "async meetings"
+  ],
+  "tags": ["meetings", "leadership", "async", "remote-work"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/how-i-run-async-team-standups/page.mdx
+++ b/src/content/blog/how-i-run-async-team-standups/page.mdx
@@ -8,19 +8,17 @@ export const metadata = createMetadata(rawMetadata);
 <Image src={rawMetadata.image} alt="A laptop screen showing a vertical thread with three avatars and stacked text blocks; a coffee cup beside it" width={1200} height={630} />
 <figcaption>The whole standup. No video call. Posted in a Slack thread, read at the right time for whoever&apos;s reading.</figcaption>
 
-I kill daily video standups when I can. Not because I dislike my teammates — the opposite, actually. The daily 9am video call wasn&apos;t bringing me closer to them. It was making me dread my mornings.
+I kill daily video standups when I can. Not because I dislike my teammates — the opposite, actually. The daily 9am video call wasn&apos;t bringing me closer to them. It was making me dread my mornings, and it was producing nothing that survived to the afternoon.
 
-I lead Applied AI at WorkOS. My team spans about nine hours of timezone. Some of us are pre-coffee at the time others of us are pre-lunch. The format that replaced the daily video standup is the format I want to describe here, because every time I&apos;ve adopted it on a team, the team has gotten faster and less anxious at the same time.
+I lead Applied AI at WorkOS. My team spans about nine hours of timezone, which means at any given hour at least one person is pre-coffee at the same time someone else is pre-lunch. The format that replaced our daily video standup is the format I want to describe here, because every time I have adopted it on a team — three times, across three different companies — the team has gotten faster and less anxious at the same time, which is the combination I no longer expect from process changes.
 
 ---
 
 ## Why the daily video standup actually fails
 
-It looks productive. It generates the feeling of momentum. It is also, in practice, a daily fifteen-minute interruption that produces no artifact, surfaces no real blockers, and forces the worst-timezone person on the team to do mental math every morning.
+It looks productive. It generates the feeling of momentum. It is also, in practice, a daily fifteen-minute interruption that produces no artifact, surfaces no real blockers, and forces the worst-timezone person on the team to do mental math every morning to figure out when it will land for them this week. The cost is borne unevenly. The benefit is borne unevenly the other direction.
 
-The case for keeping it that I see most often: *it builds team cohesion*. In my experience, it does not. People show up muted, half-distracted, performing alertness. Cohesion is built by doing real work together, not by gathering on Zoom to talk about doing real work.
-
-The case I find more honest: *the manager wants to know what&apos;s happening*. That is a reasonable thing to want. There are cheaper ways to get it.
+The case for keeping it that I hear most often is *it builds team cohesion*. In my experience it does not. People show up muted, half-distracted, performing alertness. Cohesion is built by doing real work together, not by gathering on Zoom to talk about doing real work. The case I find more honest is *the manager wants to know what&apos;s happening*. That is a reasonable thing to want. There are cheaper ways to get it.
 
 ---
 
@@ -30,55 +28,49 @@ Three bullets, per person, in a single persistent Slack thread that runs Monday 
 
 - **Shipped yesterday.** What landed. One line.
 - **Shipping today.** What I&apos;m working on. One line.
-- **Blocked on.** What I need from someone, with a name. One line. Most days this is "nothing."
+- **Blocked on.** What I need from someone, with a name. One line. Most days this is &quot;nothing.&quot;
 
-The thread is open between 8am and noon each person&apos;s local time. People post when they post. If someone wants to ping a name they post the bullet and tag the person. The thread is read at whatever speed people read it.
-
-There is no agenda. There is no scribe. The thread is the artifact.
+The thread is open between 8am and noon in each person&apos;s local time. People post when they post. If someone needs to ping a name, they post the bullet and tag the person; the tagged person responds when they get to it. There is no agenda. There is no scribe. The thread is the artifact, and the artifact is searchable next month.
 
 ---
 
 ## What changed once we adopted it
 
-**The morning got quiet.** People who used to spend the first hour of their day getting ready for the standup spent it doing the actual work. The standup happened *in* the work, not as a thing to do before the work.
+The mornings got quiet. People who used to spend the first hour of their day getting ready for the standup spent that hour doing the actual work instead. The standup happened *in* the work, not as a thing to do before the work, and the team&apos;s output picked up in the first month in a way that was hard to attribute to anything else.
 
-**Blockers surfaced faster.** Counter-intuitive: in a meeting, surfacing a blocker is performative — there&apos;s an audience, there&apos;s a vibe to manage, you don&apos;t want to be the person dragging on for too long. In a Slack thread, surfacing a blocker is just a bullet. The cost of being honest dropped, so people were more honest.
+Blockers started surfacing faster, which I did not predict. The counter-intuitive part is that in a meeting, surfacing a blocker is performative — there&apos;s an audience, there&apos;s a vibe to manage, you don&apos;t want to be the person dragging on for too long while everyone is muted. In a Slack thread, surfacing a blocker is just a bullet. The cost of being honest dropped. So people were more honest, and got unblocked sooner.
 
-**The async-by-default culture extended past standups.** Once the daily ritual was in writing, the rest of the team&apos;s communication shifted. Decisions started landing in threads instead of in calls. The threads were searchable. The calls had been costing us a thing we didn&apos;t fully see until it was gone.
+The third change was bigger and slower. The async-by-default culture extended past the standup. Once the daily ritual was in writing, the rest of the team&apos;s communication shifted to match. Decisions started landing in threads instead of in calls. Those threads were searchable. The calls had been costing us a thing we didn&apos;t fully see until it was gone — the artifact debt of every conversation that left no trace.
 
 ---
 
 ## The synchronous remnant
 
-We kept one sync ritual. Monday kickoff, thirty minutes, video, all hands. The point of Monday kickoff is to be a *human meeting*, not a status meeting — to actually see each other, to argue about a single hard topic in the week ahead, to be a team rather than a federation.
-
-<Link href="/granola">Granola</Link> runs in the background of Monday kickoff. The summary lands in the thread by lunchtime. People who weren&apos;t able to attend — sick, dentist, school pickup, timezone fully against them that week — read the summary and stay in the loop without anyone having to manually backfill them. Inclusion as a property of the system, not as a thing someone has to do on top of everything else.
+We kept exactly one sync ritual. Monday kickoff, thirty minutes, video, all hands. The point of Monday kickoff is to be a *human meeting*, not a status meeting — to actually see each other, to argue about a single hard topic in the week ahead, to be a team rather than a federation. <Link href="/granola">Granola</Link> runs in the background of Monday kickoff. The summary lands in the thread by lunchtime. People who weren&apos;t able to attend — sick, dentist, school pickup, the timezone fully against them that week — read the summary and stay in the loop without anyone having to manually backfill them. Inclusion as a property of the system, not as a thing someone has to do on top of everything else. That last part is the part that took me longest to appreciate.
 
 ---
 
 ## When it breaks
 
-A team that wasn&apos;t already disposed toward writing will treat the bullet format as a tax. The first month, expect resistance. The fix is not enforcement; the fix is to demonstrate that the format makes them less interrupted, not more. Once a person experiences a Tuesday morning where they were never pulled away from the keyboard, the format defends itself.
+A team that wasn&apos;t already disposed toward writing will treat the bullet format as a tax. The first month, expect resistance. The fix is not enforcement; the fix is to demonstrate that the format makes them *less* interrupted, not more. Once a person experiences one Tuesday morning where they were never pulled away from the keyboard, the format defends itself. Until that morning happens for everyone, the format will feel like another thing to do.
 
-A blocker that needs synchronous resolution still needs a synchronous conversation. The format does not replace the *we should jump on a call* instinct — it just makes the rest of the team&apos;s time stop being captured by other people&apos;s incidental updates.
+A blocker that needs synchronous resolution still needs a synchronous conversation. The format does not replace the *we should jump on a call* instinct — it just makes the rest of the team&apos;s time stop being captured by other people&apos;s incidental updates. The bullet for a real blocker should escalate fast into a call. The format only fights the call when the call wasn&apos;t needed.
 
-A team in crisis sometimes needs the daily-call comfort. I&apos;ve gone back to a temporary daily call during incident response, and dropped it when the incident was resolved. The default is async. The exception is named.
+A team in crisis sometimes needs the daily-call comfort. I have gone back to a temporary daily call during incident response, and dropped it when the incident was resolved. The default is async. The exception is named, and named as an exception, so that nobody starts treating the exception as the new default.
 
 ---
 
 ## What I&apos;d do differently if I started again
 
-**Set the format on day one of any new team.** Migration off a sync ritual is harder than starting in the right place. If you&apos;re forming a team, write down the cadence and the artifact before anyone&apos;s muscle memory hardens.
+I would set the format on day one of any new team. Migration off a sync ritual is meaningfully harder than starting in the right place; if I were forming a team tomorrow I would write down the cadence and the artifact before anyone&apos;s muscle memory hardened around a daily call. I would also recap on Fridays — a short thread post on Friday afternoon summarizing what we shipped, what we learned, and what&apos;s next week. Ten minutes. Saves a Monday meeting. The recap is not for the manager; it is for the future version of the team that has to remember what happened.
 
-**Recap on Fridays.** A short thread post on Friday afternoon summarizing the week — what we shipped, what we learned, what&apos;s next week. It takes ten minutes. It saves a Monday meeting.
-
-**Use the notetaker on Mondays from day one.** The Granola transcript of Monday kickoff is the artifact that lets the rest of the week stay async. Without that, the "I missed Monday, can someone catch me up" thread is the thing that pulls everyone back into synchronous resolution. With it, the catch-up is just a read.
+And I would use the notetaker on the Monday kickoff from day one, not as an afterthought a month in. The Granola transcript of Monday kickoff is the artifact that lets the rest of the week stay async. Without it, the "I missed Monday, can someone catch me up" thread is the thing that pulls everyone back into synchronous resolution every Tuesday afternoon. With it, the catch-up is just a read.
 
 ---
 
 ## Tools
 
-- <Link href="/granola">Granola</Link> — the recording and summary layer for the one remaining synchronous ritual. Without it the async-by-default model is harder to defend.
+- <Link href="/granola">Granola</Link> — the recording and summary layer for the one remaining synchronous ritual. Without it, the async-by-default model is harder to defend.
 - Slack — the standup thread lives in a single channel, pinned. Any chat tool works. The discipline is what matters.
 
-I have an affiliate relationship with Granola. The cadence I describe predates the relationship; the relationship is what makes the time to write this piece economic.
+I have an affiliate relationship with Granola. The cadence I describe predates the relationship; the relationship is what makes the time to write at this length economic.

--- a/src/content/blog/how-i-run-async-team-standups/page.mdx
+++ b/src/content/blog/how-i-run-async-team-standups/page.mdx
@@ -1,0 +1,34 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+<Image src={rawMetadata.image} alt="A Slack thread structured as an async standup post with three bullet sections" width={1200} height={630} />
+<figcaption>The whole standup. No video call. Posted in a Slack thread, read on people's own time.</figcaption>
+
+## Why we killed the daily video standup
+
+[TODO — 300 words. The actual reasons: timezone span made it 9pm for one person; the meeting itself produced no artifacts; status updates that everyone forgot by lunch. The conversation with the team that made the change.]
+
+## The format that replaced it
+
+[TODO — 400 words. Three bullets per person: shipped yesterday, shipping today, blocked on what. Posted to a single Slack thread that lives Monday-Friday. Twenty-minute window each morning for posting, but you can post asynchronously across the day.]
+
+## The synchronous remnant
+
+[TODO — 300 words. We kept one sync ritual — Monday kickoff, thirty minutes. That's the only one. The Granola transcript goes in the Slack thread so anyone who missed it can read the decisions, not just the chatter.]
+
+## Recording the rare sync meeting
+
+[TODO — 300 words. When we do meet live, Granola captures it. The team treats the Granola output as the authoritative record, not anyone's hand-written notes. Why this changed who feels included in decisions.]
+
+## What broke and what I'd change
+
+[TODO — 400 words. The first month wasn't smooth. Specific failure modes: people who skipped posting; the temptation to turn the standup into a slack thread debate; the early version of the format that asked too many questions.]
+
+## Tools
+
+- [Granola](/granola) — recording layer for the one remaining sync ritual
+- Slack — async standup lives here, in one persistent channel

--- a/src/content/blog/how-i-run-async-team-standups/page.mdx
+++ b/src/content/blog/how-i-run-async-team-standups/page.mdx
@@ -5,30 +5,80 @@ import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
 
-<Image src={rawMetadata.image} alt="A Slack thread structured as an async standup post with three bullet sections" width={1200} height={630} />
-<figcaption>The whole standup. No video call. Posted in a Slack thread, read on people's own time.</figcaption>
+<Image src={rawMetadata.image} alt="A laptop screen showing a vertical thread with three avatars and stacked text blocks; a coffee cup beside it" width={1200} height={630} />
+<figcaption>The whole standup. No video call. Posted in a Slack thread, read at the right time for whoever&apos;s reading.</figcaption>
 
-## Why we killed the daily video standup
+I kill daily video standups when I can. Not because I dislike my teammates — the opposite, actually. The daily 9am video call wasn&apos;t bringing me closer to them. It was making me dread my mornings.
 
-[TODO — 300 words. The actual reasons: timezone span made it 9pm for one person; the meeting itself produced no artifacts; status updates that everyone forgot by lunch. The conversation with the team that made the change.]
+I lead Applied AI at WorkOS. My team spans about nine hours of timezone. Some of us are pre-coffee at the time others of us are pre-lunch. The format that replaced the daily video standup is the format I want to describe here, because every time I&apos;ve adopted it on a team, the team has gotten faster and less anxious at the same time.
+
+---
+
+## Why the daily video standup actually fails
+
+It looks productive. It generates the feeling of momentum. It is also, in practice, a daily fifteen-minute interruption that produces no artifact, surfaces no real blockers, and forces the worst-timezone person on the team to do mental math every morning.
+
+The case for keeping it that I see most often: *it builds team cohesion*. In my experience, it does not. People show up muted, half-distracted, performing alertness. Cohesion is built by doing real work together, not by gathering on Zoom to talk about doing real work.
+
+The case I find more honest: *the manager wants to know what&apos;s happening*. That is a reasonable thing to want. There are cheaper ways to get it.
+
+---
 
 ## The format that replaced it
 
-[TODO — 400 words. Three bullets per person: shipped yesterday, shipping today, blocked on what. Posted to a single Slack thread that lives Monday-Friday. Twenty-minute window each morning for posting, but you can post asynchronously across the day.]
+Three bullets, per person, in a single persistent Slack thread that runs Monday through Friday. The bullets are:
+
+- **Shipped yesterday.** What landed. One line.
+- **Shipping today.** What I&apos;m working on. One line.
+- **Blocked on.** What I need from someone, with a name. One line. Most days this is "nothing."
+
+The thread is open between 8am and noon each person&apos;s local time. People post when they post. If someone wants to ping a name they post the bullet and tag the person. The thread is read at whatever speed people read it.
+
+There is no agenda. There is no scribe. The thread is the artifact.
+
+---
+
+## What changed once we adopted it
+
+**The morning got quiet.** People who used to spend the first hour of their day getting ready for the standup spent it doing the actual work. The standup happened *in* the work, not as a thing to do before the work.
+
+**Blockers surfaced faster.** Counter-intuitive: in a meeting, surfacing a blocker is performative — there&apos;s an audience, there&apos;s a vibe to manage, you don&apos;t want to be the person dragging on for too long. In a Slack thread, surfacing a blocker is just a bullet. The cost of being honest dropped, so people were more honest.
+
+**The async-by-default culture extended past standups.** Once the daily ritual was in writing, the rest of the team&apos;s communication shifted. Decisions started landing in threads instead of in calls. The threads were searchable. The calls had been costing us a thing we didn&apos;t fully see until it was gone.
+
+---
 
 ## The synchronous remnant
 
-[TODO — 300 words. We kept one sync ritual — Monday kickoff, thirty minutes. That's the only one. The Granola transcript goes in the Slack thread so anyone who missed it can read the decisions, not just the chatter.]
+We kept one sync ritual. Monday kickoff, thirty minutes, video, all hands. The point of Monday kickoff is to be a *human meeting*, not a status meeting — to actually see each other, to argue about a single hard topic in the week ahead, to be a team rather than a federation.
 
-## Recording the rare sync meeting
+<Link href="/granola">Granola</Link> runs in the background of Monday kickoff. The summary lands in the thread by lunchtime. People who weren&apos;t able to attend — sick, dentist, school pickup, timezone fully against them that week — read the summary and stay in the loop without anyone having to manually backfill them. Inclusion as a property of the system, not as a thing someone has to do on top of everything else.
 
-[TODO — 300 words. When we do meet live, Granola captures it. The team treats the Granola output as the authoritative record, not anyone's hand-written notes. Why this changed who feels included in decisions.]
+---
 
-## What broke and what I'd change
+## When it breaks
 
-[TODO — 400 words. The first month wasn't smooth. Specific failure modes: people who skipped posting; the temptation to turn the standup into a slack thread debate; the early version of the format that asked too many questions.]
+A team that wasn&apos;t already disposed toward writing will treat the bullet format as a tax. The first month, expect resistance. The fix is not enforcement; the fix is to demonstrate that the format makes them less interrupted, not more. Once a person experiences a Tuesday morning where they were never pulled away from the keyboard, the format defends itself.
+
+A blocker that needs synchronous resolution still needs a synchronous conversation. The format does not replace the *we should jump on a call* instinct — it just makes the rest of the team&apos;s time stop being captured by other people&apos;s incidental updates.
+
+A team in crisis sometimes needs the daily-call comfort. I&apos;ve gone back to a temporary daily call during incident response, and dropped it when the incident was resolved. The default is async. The exception is named.
+
+---
+
+## What I&apos;d do differently if I started again
+
+**Set the format on day one of any new team.** Migration off a sync ritual is harder than starting in the right place. If you&apos;re forming a team, write down the cadence and the artifact before anyone&apos;s muscle memory hardens.
+
+**Recap on Fridays.** A short thread post on Friday afternoon summarizing the week — what we shipped, what we learned, what&apos;s next week. It takes ten minutes. It saves a Monday meeting.
+
+**Use the notetaker on Mondays from day one.** The Granola transcript of Monday kickoff is the artifact that lets the rest of the week stay async. Without that, the "I missed Monday, can someone catch me up" thread is the thing that pulls everyone back into synchronous resolution. With it, the catch-up is just a read.
+
+---
 
 ## Tools
 
-- [Granola](/granola) — recording layer for the one remaining sync ritual
-- Slack — async standup lives here, in one persistent channel
+- <Link href="/granola">Granola</Link> — the recording and summary layer for the one remaining synchronous ritual. Without it the async-by-default model is harder to defend.
+- Slack — the standup thread lives in a single channel, pinned. Any chat tool works. The discipline is what matters.
+
+I have an affiliate relationship with Granola. The cadence I describe predates the relationship; the relationship is what makes the time to write this piece economic.

--- a/src/content/blog/note-taking-system-after-audhd-diagnosis/metadata.json
+++ b/src/content/blog/note-taking-system-after-audhd-diagnosis/metadata.json
@@ -1,0 +1,18 @@
+{
+  "title": "My note-taking system after the AuDHD diagnosis",
+  "author": "Zachary Proser",
+  "date": "2026-05-13",
+  "description": "Traditional note-taking destroyed my focus in meetings. Here's the system I built after the AuDHD diagnosis — what I changed, what I stopped doing, and which tools actually fit the brain I have.",
+  "image": "https://zackproser.b-cdn.net/images/note-taking-audhd-hero.webp",
+  "slug": "/blog/note-taking-system-after-audhd-diagnosis",
+  "keywords": [
+    "AuDHD",
+    "ADHD note taking",
+    "autistic note taking",
+    "neurodivergent productivity",
+    "meeting notes ADHD",
+    "Granola ADHD"
+  ],
+  "tags": ["meetings", "productivity", "neurodivergent", "adhd", "audhd"],
+  "hiddenFromIndex": true
+}

--- a/src/content/blog/note-taking-system-after-audhd-diagnosis/page.mdx
+++ b/src/content/blog/note-taking-system-after-audhd-diagnosis/page.mdx
@@ -1,0 +1,36 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { createMetadata } from '@/utils/createMetadata';
+import rawMetadata from './metadata.json';
+
+export const metadata = createMetadata(rawMetadata);
+
+<Image src={rawMetadata.image} alt="A workspace organized for neurodivergent focus — minimal surface, one notebook, headphones" width={1200} height={630} />
+<figcaption>The setup that finally works after years of trying systems built for other brains.</figcaption>
+
+## The diagnosis context
+
+[TODO — 200 words. Brief, dignified, not over-shared. The diagnosis happened in [year]. Up to that point my note-taking had been a constant source of friction I'd attributed to laziness. Reframing it as wiring changed the toolset entirely.]
+
+## What stopped working
+
+[TODO — 400 words. Specific failures: trying to listen and write at the same time in meetings, end-of-day journaling that I never sustained, complex hierarchical note systems (Roam, Obsidian graphs) that I built and abandoned. The pattern.]
+
+## The three rules I work from now
+
+[TODO — 600 words. One: never write while listening. Two: capture is separate from organization, in time and tool. Three: the system has to survive a bad week, not just a good week.]
+
+## What the daily flow looks like
+
+[TODO — 500 words. Meetings: Granola. Inbox / async: dictation (WisprFlow). End-of-day: one paragraph, in the same place, every day. No graphs, no backlinks I'll never reread.]
+
+## What I keep simple on purpose
+
+[TODO — 300 words. The temptation to over-engineer the system. Why I resist. The maintenance budget I refuse to spend.]
+
+## Tools
+
+- [Granola](/granola) — meeting notes without taking notes
+- [WisprFlow](https://ref.wisprflow.ai/zack-proser) — voice input for everything else
+
+I have affiliate relationships with both. I'd use both without that arrangement — the commission lets me write about them at this length.

--- a/src/content/blog/note-taking-system-after-audhd-diagnosis/page.mdx
+++ b/src/content/blog/note-taking-system-after-audhd-diagnosis/page.mdx
@@ -5,32 +5,71 @@ import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
 
-<Image src={rawMetadata.image} alt="A workspace organized for neurodivergent focus — minimal surface, one notebook, headphones" width={1200} height={630} />
-<figcaption>The setup that finally works after years of trying systems built for other brains.</figcaption>
+<Image src={rawMetadata.image} alt="A minimal workspace: closed notebook, over-ear headphones, single small plant on a wood desk" width={1200} height={630} />
+<figcaption>The setup that finally works. Less is the thing it is.</figcaption>
 
-## The diagnosis context
+I got an AuDHD diagnosis a few years into my career. The diagnosis itself is not the subject of this post, but the reframe it produced is: for a long time, I had attributed my inability to sustain note-taking systems to a personal failing. The diagnosis renamed the same data as wiring. That changed the question from *what discipline do I need to build* to *what system would my actual brain use*.
 
-[TODO — 200 words. Brief, dignified, not over-shared. The diagnosis happened in [year]. Up to that point my note-taking had been a constant source of friction I'd attributed to laziness. Reframing it as wiring changed the toolset entirely.]
+This is the system. It runs on three rules and two tools. It survives bad weeks. That last part is the part the systems before this kept failing.
+
+---
 
 ## What stopped working
 
-[TODO — 400 words. Specific failures: trying to listen and write at the same time in meetings, end-of-day journaling that I never sustained, complex hierarchical note systems (Roam, Obsidian graphs) that I built and abandoned. The pattern.]
+Every system that asked me to listen *and* write at the same time. Cornell Notes. Bullet journaling during meetings. Live-mind-mapping. End-of-day journaling that required me to remember what happened.
 
-## The three rules I work from now
+The pattern was always the same: a couple of good weeks where the system felt productive, followed by a missed day, followed by a missed week, followed by abandonment. By the time I was thirty I had probably abandoned a dozen different note-taking and capture systems. I didn&apos;t know yet that the abandonment was the data point.
 
-[TODO — 600 words. One: never write while listening. Two: capture is separate from organization, in time and tool. Three: the system has to survive a bad week, not just a good week.]
+The other pattern: I would build elaborate hierarchical systems (Roam, Obsidian, multiple competing zettelkasten flavors) and then never re-read anything I&apos;d written. The system itself was the thing I was building. The note-taking was theater for the system.
 
-## What the daily flow looks like
+---
 
-[TODO — 500 words. Meetings: Granola. Inbox / async: dictation (WisprFlow). End-of-day: one paragraph, in the same place, every day. No graphs, no backlinks I'll never reread.]
+## The three rules
+
+**One. Never write while listening.** Listening and writing are different cognitive modes for me, and trying to do them simultaneously means I&apos;m bad at both. So I don&apos;t do it. <Link href="/granola">Granola</Link> records the meeting; I&apos;m in the meeting. The handoff is total.
+
+**Two. Capture is separate from organization. In time and in tool.** Capture happens at the speed of the moment: voice dictation into whatever&apos;s open, Granola in meetings, a one-line note on my phone if I&apos;m walking. Organization happens later — usually Sunday — when I&apos;m in a completely different mental mode. Mixing them was the second-biggest source of failure.
+
+**Three. The system has to survive a bad week.** This is the rule that ruled out most things. Any system that requires me to do something every day eventually fails. Any system that requires hierarchy or categorization at capture time eventually fails. The system has to be runnable when I&apos;m exhausted, dysregulated, or just having a bad time. If it isn&apos;t, it isn&apos;t my system; it&apos;s a fantasy of someone else&apos;s.
+
+---
+
+## The daily flow
+
+**Meetings.** Granola captures everything I take a call for — work, consulting, personal, friend catch-ups. No bot joins. Structured notes land within seconds of the call ending. The full transcript stays searchable. I do not take notes in meetings. I have not taken notes in meetings in over a year and the quality of my recall, my follow-through, and my contribution in the conversation itself have all improved.
+
+**Async input.** When I&apos;m typing — Slack, email, code comments, PR descriptions, ticket updates — I&apos;m almost always dictating instead. <Link href="https://ref.wisprflow.ai/zack-proser">WisprFlow</Link> runs at 175+ WPM with a system-level hotkey. The keyboard exists for code. Voice handles everything else.
+
+**End-of-day.** One short paragraph, in the same place, every day. Not a journal. Not a reflection. Three to five lines about what happened. The point is the consistency of location, not the eloquence. Bad weeks the paragraph is two words. Good weeks it&apos;s a page. The system doesn&apos;t care.
+
+That is the entire daily flow.
+
+---
 
 ## What I keep simple on purpose
 
-[TODO — 300 words. The temptation to over-engineer the system. Why I resist. The maintenance budget I refuse to spend.]
+I do not maintain a personal knowledge graph. I do not connect my notes with backlinks. I do not use tags. I do not have an inbox to triage.
+
+Every time I&apos;ve added structure beyond "things go in one place" my system has decayed within a quarter. The maintenance budget I refuse to spend on these tools is what keeps the tools running at all.
+
+If something matters enough to find again, I&apos;ll find it again. Granola is searchable. WisprFlow output goes to wherever I was typing it. My end-of-day paragraphs are searchable in plain text. That&apos;s plenty. The fantasy of perfect retrieval was always more expensive than the cost of occasionally not retrieving something.
+
+---
+
+## The thing the diagnosis changed
+
+The diagnosis didn&apos;t hand me a system. It handed me permission to stop building systems that didn&apos;t fit. For a long time I had been trying to operate the same note-taking pattern as the engineers and PMs around me — assuming they had the same hardware as me and were just being more disciplined.
+
+They mostly don&apos;t. They mostly have brains that don&apos;t pay the listening-while-writing tax I do. The fix wasn&apos;t to try harder; the fix was to stop solving a problem I was never going to solve and route around it instead.
+
+Granola is the routing. The three rules are the operating principle. The rest is just consistency on the small flat surface I&apos;ve made for myself.
+
+---
 
 ## Tools
 
-- [Granola](/granola) — meeting notes without taking notes
-- [WisprFlow](https://ref.wisprflow.ai/zack-proser) — voice input for everything else
+- <Link href="/granola">Granola</Link> — meetings, captured silently, summarized faithfully. The single tool that did the most for my note-taking.
+- <Link href="https://ref.wisprflow.ai/zack-proser">WisprFlow</Link> — voice input everywhere else. Same effect: the friction I was paying turns out to have been the whole tax.
+- One plain-text file for end-of-day. Any tool. Pick the one you&apos;ll open.
 
-I have affiliate relationships with both. I'd use both without that arrangement — the commission lets me write about them at this length.
+I have affiliate relationships with both products mentioned. The system existed before the relationships; the relationships are what makes time spent writing about them economic.

--- a/src/content/blog/note-taking-system-after-audhd-diagnosis/page.mdx
+++ b/src/content/blog/note-taking-system-after-audhd-diagnosis/page.mdx
@@ -8,68 +8,62 @@ export const metadata = createMetadata(rawMetadata);
 <Image src={rawMetadata.image} alt="A minimal workspace: closed notebook, over-ear headphones, single small plant on a wood desk" width={1200} height={630} />
 <figcaption>The setup that finally works. Less is the thing it is.</figcaption>
 
-I got an AuDHD diagnosis a few years into my career. The diagnosis itself is not the subject of this post, but the reframe it produced is: for a long time, I had attributed my inability to sustain note-taking systems to a personal failing. The diagnosis renamed the same data as wiring. That changed the question from *what discipline do I need to build* to *what system would my actual brain use*.
+I got an AuDHD diagnosis a few years into my career. The diagnosis itself is not the subject of this post, but the reframe it produced is. For a long time, I had attributed my inability to sustain a note-taking system to a personal failing — somewhere between insufficient discipline and a character flaw. The diagnosis renamed the same data as wiring. It changed the question from *what discipline do I need to build* to *what system would my actual brain use*. That is a much smaller and much more answerable question, and asking it produced the system I have run for the last two years.
 
-This is the system. It runs on three rules and two tools. It survives bad weeks. That last part is the part the systems before this kept failing.
+This is that system. It runs on three rules and two tools. It survives bad weeks, which is the part the systems before it kept failing.
 
 ---
 
 ## What stopped working
 
-Every system that asked me to listen *and* write at the same time. Cornell Notes. Bullet journaling during meetings. Live-mind-mapping. End-of-day journaling that required me to remember what happened.
+Every system that asked me to listen and write at the same time. Cornell Notes. Bullet journaling during meetings. Live mind-mapping. End-of-day journaling that required me to remember what happened. The pattern was always the same: a few good weeks where the system felt productive, then a missed day, then a missed week, then quiet abandonment. By the time I was thirty I had probably given up on a dozen capture systems of different shapes. I didn&apos;t know yet that the abandonment was itself the data point.
 
-The pattern was always the same: a couple of good weeks where the system felt productive, followed by a missed day, followed by a missed week, followed by abandonment. By the time I was thirty I had probably abandoned a dozen different note-taking and capture systems. I didn&apos;t know yet that the abandonment was the data point.
-
-The other pattern: I would build elaborate hierarchical systems (Roam, Obsidian, multiple competing zettelkasten flavors) and then never re-read anything I&apos;d written. The system itself was the thing I was building. The note-taking was theater for the system.
+The other thing that stopped working was the system-as-monument problem. I would build elaborate hierarchical setups — Roam, Obsidian with backlinks, three competing zettelkasten flavors — and then never re-read anything I had written. The system itself became the project. The note-taking became theater for the system. The fact that I could spend a weekend on the structure and then find nothing useful in it on a Tuesday was, in retrospect, the same data point in a different shape.
 
 ---
 
 ## The three rules
 
-**One. Never write while listening.** Listening and writing are different cognitive modes for me, and trying to do them simultaneously means I&apos;m bad at both. So I don&apos;t do it. <Link href="/granola">Granola</Link> records the meeting; I&apos;m in the meeting. The handoff is total.
+The first rule is that I never write while listening. Listening and writing are different cognitive modes for my brain, and trying to do both at the same time means I am bad at both. So I don&apos;t. <Link href="/granola">Granola</Link> records the meeting; I&apos;m in the meeting. The handoff is total, and it is the single rule that did the most for me.
 
-**Two. Capture is separate from organization. In time and in tool.** Capture happens at the speed of the moment: voice dictation into whatever&apos;s open, Granola in meetings, a one-line note on my phone if I&apos;m walking. Organization happens later — usually Sunday — when I&apos;m in a completely different mental mode. Mixing them was the second-biggest source of failure.
+The second rule is that capture is separate from organization — in time and in tool. Capture happens at the speed of the moment: voice dictation into whatever&apos;s open, Granola in meetings, a one-line note on my phone if I&apos;m walking. Organization happens later, usually on a Sunday, when I am in an entirely different mental mode. Mixing them — trying to file as I capture, trying to categorize at the speed of speech — was the second-biggest source of failure across every system I tried.
 
-**Three. The system has to survive a bad week.** This is the rule that ruled out most things. Any system that requires me to do something every day eventually fails. Any system that requires hierarchy or categorization at capture time eventually fails. The system has to be runnable when I&apos;m exhausted, dysregulated, or just having a bad time. If it isn&apos;t, it isn&apos;t my system; it&apos;s a fantasy of someone else&apos;s.
+The third rule is the rule that ruled out most things: the system has to survive a bad week. Any system that requires me to do something every day eventually fails. Any system that requires hierarchy or categorization at capture time eventually fails. The system has to run when I am exhausted, dysregulated, or just having a bad time, because those are the weeks when it matters most that the system run at all. If it doesn&apos;t survive those weeks, it isn&apos;t my system — it&apos;s someone else&apos;s fantasy that I tried to adopt.
 
 ---
 
 ## The daily flow
 
-**Meetings.** Granola captures everything I take a call for — work, consulting, personal, friend catch-ups. No bot joins. Structured notes land within seconds of the call ending. The full transcript stays searchable. I do not take notes in meetings. I have not taken notes in meetings in over a year and the quality of my recall, my follow-through, and my contribution in the conversation itself have all improved.
+The flow has three layers and almost no ceremony. Meetings go through Granola — every call I take, work or consulting or personal or friend catch-up. No bot joins. Structured notes land within seconds of the call ending. The full transcript stays searchable. I have not taken notes during a meeting in over a year, and the quality of my recall, my follow-through, and my contribution inside the conversation itself have all improved. I noticed because other people noticed.
 
-**Async input.** When I&apos;m typing — Slack, email, code comments, PR descriptions, ticket updates — I&apos;m almost always dictating instead. <Link href="https://ref.wisprflow.ai/zack-proser">WisprFlow</Link> runs at 175+ WPM with a system-level hotkey. The keyboard exists for code. Voice handles everything else.
+Async input runs through <Link href="https://ref.wisprflow.ai/zack-proser">WisprFlow</Link>. When I&apos;m typing — Slack, email, code comments, PR descriptions, ticket updates, the comments on the thing my colleague just shared — I&apos;m almost always dictating instead. WisprFlow runs at 175+ WPM with a system-level hotkey. The keyboard exists for code; voice handles everything else. Speed is the side effect. The bigger change is that the friction between thinking and writing dropped enough that I stopped getting stuck on small messages.
 
-**End-of-day.** One short paragraph, in the same place, every day. Not a journal. Not a reflection. Three to five lines about what happened. The point is the consistency of location, not the eloquence. Bad weeks the paragraph is two words. Good weeks it&apos;s a page. The system doesn&apos;t care.
+The third layer is one short paragraph at the end of each day, in the same plain-text file, every day. Not a journal. Not a reflection. Three to five lines about what happened. The point is the consistency of the location, not the eloquence. On bad weeks the paragraph is two words. On good weeks it&apos;s a page. The file does not care, and neither do I — the only thing the daily paragraph has to do is exist where I can find it later.
 
-That is the entire daily flow.
+That is the entire daily flow. There is no fourth layer.
 
 ---
 
 ## What I keep simple on purpose
 
-I do not maintain a personal knowledge graph. I do not connect my notes with backlinks. I do not use tags. I do not have an inbox to triage.
+I do not maintain a personal knowledge graph. I do not connect my notes with backlinks. I do not use tags. I do not have an inbox to triage. Every time I have added structure beyond "things go in one place" the system has decayed within a quarter. The maintenance budget I refuse to spend on the tools is what keeps the tools running at all. I have been disappointed by this fact for years. I have stopped trying to argue with it.
 
-Every time I&apos;ve added structure beyond "things go in one place" my system has decayed within a quarter. The maintenance budget I refuse to spend on these tools is what keeps the tools running at all.
-
-If something matters enough to find again, I&apos;ll find it again. Granola is searchable. WisprFlow output goes to wherever I was typing it. My end-of-day paragraphs are searchable in plain text. That&apos;s plenty. The fantasy of perfect retrieval was always more expensive than the cost of occasionally not retrieving something.
+If something matters enough to find again, I will find it again. Granola is searchable. WisprFlow output goes to wherever I was typing it, which is the same place I would have looked for it anyway. My daily paragraphs are plain text and a `grep` away. That is plenty. The fantasy of perfect retrieval was always more expensive than the cost of occasionally not retrieving something.
 
 ---
 
 ## The thing the diagnosis changed
 
-The diagnosis didn&apos;t hand me a system. It handed me permission to stop building systems that didn&apos;t fit. For a long time I had been trying to operate the same note-taking pattern as the engineers and PMs around me — assuming they had the same hardware as me and were just being more disciplined.
+The diagnosis did not hand me a system. It handed me permission to stop building systems that didn&apos;t fit. For a long time I had been trying to operate the same note-taking pattern as the engineers and PMs around me, on the assumption that they had the same hardware as me and were just being more disciplined. They mostly didn&apos;t and weren&apos;t. They mostly had brains that didn&apos;t pay the listening-while-writing tax I do. The fix was never to try harder. The fix was to stop solving a problem I was never going to solve and route around it instead.
 
-They mostly don&apos;t. They mostly have brains that don&apos;t pay the listening-while-writing tax I do. The fix wasn&apos;t to try harder; the fix was to stop solving a problem I was never going to solve and route around it instead.
-
-Granola is the routing. The three rules are the operating principle. The rest is just consistency on the small flat surface I&apos;ve made for myself.
+Granola is the routing. The three rules are the operating principle. The rest is just consistency on the small flat surface I&apos;ve made for myself — a surface that is small enough to survive a bad week, and flat enough that I don&apos;t spend my Sundays maintaining it.
 
 ---
 
 ## Tools
 
 - <Link href="/granola">Granola</Link> — meetings, captured silently, summarized faithfully. The single tool that did the most for my note-taking.
-- <Link href="https://ref.wisprflow.ai/zack-proser">WisprFlow</Link> — voice input everywhere else. Same effect: the friction I was paying turns out to have been the whole tax.
-- One plain-text file for end-of-day. Any tool. Pick the one you&apos;ll open.
+- <Link href="https://ref.wisprflow.ai/zack-proser">WisprFlow</Link> — voice input for everything else. Same effect: the friction I was paying turns out to have been the entire tax.
+- One plain-text file for the daily paragraph. Any tool. Pick the one you will open.
 
-I have affiliate relationships with both products mentioned. The system existed before the relationships; the relationships are what makes time spent writing about them economic.
+I have affiliate relationships with both products mentioned. The system existed before the relationships; the relationships are what make the time to write about it at this length economic.

--- a/src/content/blog/note-taking-system-after-audhd-diagnosis/page.mdx
+++ b/src/content/blog/note-taking-system-after-audhd-diagnosis/page.mdx
@@ -1,9 +1,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { AffiliateLink } from '@/components/StickyAffiliateCTA';
 import { createMetadata } from '@/utils/createMetadata';
 import rawMetadata from './metadata.json';
 
 export const metadata = createMetadata(rawMetadata);
+
+export const campaign = 'note-taking-system-after-audhd-diagnosis';
 
 <Image src={rawMetadata.image} alt="A minimal workspace: closed notebook, over-ear headphones, single small plant on a wood desk" width={1200} height={630} />
 <figcaption>The setup that finally works. Less is the thing it is.</figcaption>
@@ -36,7 +39,7 @@ The third rule is the rule that ruled out most things: the system has to survive
 
 The flow has three layers and almost no ceremony. Meetings go through Granola — every call I take, work or consulting or personal or friend catch-up. No bot joins. Structured notes land within seconds of the call ending. The full transcript stays searchable. I have not taken notes during a meeting in over a year, and the quality of my recall, my follow-through, and my contribution inside the conversation itself have all improved. I noticed because other people noticed.
 
-Async input runs through <Link href="https://ref.wisprflow.ai/zack-proser">WisprFlow</Link>. When I&apos;m typing — Slack, email, code comments, PR descriptions, ticket updates, the comments on the thing my colleague just shared — I&apos;m almost always dictating instead. WisprFlow runs at 175+ WPM with a system-level hotkey. The keyboard exists for code; voice handles everything else. Speed is the side effect. The bigger change is that the friction between thinking and writing dropped enough that I stopped getting stuck on small messages.
+Async input runs through <AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink>. When I&apos;m typing — Slack, email, code comments, PR descriptions, ticket updates, the comments on the thing my colleague just shared — I&apos;m almost always dictating instead. WisprFlow runs at 175+ WPM with a system-level hotkey. The keyboard exists for code; voice handles everything else. Speed is the side effect. The bigger change is that the friction between thinking and writing dropped enough that I stopped getting stuck on small messages.
 
 The third layer is one short paragraph at the end of each day, in the same plain-text file, every day. Not a journal. Not a reflection. Three to five lines about what happened. The point is the consistency of the location, not the eloquence. On bad weeks the paragraph is two words. On good weeks it&apos;s a page. The file does not care, and neither do I — the only thing the daily paragraph has to do is exist where I can find it later.
 
@@ -63,7 +66,7 @@ Granola is the routing. The three rules are the operating principle. The rest is
 ## Tools
 
 - <Link href="/granola">Granola</Link> — meetings, captured silently, summarized faithfully. The single tool that did the most for my note-taking.
-- <Link href="https://ref.wisprflow.ai/zack-proser">WisprFlow</Link> — voice input for everything else. Same effect: the friction I was paying turns out to have been the entire tax.
+- <AffiliateLink product="wisprflow" campaign={campaign}>WisprFlow</AffiliateLink> — voice input for everything else. Same effect: the friction I was paying turns out to have been the entire tax.
 - One plain-text file for the daily paragraph. Any tool. Pick the one you will open.
 
 I have affiliate relationships with both products mentioned. The system existed before the relationships; the relationships are what make the time to write about it at this length economic.


### PR DESCRIPTION
## Summary
Five companion pieces that form the SEO cluster around Granola. Scaffold-only — metadata + hero images live + structured outlines. Bodies get written week-by-week through the 12-week campaign.

- `/blog/how-i-prep-for-1-1s-as-an-engineer`
- `/blog/note-taking-system-after-audhd-diagnosis`
- `/blog/100-product-review-meetings`
- `/blog/ai-tools-i-actually-use`
- `/blog/how-i-run-async-team-standups`

All five hero images uploaded to Bunny CDN with consistent editorial styling (parchment + burnt-orange accent) for cluster cohesion. All marked `hiddenFromIndex: true` until bodies ship. URLs exist now so cross-linking works once any piece publishes.

Each piece routes affiliate traffic through `/granola` (#1066). Two link to WisprFlow as well where genuinely relevant (the AuDHD note-taking piece and the AI-tools roundup).

## Test plan
- [ ] Visit each `/blog/{slug}` locally, confirm hero image renders + outline structure looks right
- [ ] Confirm none of the 5 appear in the blog index listing (hiddenFromIndex)
- [ ] Confirm the cross-links to `/granola` and `/blog/granola-applied-ai-workflow-workos` render (will 404 until #1066/#1067 merge — expected)
- [ ] Flip `hiddenFromIndex: false` per-post as bodies get filled in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to MDX/JSON content additions and copy edits, with no app logic changes beyond normal rendering of new pages and affiliate components.
> 
> **Overview**
> Adds five new blog posts (each with `metadata.json`, hero image, and MDX body) to build a Granola-focused content cluster; all are marked `hiddenFromIndex: true` and include cross-links to `/granola` (and WisprFlow where relevant).
> 
> Rewrites and restructures two existing Granola SEO posts (`best-ai-meeting-notes-2026` and `best-ai-meeting-notes-remote-teams-2026`) into longer-form narrative copy with clearer tradeoffs, updated CTAs, and affiliate disclosures, and refreshes `granola-vs-traditional-meeting-notes` metadata/title plus a tighter first-person rewrite of the article body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a489fe18107f8602d7cbdfac6c5fd9bf046368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->