### PR TITLE
design(workshops): enterprise rebuild + homepage feature swap

### DIFF
--- a/src/app/HomepageClientComponent.tsx
+++ b/src/app/HomepageClientComponent.tsx
@@ -156,39 +156,41 @@ function StatRow() {
   )
 }
 
-// ----- Featured Project ---------------------------------------------
+// ----- Featured Workshops (primary slot) ---------------------------
 
-function FeaturedProject() {
+function FeaturedWorkshops() {
   return (
     <section className="py-16">
       <div className="container mx-auto max-w-6xl px-4 md:px-6">
         <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
-          Featured project
+          Featured engagement
         </div>
         <article className="grid gap-10 lg:grid-cols-[1.3fr_1fr] lg:gap-16 items-start">
           <div>
             <div className="flex flex-wrap gap-2 mb-5">
-              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-[11px] font-bold font-mono uppercase tracking-wider text-amber-700 dark:text-amber-300 border border-amber-300 dark:border-amber-400/50">
-                Premium · $149
+              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-[11px] font-bold font-mono uppercase tracking-wider text-burnt-600 dark:text-amber-300 border border-burnt-400/50 dark:border-amber-400/50 bg-burnt-400/10 dark:bg-transparent">
+                Workshops · From $15k
               </span>
               <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-[11px] font-semibold font-mono uppercase tracking-wider text-green-700 dark:text-green-300 border border-green-600/40">
                 <span className="w-1.5 h-1.5 rounded-full bg-green-600 dark:bg-green-400" />
-                Shipping
+                Booking · Q3 open
               </span>
             </div>
-            <h2 className="font-serif text-3xl md:text-4xl font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100">
-              Build a chatbot that actually knows your shit.
+            <h2 className="font-serif text-3xl md:text-4xl font-extrabold leading-[1.08] tracking-tight text-charcoal-50 dark:text-parchment-100 text-balance">
+              Make Claude{' '}
+              <em className="italic text-burnt-400 dark:text-amber-400">how your team works</em>
+              {' '}— not just a tool they have.
             </h2>
             <p className="mt-5 text-[17px] leading-relaxed text-parchment-600 dark:text-slate-300 max-w-[52ch]">
-              End-to-end RAG with Pinecone, the Vercel AI SDK, and Next.js 15.
-              No hallucinations. No magic. A production harness you can hand to
-              your team and they&apos;ll still understand it in six months.
+              Three practitioners who ship with Claude daily at WorkOS come into your team — single team or
+              whole org — and embed inside your pods. We leave you with workflows, skills, and named
+              champions. Half-day, full-day, or two-day.
             </p>
             <div className="mt-7 grid grid-cols-3 gap-4 max-w-md">
               {[
-                ['Runtime', 'Node 20'],
-                ['Vector DB', 'Pinecone'],
-                ['Eval', 'Ragas++'],
+                ['Crew', '1 – 3 practitioners'],
+                ['Shape', '½ – 2 days'],
+                ['For', 'Team or whole org'],
               ].map(([label, val]) => (
                 <div key={label}>
                   <div className="font-mono text-[10px] uppercase tracking-wider text-parchment-500 dark:text-slate-500">
@@ -202,24 +204,130 @@ function FeaturedProject() {
             </div>
             <div className="mt-8 flex flex-wrap gap-3">
               <Link
-                href="/checkout?product=rag-pipeline-tutorial&type=blog"
+                href="/workshops/claude-cowork#book"
                 className="inline-flex items-center justify-center px-5 py-3 text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors"
                 onClick={() =>
-                  track('featured_product_click', {
+                  track('featured_engagement_click', {
                     location: 'hero_section',
-                    product: 'rag_tutorial',
-                    action: 'buy',
+                    product: 'claude_workshops',
+                    action: 'book',
                   })
                 }
               >
-                Buy tutorial — $149
+                Book a workshop →
               </Link>
               <Link
-                href="/chat"
+                href="/workshops/claude-cowork#engagements"
                 className="inline-flex items-center justify-center px-5 py-3 text-sm font-semibold rounded-md border border-parchment-400 dark:border-slate-600 text-charcoal-50 dark:text-parchment-100 hover:border-burnt-400 dark:hover:border-amber-400 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors"
                 onClick={() =>
-                  track('featured_product_click', {
+                  track('featured_engagement_click', {
                     location: 'hero_section',
+                    product: 'claude_workshops',
+                    action: 'engagements',
+                  })
+                }
+              >
+                Engagement shapes →
+              </Link>
+            </div>
+          </div>
+
+          {/* Booking card — terminal-style calendar of upcoming weeks */}
+          <div className="rounded-md border border-parchment-300 dark:border-slate-700 bg-parchment-50 dark:bg-slate-800 shadow-md p-6 flex flex-col gap-4">
+            <div className="flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
+              <span className="font-bold text-burnt-400 dark:text-amber-400">~/workshops — calendar</span>
+              <span>Live</span>
+            </div>
+            <h3 className="font-serif text-[21px] font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100 m-0">
+              Booking the next collaboration weeks.
+            </h3>
+            <div className="h-px bg-parchment-300 dark:bg-slate-700" />
+            {[
+              { when: 'Jun 17', what: 'Healthcare · Org-wide', who: 'Booked', open: false },
+              { when: 'Jul 22', what: 'Fintech · Two-day', who: 'Booked', open: false },
+              { when: 'Aug — open', what: 'Your org here', who: '→', open: true },
+              { when: 'Sep — open', what: 'Your org here', who: '→', open: true },
+            ].map((row) => (
+              <div
+                key={row.when}
+                className="grid grid-cols-[92px_1fr_auto] gap-3 items-baseline font-mono text-[12px] py-1"
+              >
+                <span className="text-parchment-500 dark:text-slate-500">{row.when}</span>
+                <span
+                  className={`font-semibold ${
+                    row.open
+                      ? 'text-burnt-400 dark:text-amber-400'
+                      : 'text-charcoal-50 dark:text-parchment-100'
+                  }`}
+                >
+                  {row.what}
+                </span>
+                <span className="italic text-parchment-600 dark:text-slate-400">{row.who}</span>
+              </div>
+            ))}
+            <div className="flex justify-between items-baseline font-mono text-[11px] uppercase tracking-[0.1em] text-parchment-600 dark:text-slate-400 mt-2 pt-4 border-t border-parchment-300 dark:border-slate-700">
+              <span>Typical lead time 6–10 wk</span>
+              <Link
+                href="/workshops/claude-cowork#book"
+                className="text-burnt-400 dark:text-amber-400 no-underline hover:underline"
+              >
+                Hold a date →
+              </Link>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  )
+}
+
+// ----- Featured Tutorial (demoted RAG, between rails) --------------
+
+function FeaturedTutorialSecondary() {
+  return (
+    <section className="py-12">
+      <div className="container mx-auto max-w-6xl px-4 md:px-6">
+        <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+          Also from the catalog
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          {/* Demoted RAG tutorial */}
+          <article className="rounded-md border border-parchment-300 dark:border-slate-700 bg-parchment-50 dark:bg-slate-800 p-6 flex flex-col gap-3">
+            <div className="flex justify-between items-baseline font-mono text-[11px] uppercase tracking-[0.12em] text-parchment-600 dark:text-slate-400">
+              <span className="font-bold text-charcoal-50 dark:text-parchment-100">Tutorial · Premium</span>
+              <span className="text-burnt-400 dark:text-amber-400">$149 · Shipping</span>
+            </div>
+            <h3 className="font-serif text-2xl font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100 m-0">
+              Build a chatbot that actually knows your shit.
+            </h3>
+            <p className="m-0 text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300 max-w-[52ch]">
+              End-to-end RAG with Pinecone, the Vercel AI SDK, and Next.js 15. No hallucinations. No magic.
+              A production harness you can hand to your team and they&apos;ll still understand it in six
+              months.
+            </p>
+            <dl className="grid grid-cols-3 gap-3 py-3 border-t border-b border-parchment-300 dark:border-slate-700">
+              {[
+                ['Runtime', 'Node 20'],
+                ['Vector DB', 'Pinecone'],
+                ['Eval', 'Ragas++'],
+              ].map(([label, val]) => (
+                <div key={label}>
+                  <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
+                    {label}
+                  </dt>
+                  <dd className="m-0 mt-0.5 font-mono text-xs font-semibold text-charcoal-50 dark:text-parchment-100">
+                    {val}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+            <div className="flex justify-between items-baseline font-mono text-[11px] uppercase tracking-[0.1em] text-parchment-600 dark:text-slate-400">
+              <Link
+                href="/chat"
+                className="text-burnt-400 dark:text-amber-400 no-underline hover:underline"
+                onClick={() =>
+                  track('featured_product_click', {
+                    location: 'secondary_catalog',
                     product: 'rag_tutorial',
                     action: 'demo',
                   })
@@ -227,29 +335,46 @@ function FeaturedProject() {
               >
                 Try the live demo →
               </Link>
+              <Link
+                href="/checkout?product=rag-pipeline-tutorial&type=blog"
+                className="text-charcoal-50 dark:text-parchment-100 no-underline border-b border-parchment-400 dark:border-slate-600 pb-px hover:text-burnt-400 dark:hover:text-amber-400 hover:border-burnt-400 dark:hover:border-amber-400"
+                onClick={() =>
+                  track('featured_product_click', {
+                    location: 'secondary_catalog',
+                    product: 'rag_tutorial',
+                    action: 'buy',
+                  })
+                }
+              >
+                Buy — $149
+              </Link>
             </div>
-          </div>
+          </article>
 
-          {/* Terminal readout — site index */}
-          <div className="rounded-md overflow-hidden border border-charcoal-100/30 dark:border-slate-700 bg-[#141428] text-sm font-mono shadow-lg">
-            <div className="flex items-center gap-1.5 px-3 py-2 border-b border-white/10 bg-black/20">
-              <span className="w-2.5 h-2.5 rounded-full bg-red-400/60" />
-              <span className="w-2.5 h-2.5 rounded-full bg-yellow-400/60" />
-              <span className="w-2.5 h-2.5 rounded-full bg-green-400/60" />
-              <span className="ml-3 text-[11px] tracking-wider uppercase text-slate-400">~/zackproser.com — index</span>
+          {/* Newsletter — dashed companion card */}
+          <article className="rounded-md border border-dashed border-parchment-400 dark:border-slate-600 p-6 flex flex-col gap-3">
+            <div className="flex justify-between items-baseline font-mono text-[11px] uppercase tracking-[0.12em] text-parchment-600 dark:text-slate-400">
+              <span className="font-bold text-charcoal-50 dark:text-parchment-100">Newsletter</span>
+              <span className="text-burnt-400 dark:text-amber-400">5,000+ readers</span>
             </div>
-            <div className="p-4 text-[12px] leading-relaxed text-slate-200 whitespace-nowrap overflow-x-auto">
-              <div><span className="text-slate-500">zp@work ~ $</span> ls -lh ./content</div>
-              <div><span className="text-slate-500">drwx  </span>writing/<span className="text-slate-500">        218 essays       </span><span className="text-amber-400">&quot;modern-coding&quot;</span></div>
-              <div><span className="text-slate-500">drwx  </span>builds/<span className="text-slate-500">          37 projects     </span><span className="text-amber-400">&quot;rag, tools, tuis&quot;</span></div>
-              <div><span className="text-slate-500">drwx  </span>videos/<span className="text-slate-500">          24 screencasts  </span><span className="text-amber-400">&quot;long-form&quot;</span></div>
-              <div><span className="text-slate-500">drwx  </span>workshops/<span className="text-slate-500">        6 decks        </span><span className="text-amber-400">&quot;cowork, claude&quot;</span></div>
-              <div><span className="text-slate-500">zp@work ~ $</span> cat ./status.json</div>
-              <div>{'{ '}<span className="text-amber-400">&quot;current&quot;</span>: <span className="text-green-400">&quot;applied-ai @ workos&quot;</span>, <span className="text-amber-400">&quot;open_to&quot;</span>: [<span className="text-green-400">&quot;workshops&quot;</span>, <span className="text-green-400">&quot;retainers&quot;</span>], <span className="text-amber-400">&quot;wpm&quot;</span>: <span className="text-green-400">184</span> {'}'}</div>
-              <div><span className="text-slate-500">zp@work ~ $</span> <span className="inline-block w-2 h-3.5 bg-amber-400 align-middle animate-pulse ml-1" /></div>
+            <h3 className="font-serif text-2xl font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100 m-0">
+              The Modern Coding letter.
+            </h3>
+            <p className="m-0 text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300 max-w-[52ch]">
+              Dispatches from the edge of applied AI. What I&apos;m building, what I&apos;m learning, the
+              tools I&apos;d actually pay for. Names named, vendors graded, evals included.
+            </p>
+            <div className="flex justify-between items-baseline font-mono text-[11px] uppercase tracking-[0.1em] text-parchment-600 dark:text-slate-400 mt-auto pt-4 border-t border-parchment-300 dark:border-slate-700">
+              <span>Unsubscribe in one click</span>
+              <Link
+                href="/newsletter"
+                className="text-burnt-400 dark:text-amber-400 no-underline hover:underline"
+              >
+                Subscribe →
+              </Link>
             </div>
-          </div>
-        </article>
+          </article>
+        </div>
       </div>
     </section>
   )
@@ -371,7 +496,7 @@ export default function HomepageClientComponent({
       <main className="flex-1">
         <EditorialHero />
         <StatRow />
-        <FeaturedProject />
+        <FeaturedWorkshops />
 
         <ContentRail
           num="01"
@@ -382,6 +507,8 @@ export default function HomepageClientComponent({
           keyPrefix="ml-tutorial"
           kind="Tutorial"
         />
+
+        <FeaturedTutorialSecondary />
 
         <ContentRail
           num="02"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import '@/styles/blog-post.css';
 import '@/styles/testimonials.css';
 import '@/styles/contact.css';
 import '@/styles/partnerships.css';
+import '@/styles/claude-cowork.css';
 import '@/styles/granola-pillar.css';
 import '@/styles/meeting-notes.css';
 import '@/styles/subscribe.css';

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -15,10 +15,13 @@ export const metadata: Metadata = {
   },
 }
 
-const ZACK_PHOTO = "https://zackproser.b-cdn.net/images/workshop-zack-presenting-v2.webp"
-const AUDIENCE_PHOTO = "https://zackproser.b-cdn.net/images/workshop-audience-coding-v2.webp"
-const QA_PHOTO = "https://zackproser.b-cdn.net/images/workshop-qa-lydia-zack-v2.webp"
+const HERO_PHOTO = "https://zackproser.b-cdn.net/images/zack-and-nick.webp"
+const STRIP_NICK_ZACK = "https://zackproser.b-cdn.net/images/aie-london-workshop-nick-zack.webp"
+const STRIP_EVIDENCE = "https://zackproser.b-cdn.net/images/aie-london-workshop-evidence.webp"
+const STRIP_AUDIENCE = "https://zackproser.b-cdn.net/images/aie-london-audience-wide.webp"
 const ZACK_PORTRAIT = "https://zackproser.b-cdn.net/images/zack-sketch.webp"
+const NICK_NISI_PORTRAIT = "https://zackproser.b-cdn.net/images/nick-nisi-sketch.webp"
+const NICK_CANNARIATO_PORTRAIT = "https://zackproser.b-cdn.net/images/nick-cannariato-sketch.webp"
 
 type Phase = {
   code: string
@@ -223,7 +226,7 @@ type Person = {
   role: string
   name: React.ReactNode
   bio: string
-  creds: string[]
+  creds: React.ReactNode[]
   photo?: string
 }
 
@@ -237,13 +240,22 @@ const people: Person[] = [
         Zachary <em>Proser</em>
       </>
     ),
-    bio: "One of five on the Applied AI team at WorkOS supporting the entire org with internal tooling, AI enablement, training, and harnesses. WorkOS powers auth at OpenAI, Cursor, and most of the labs you've heard of. Ships production Claude Code daily — watchOS apps, MCP integrations, full-stack features.",
+    bio: "Full-stack engineer, 15 years shipping distributed systems, internal tooling, and customer-facing applications that automate manual tedium away. Currently one of five on the Applied AI team at WorkOS — which powers auth for OpenAI, Cursor, and most of the labs you've heard of. Ships production Claude Code daily.",
     creds: [
-      "14 years shipping production systems",
-      "Previously Staff DevRel at Pinecone, Cloudflare, Gruntwork",
+      "Full-stack engineer · 15 years",
+      "Core engineer · Cloudflare (when eng was ~100 worldwide)",
+      "Staff DevRel · Pinecone",
+      "Open-source developer, speaker, trainer",
       "AIE NY & AIE London workshop instructor",
-      "DevSecCon 2025 keynote speaker",
-      "5,000+ readers on Modern Coding",
+      <>
+        DevSecCon 2025 keynote —{" "}
+        <Link
+          href="/videos/devseccon-2025-keynote-walking-and-talking-in-the-woods-with-ai"
+          className="underline decoration-dotted underline-offset-2 hover:text-burnt-400 dark:hover:text-amber-400"
+        >
+          watch the talk →
+        </Link>
+      </>,
     ],
     photo: ZACK_PORTRAIT,
   },
@@ -263,6 +275,7 @@ const people: Person[] = [
       "Co-host · AIE London workshop",
       "Long-time JS & tooling community voice",
     ],
+    photo: NICK_NISI_PORTRAIT,
   },
   {
     id: "nick-cannariato",
@@ -280,6 +293,7 @@ const people: Person[] = [
       "Specializes in adoption + change management",
       'Brings the "what about IT?" sanity check',
     ],
+    photo: NICK_CANNARIATO_PORTRAIT,
   },
 ]
 
@@ -330,15 +344,15 @@ export default function ClaudeWorkshopsPage() {
               <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">In the room</div>
               <div className="relative aspect-[4/5] overflow-hidden rounded-sm border border-parchment-300 dark:border-slate-700 shadow-md">
                 <Image
-                  src={AUDIENCE_PHOTO}
-                  alt="Workshop pods mid-build at AI Engineer World's Fair"
+                  src={HERO_PHOTO}
+                  alt="Zack and Nick at the AI Engineer World's Fair, ready to teach the Mastra workshop"
                   fill
                   sizes="(max-width: 1024px) 100vw, 40vw"
                   className="object-cover"
                 />
               </div>
               <p className="mt-3 font-mono text-[11px] tracking-[0.1em] uppercase text-parchment-600 dark:text-slate-400">
-                AIE · 2025 — pods mid-build
+                AIE World&apos;s Fair · SF · Mastra workshop
               </p>
             </div>
           </div>
@@ -757,7 +771,7 @@ export default function ClaudeWorkshopsPage() {
                   <div className="cw-person-bio">{person.bio}</div>
                   <dl className="cw-creds">
                     {person.creds.map((c, i) => (
-                      <div key={c} className="contents">
+                      <div key={i} className="contents">
                         <dt>{String(i + 1).padStart(2, "0")}</dt>
                         <dd>{c}</dd>
                       </div>
@@ -862,13 +876,25 @@ export default function ClaudeWorkshopsPage() {
         <section className="py-14">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
             <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
-              In the room · AIE · WorkOS × Anthropic
+              In the room · AIE London · WorkOS
             </div>
             <div className="grid gap-4 md:grid-cols-3">
               {[
-                { src: ZACK_PHOTO, alt: "Workshop opening", caption: "Workshop opening" },
-                { src: AUDIENCE_PHOTO, alt: "The room mid-build", caption: "The room mid-build" },
-                { src: QA_PHOTO, alt: "Q&A · Anthropic · Feb 2026", caption: "Q&A · Anthropic · Feb 2026" },
+                {
+                  src: STRIP_NICK_ZACK,
+                  alt: "Zack and Nick co-instructing the Skills at Scale workshop at AI Engineering London",
+                  caption: "Skills at Scale · Nick & Zack",
+                },
+                {
+                  src: STRIP_EVIDENCE,
+                  alt: "Zack teaching backtick evidence patterns to workshop attendees",
+                  caption: "Teaching evidence patterns",
+                },
+                {
+                  src: STRIP_AUDIENCE,
+                  alt: "Packed audience at the AI Engineering London workshop",
+                  caption: "AIE London · the room",
+                },
               ].map((img) => (
                 <figure key={img.src} className="m-0">
                   <div className="relative aspect-[4/3] overflow-hidden rounded-sm border border-parchment-300 dark:border-slate-700 shadow-sm">

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -277,14 +277,15 @@ const people: Person[] = [
   },
   {
     id: "nick-cannariato",
-    role: "Senior Solutions Engineer · AI Practitioner",
+    role: "Senior Solutions Engineer · WorkOS",
     name: (
       <>
         Nick <em>Cannariato</em>
       </>
     ),
-    bio: "Senior solutions engineer with a developer-tools tour-of-duty: Twilio, Heroku, Zapier, GitHub. Knows enterprise rollouts from inside the room — what melts, what scales, what your IT team will actually approve.",
+    bio: "Senior solutions engineer at WorkOS, with a developer-tools tour-of-duty before that: Twilio, Heroku, Zapier, GitHub. Knows enterprise rollouts from inside the room — what melts, what scales, what your IT team will actually approve.",
     creds: [
+      "Senior Solutions Engineer · WorkOS",
       "Ex-Twilio · Heroku · Zapier · GitHub",
       "Embedded with rollouts at Fortune-scale orgs",
       "Specializes in adoption + change management",

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -892,10 +892,10 @@ export default function ClaudeWorkshopsPage() {
           </div>
         </section>
 
-        {/* ============ § 10 FAQ ============ */}
+        {/* ============ § 09 FAQ ============ */}
         <section className="py-14">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <SectionHead num="10" title={<>Frequently — and reasonably — asked.</>} />
+            <SectionHead num="09" title={<>Frequently — and reasonably — asked.</>} />
             <div className="cw-faq-list">
               {faqs.map((f, i) => (
                 <div className="cw-faq-item" key={f.q}>
@@ -910,7 +910,7 @@ export default function ClaudeWorkshopsPage() {
           </div>
         </section>
 
-        {/* ============ § 11 Closing CTA ============ */}
+        {/* ============ § 10 Closing CTA ============ */}
         <section id="book" className="py-20 editorial-section-alt">
           <div className="container mx-auto max-w-4xl px-4 md:px-6 text-center">
             <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -188,7 +188,7 @@ const engagements: Engagement[] = [
 const faqs: { q: string; a: string }[] = [
   {
     q: "Will this embarrass executives who haven't touched a terminal in years?",
-    a: 'No — and that\'s not an accident. See "Why the room is safe" above. Mixed-skill pods, a rotating keyboard, no public coding, no "stand up and demo." The shape of the room makes embarrassment impossible by design, not by hope.',
+    a: 'No — and that\'s not an accident. See § 05 above. Mixed-skill pods, a rotating keyboard, no public coding, no "stand up and demo." The shape of the room makes embarrassment impossible by design, not by hope.',
   },
   {
     q: "Can you actually handle a hundred attendees?",

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -222,7 +222,6 @@ const faqs: { q: string; a: string }[] = [
 
 type Person = {
   id: string
-  tag: string
   role: string
   name: React.ReactNode
   bio: string
@@ -233,7 +232,6 @@ type Person = {
 const people: Person[] = [
   {
     id: "zack",
-    tag: "Lead",
     role: "Applied AI · WorkOS",
     name: (
       <>
@@ -261,16 +259,16 @@ const people: Person[] = [
   },
   {
     id: "nick-nisi",
-    tag: "Co-lead",
     role: "EM · DX / AI · WorkOS",
     name: (
       <>
         Nick <em>Nisi</em>
       </>
     ),
-    bio: "Engineering manager for WorkOS's DX / AI team. Same depth as Zack on Claude Code; ships the internal harnesses other teams build on top of. Co-instructed at AIE NY and AIE London.",
+    bio: "Staff engineer and AI practitioner working at the front of the field. EM of WorkOS's DX / AI team — owns the internal harnesses other teams build on top of. Co-instructed at AIE NY and AIE London.",
     creds: [
-      "Engineering manager · DX / AI · WorkOS",
+      "Staff engineer · AI practitioner",
+      "EM · DX / AI · WorkOS",
       "Co-host · AIE NY workshop",
       "Co-host · AIE London workshop",
       "Long-time JS & tooling community voice",
@@ -279,7 +277,6 @@ const people: Person[] = [
   },
   {
     id: "nick-cannariato",
-    tag: "Senior practitioner",
     role: "Senior Solutions Engineer · AI Practitioner",
     name: (
       <>
@@ -764,7 +761,6 @@ export default function ClaudeWorkshopsPage() {
                 </div>
                 <div>
                   <div className="cw-person-meta">
-                    <span className="tag">{person.tag}</span>
                     <span className="role">{person.role}</span>
                   </div>
                   <h4>{person.name}</h4>

--- a/src/app/workshops/claude-cowork/page.tsx
+++ b/src/app/workshops/claude-cowork/page.tsx
@@ -1,516 +1,951 @@
 import type { Metadata } from "next"
 import Image from "next/image"
 import Link from "next/link"
-import YoutubeEmbed from "@/components/YoutubeEmbed"
 import { SectionHead } from "@/components/SectionHead"
 
 export const metadata: Metadata = {
-  title: "Claude Cowork Workshop | Hands-On AI-Assisted Development | Zachary Proser",
-  description: "A hands-on workshop where your team builds real workflows with Claude Code and Cowork. From ICP research to automated content production — in one session.",
+  title: "Claude Workshops for Enterprise | Zachary Proser",
+  description:
+    "Three practitioners. Half-day to two-day. Up to 100 leaders shipping with Claude by the end of the session — including the ones who haven't opened a terminal in a decade.",
   openGraph: {
-    title: "Claude Cowork Workshop | Hands-On AI-Assisted Development",
-    description: "A hands-on workshop where your team builds real workflows with Claude Code and Cowork.",
+    title: "Claude Workshops for Enterprise | Zachary Proser",
+    description:
+      "Three practitioners. Half-day to two-day. Up to 100 leaders shipping with Claude by the end of the session.",
     images: [{ url: "https://zackproser.b-cdn.net/images/claude-cowork-workshop.webp" }],
   },
 }
 
-const workshopPhases = [
+const ZACK_PHOTO = "https://zackproser.b-cdn.net/images/workshop-zack-presenting-v2.webp"
+const AUDIENCE_PHOTO = "https://zackproser.b-cdn.net/images/workshop-audience-coding-v2.webp"
+const QA_PHOTO = "https://zackproser.b-cdn.net/images/workshop-qa-lydia-zack-v2.webp"
+const ZACK_PORTRAIT = "https://zackproser.b-cdn.net/images/zack-sketch.webp"
+
+type Phase = {
+  code: string
+  kind: string
+  time: string
+  title: string
+  desc: string
+  tools: string[]
+}
+
+const phases: Phase[] = [
   {
-    num: "01",
-    phase: "Demo",
-    duration: "30 min",
-    title: "What's possible with Claude Code",
-    items: [
-      "Real projects built with Claude: Oura MCP integration, Handwave watchOS app",
-      "Walking-and-talking development — shipping code from mountain trails",
-      "Voice-first workflows with WisprFlow at 179 WPM",
-      "How far you can push AI-assisted development today",
+    code: "01",
+    kind: "Calibration",
+    time: "T+0:00",
+    title: "Sterile pre-flight check",
+    desc: "Laptops verified. Whisper Flow, Claude Code, and a pod-shared scratchpad warmed up. We do introductions during the install, not before.",
+    tools: ["Claude.ai", "Claude Code", "Whisper Flow"],
+  },
+  {
+    code: "02",
+    kind: "Demo",
+    time: "T+0:20",
+    title: "Voice coding — the first holy-shit moment",
+    desc: "Whisper Flow plus Claude Code in a terminal. We dictate the same task three different ways and watch the pod realize they just typed at 180 WPM without typing. This is the moment the room shifts.",
+    tools: ["Whisper Flow", "Claude Code"],
+  },
+  {
+    code: "03",
+    kind: "Hands-on",
+    time: "T+0:50",
+    title: "The pod ships its first real thing",
+    desc: "Each pod picks a workflow from their own job. CS picks a triage automation. Marketing picks a competitive teardown. Finance picks a Salesforce report. We unblock, suggest, get out of the way. Working code at the end of the hour — not a demo.",
+    tools: ["Claude Code", "Your stack"],
+  },
+  {
+    code: "04",
+    kind: "Skills",
+    time: "T+1:50",
+    title: "Package the work as a reusable skill",
+    desc: "The thing your pod just built becomes a Claude skill — branded, on-policy, in your org's shared repo. Fifteen to forty of these by the time we leave, depending on engagement shape.",
+    tools: ["Skills", "Brand template", "Your repo"],
+  },
+  {
+    code: "05",
+    kind: "Champions",
+    time: "T+2:40",
+    title: "Cross-pod demo & champion identification",
+    desc: "Each pod shows their skill. We tag the people who lit up — your internal champions. They go home with a 30-day playbook for keeping the flywheel turning after we're gone.",
+    tools: ["Champion roster", "30-day playbook"],
+  },
+]
+
+type Artifact = { n: string; tag: string; title: string; desc: string }
+const artifacts: Artifact[] = [
+  {
+    n: "01",
+    tag: "The thing that makes it stick",
+    title: "A playbook tailored to your team",
+    desc: "A bound and digital playbook written for your org by name. Covers the workflows your pods discovered, the skills they shipped, the rules of your brand and policy, and the specific way your champions should run their first thirty days of office hours. Your team's voice, your team's tools.",
+  },
+  {
+    n: "02",
+    tag: "In your repo before we leave",
+    title: "Org-specific Claude skills",
+    desc: "Fifteen to forty reusable skills built by the pods during the session, branded with your brand template, scoped to your stack and your policy. Each one solves an actual problem someone in the room has.",
+  },
+  {
+    n: "03",
+    tag: "Who lit up, and where they sit",
+    title: "Champion roster + spark map",
+    desc: "By end of day we hand you a labeled list of who lit up, where they sit, and what they shipped. Plus a heatmap of which departments are warm, lukewarm, or about-to-revolt — so your next moves are aimed, not sprayed.",
+  },
+  {
+    n: "04",
+    tag: "An on-ramp for the people who missed it",
+    title: "Recordings + searchable transcripts",
+    desc: "Every plenary recorded, transcribed, and uploaded to a private destination of your choosing. People who couldn't attend get a chaptered, searchable archive — not a four-hour video they'll never watch.",
+  },
+]
+
+type Engagement = {
+  n: string
+  kind: string
+  title: React.ReactNode
+  when: string
+  who: string
+  crew: string
+  price: string
+  desc: string
+  bullets: string[]
+  feature?: boolean
+}
+
+const engagements: Engagement[] = [
+  {
+    n: "01",
+    kind: "Half-day",
+    title: (
+      <>
+        Single-team <em>workshop.</em>
+      </>
+    ),
+    when: "Half-day · single session",
+    who: "Up to 25 attendees",
+    crew: "1 – 2 practitioners",
+    price: "From $15k",
+    desc: "A focused half-day for one team that already has Claude in their hands and wants to compound. Engineering teams who want the Claude Code playbook compressed. AI working groups who want voice coding and skills under their belt by lunch.",
+    bullets: [
+      "Hands-on, in-person or remote",
+      "One lead practitioner + optional co-lead",
+      "5–10 skills shipped live, in your repo",
+      "Tailored playbook (~12 pages)",
+      "Recording + transcripts",
     ],
   },
   {
-    num: "02",
-    phase: "Hands-on",
-    duration: "90 min",
-    title: "Build a complete GTM workflow",
-    items: [
-      "ICP identification and data scraping",
-      "Data enrichment and competitive analysis",
-      "Battlecard creation from live competitive data",
-      "Pain point messaging tailored to each ICP",
-      "Cold email generation for identified prospects",
-      "Blog post drafting and content scheduling",
-      "Scheduled Cowork tasks for automated production",
+    n: "02",
+    kind: "Collaboration-week",
+    title: (
+      <>
+        Org-wide <em>rollout workshop.</em>
+      </>
+    ),
+    when: "Half-day · large room",
+    who: "Up to 100 attendees · pods of 4–5",
+    crew: "Full three-practitioner crew",
+    price: "From $45k",
+    desc: "The collaboration-week shape. Built for orgs running a top-down Claude rollout — leadership offsite, all-hands programming, “everyone in one room and let’s actually move.” This is where the change management lives.",
+    bullets: [
+      "Hands-on, on-site",
+      "Up to 20 pods, three embedded practitioners",
+      "15–25 org-specific skills shipped live",
+      "Tailored playbook (~24 pages)",
+      "Champion roster + spark map delivered day-of",
+      "T-2wk sterile pre-flight · T+7 wrap call",
     ],
+    feature: true,
   },
   {
-    num: "03",
-    phase: "Patterns",
-    duration: "Throughout",
-    title: "Context management and session craft",
-    items: [
-      "Managing context across long Claude Code sessions",
-      "Carrying work forward without losing fidelity",
-      "When to start fresh vs. continue a session",
-      "Setting up Cowork for autonomous task execution",
+    n: "03",
+    kind: "Intensive",
+    title: (
+      <>
+        Two-day <em>deep intensive.</em>
+      </>
+    ),
+    when: "Two consecutive days",
+    who: "Up to 60 attendees · curated",
+    crew: "Full crew · embedded both days",
+    price: "From $90k",
+    desc: "Two days, full crew, deep. For organizations who want substantively more shipped, more champions identified, more workflows transformed — not just sparked. Day one mirrors the half-day arc; day two doubles down on skills, autonomous task runners, and the org-specific patterns your champions will run with for a quarter.",
+    bullets: [
+      "Two full days hands-on · same crew throughout",
+      "30–40 skills shipped live, in your repo",
+      "Tailored playbook (~40 pages, printed + digital)",
+      "Department-level workflow audits",
+      "Champion onboarding mini-workshop on day 2",
+      "T+30 follow-up working session included",
     ],
   },
 ]
 
-const audiences = [
+const faqs: { q: string; a: string }[] = [
   {
-    idx: "A.01",
-    title: "Engineering teams",
-    description: "Ship features faster with AI-assisted development patterns that actually hold up in production.",
+    q: "Will this embarrass executives who haven't touched a terminal in years?",
+    a: 'No — and that\'s not an accident. See "Why the room is safe" above. Mixed-skill pods, a rotating keyboard, no public coding, no "stand up and demo." The shape of the room makes embarrassment impossible by design, not by hope.',
   },
   {
-    idx: "A.02",
-    title: "GTM & marketing teams",
-    description: "Build automated research and content pipelines that run while you sleep.",
+    q: "Can you actually handle a hundred attendees?",
+    a: "Yes — it's the engagement we run most often. We split the room into roughly twenty pods of 4–5 with one keyboard owner each. The three of us rotate through, embedded — roughly seven pods per practitioner, but in practice we float to where the action is.",
   },
   {
-    idx: "A.03",
-    title: "Technical leaders",
-    description: "See what AI-assisted development looks like in practice so you can set strategy for your org.",
+    q: "Our laptops are locked down. Our IT team is twitchy. Now what?",
+    a: "We send you a laptop image, install script, and account checklist two weeks before the workshop. Your IT team runs it; we're on Slack if anything breaks. We dry-run three random machines remotely three days before. The sterile pre-flight is non-negotiable for a reason.",
+  },
+  {
+    q: "Our engineering team is already shipping with Claude Code. Won't they be bored?",
+    a: "They're the engine. We pair them inside mixed pods, where they become the local expert and walk a non-engineer across the chat → code bridge. Most engineers tell us afterward it was the most fun part of their week. If you specifically want engineering-only depth, the half-day single-team shape is the right pick.",
+  },
+  {
+    q: "Half-day vs. two-day — which is right for us?",
+    a: "If your goal is to spark adoption across the org and identify champions, the half-day is plenty. If your goal is substantive transformation — workflows actually replaced, autonomous task runners shipped, your team operating in a new mode — book the two-day intensive. The collaboration-week shape sits in between.",
+  },
+  {
+    q: "Do you do retainers or ongoing engagements?",
+    a: "Yes, but only after we've run a workshop together first. We need to have set a foundation with your team before ongoing work makes sense — otherwise we'd be guessing at where the leverage actually is. Mention it on the scoping call.",
+  },
+  {
+    q: "Can you do this remote-only?",
+    a: "Yes, with caveats. The pod mechanic translates to breakout rooms reasonably well; the embedded-practitioner mechanic doesn't translate as cleanly. We discount remote engagements meaningfully, and we'll be straight with you about what changes.",
+  },
+  {
+    q: "How is this different from an Anthropic-led workshop?",
+    a: "Anthropic teaches the product. We teach what doing the rollout inside an org actually looks like — change management, the bridge from chat to code, the skills layer that turns one person's win into an org-wide habit. We co-hosted with Anthropic in SF in Feb 2026. We're orthogonal, not competitive.",
   },
 ]
 
-const credentials = [
-  "14 years shipping production systems",
-  "Previously Staff DevRel at Pinecone, Cloudflare, Gruntwork",
-  "DevSecCon 2025 keynote speaker",
-  "AI Engineering World Fair workshop instructor (70+ engineers)",
-  "Workshop co-hosted with Anthropic, February 2026",
-  "35,000+ readers on zackproser.com",
+type Person = {
+  id: string
+  tag: string
+  role: string
+  name: React.ReactNode
+  bio: string
+  creds: string[]
+  photo?: string
+}
+
+const people: Person[] = [
+  {
+    id: "zack",
+    tag: "Lead",
+    role: "Applied AI · WorkOS",
+    name: (
+      <>
+        Zachary <em>Proser</em>
+      </>
+    ),
+    bio: "One of five on the Applied AI team at WorkOS supporting the entire org with internal tooling, AI enablement, training, and harnesses. WorkOS powers auth at OpenAI, Cursor, and most of the labs you've heard of. Ships production Claude Code daily — watchOS apps, MCP integrations, full-stack features.",
+    creds: [
+      "14 years shipping production systems",
+      "Previously Staff DevRel at Pinecone, Cloudflare, Gruntwork",
+      "AIE NY & AIE London workshop instructor",
+      "DevSecCon 2025 keynote speaker",
+      "5,000+ readers on Modern Coding",
+    ],
+    photo: ZACK_PORTRAIT,
+  },
+  {
+    id: "nick-nisi",
+    tag: "Co-lead",
+    role: "EM · DX / AI · WorkOS",
+    name: (
+      <>
+        Nick <em>Nisi</em>
+      </>
+    ),
+    bio: "Engineering manager for WorkOS's DX / AI team. Same depth as Zack on Claude Code; ships the internal harnesses other teams build on top of. Co-instructed at AIE NY and AIE London.",
+    creds: [
+      "Engineering manager · DX / AI · WorkOS",
+      "Co-host · AIE NY workshop",
+      "Co-host · AIE London workshop",
+      "Long-time JS & tooling community voice",
+    ],
+  },
+  {
+    id: "nick-cannariato",
+    tag: "Senior practitioner",
+    role: "Senior Solutions Engineer · AI Practitioner",
+    name: (
+      <>
+        Nick <em>Cannariato</em>
+      </>
+    ),
+    bio: "Senior solutions engineer with a developer-tools tour-of-duty: Twilio, Heroku, Zapier, GitHub. Knows enterprise rollouts from inside the room — what melts, what scales, what your IT team will actually approve.",
+    creds: [
+      "Ex-Twilio · Heroku · Zapier · GitHub",
+      "Embedded with rollouts at Fortune-scale orgs",
+      "Specializes in adoption + change management",
+      'Brings the "what about IT?" sanity check',
+    ],
+  },
 ]
 
-export default function ClaudeCoworkWorkshop() {
+export default function ClaudeWorkshopsPage() {
   return (
     <div className="editorial-home flex flex-col min-h-screen text-charcoal-50 dark:text-parchment-100 theme-transition">
       <main className="flex-1">
-        {/* ----- Hero ----- */}
-        <section className="pt-16 pb-12 md:pt-24 md:pb-16">
+        {/* ============ Hero ============ */}
+        <section className="cw-hero pt-16 pb-12 md:pt-24 md:pb-16">
           <div className="container mx-auto max-w-6xl px-4 md:px-6 grid gap-10 lg:grid-cols-[1.35fr_1fr] lg:items-start">
             <div>
-              <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
-                <Link href="/" className="hover:text-burnt-400 dark:hover:text-amber-400">Home</Link>
-                <span className="mx-2 opacity-40">/</span>
-                <Link href="/speaking" className="hover:text-burnt-400 dark:hover:text-amber-400">Workshops</Link>
-                <span className="mx-2 opacity-40">/</span>
-                <span>Claude Cowork</span>
+              <div className="cw-crumb">
+                <Link href="/">Home</Link>
+                <span className="sep">/</span>
+                <Link href="/speaking">Workshops</Link>
+                <span className="sep">/</span>
+                <b>Claude for enterprise</b>
               </div>
-              <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100">
-                Claude Cowork —{' '}
-                <span className="text-burnt-400 dark:text-amber-400">build</span>, don&apos;t watch.
+
+              <h1 className="editorial-hero-h1 text-charcoal-50 dark:text-parchment-100 mt-4">
+                Claude workshops for organizations <em>doing the rollout.</em>
               </h1>
+
               <p className="editorial-lede text-parchment-600 dark:text-slate-300">
-                Most AI workshops teach you to prompt. This one teaches you to ship.
-                A two-hour, hands-on session where your team builds a real GTM workflow
-                — ICP research, competitive data, cold email, content — with Claude Code
-                and Cowork running autonomously.
+                Three practitioners. Half-day to two-day. Up to one hundred leaders shipping with Claude
+                by the end of the session — including the ones who haven&apos;t opened a terminal in a decade.
               </p>
+
               <div className="editorial-secondary text-parchment-600 dark:text-slate-400 mt-6">
-                <Link href="/contact">Book a workshop →</Link>
+                <a className="cw-cta-mono" href="#book">Book a workshop →</a>
                 <span>·</span>
-                <Link href="/speaking">All talks →</Link>
+                <a className="cw-cta-mono" href="#engagements">Engagement shapes →</a>
                 <span>·</span>
-                <a href="#flow">Jump to the flow →</a>
+                <a className="cw-cta-mono" href="#arc">Jump to the arc →</a>
               </div>
+
               <dl className="editorial-meta text-parchment-600 dark:text-slate-400">
                 <dt>Format</dt>
-                <dd>Hands-on. Not a lecture. Attendees build alongside.</dd>
-                <dt>Co-hosted</dt>
-                <dd>WorkOS × Anthropic, February 2026</dd>
+                <dd>Hands-on. Not a lecture. Pods of four to five, practitioner per pod, mixed-skill on purpose.</dd>
+                <dt>Crew</dt>
+                <dd>One, two, or three practitioners — scales with your room.</dd>
+                <dt>Shape</dt>
+                <dd>Half-day, full-day, or two-day intensive.</dd>
               </dl>
             </div>
 
             <div>
-              <div className="editorial-rule-label text-parchment-600 dark:text-slate-400 mb-3">
-                Recorded live
-              </div>
-              <div className="rounded-md overflow-hidden border border-parchment-300 dark:border-slate-700 shadow-lg">
-                <YoutubeEmbed
-                  urls="https://www.youtube.com/watch?v=8bjcx5Hkj5w"
-                  title="Claude Cowork Workshop with Anthropic — February 2026"
+              <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">In the room</div>
+              <div className="relative aspect-[4/5] overflow-hidden rounded-sm border border-parchment-300 dark:border-slate-700 shadow-md">
+                <Image
+                  src={AUDIENCE_PHOTO}
+                  alt="Workshop pods mid-build at AI Engineer World's Fair"
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 40vw"
+                  className="object-cover"
                 />
               </div>
-              <p className="mt-3 text-[12px] font-mono uppercase tracking-wider text-parchment-600 dark:text-slate-400">
-                SF · WorkOS × Anthropic · Feb 2026
+              <p className="mt-3 font-mono text-[11px] tracking-[0.1em] uppercase text-parchment-600 dark:text-slate-400">
+                AIE · 2025 — pods mid-build
               </p>
             </div>
           </div>
         </section>
 
-        {/* ----- Stat slab ----- */}
+        {/* ============ Stat slab ============ */}
         <section className="pb-12">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
             <div className="editorial-stats text-charcoal-50 dark:text-parchment-100">
               <div className="editorial-stat">
                 <div className="editorial-stat-num">
-                  2<span className="unit">hr</span>
+                  3<span className="unit">crew</span>
                 </div>
                 <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
-                  Hands-on, not lecture
+                  Practitioners on-site
                 </div>
               </div>
               <div className="editorial-stat">
                 <div className="editorial-stat-num">
-                  20<span className="unit">seats</span>
+                  100<span className="unit">leaders</span>
                 </div>
                 <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
-                  Max per session
+                  Per collaboration-week session
                 </div>
               </div>
               <div className="editorial-stat">
                 <div className="editorial-stat-num">
-                  $750<span className="unit">/pp</span>
+                  ½–2<span className="unit">days</span>
                 </div>
                 <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
-                  Team pricing available
+                  Shape to your week
                 </div>
               </div>
               <div className="editorial-stat">
                 <div className="editorial-stat-num">
-                  70<span className="unit">+</span>
+                  15–40<span className="unit">skills</span>
                 </div>
                 <div className="editorial-stat-label text-parchment-600 dark:text-slate-400">
-                  Engineers trained at AIE
+                  Shipped live, in your repo
                 </div>
               </div>
             </div>
           </div>
         </section>
 
-        {/* ----- § 01 Workshop catalog (single card, full product treatment) ----- */}
+        {/* ============ § 01 The job to be done ============ */}
         <section className="py-14">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <SectionHead num="01" title="The workshop" moreHref="/contact" moreLabel="Book for your team →" />
-            <article className="editorial-card grid md:grid-cols-[1.1fr_1fr] overflow-hidden">
-              <div className="relative aspect-[4/3] md:aspect-auto md:min-h-[420px]">
-                <Image
-                  src="https://zackproser.b-cdn.net/images/workshop-zack-presenting-v2.webp"
-                  alt="Zack presenting the Claude Cowork workshop at WorkOS x Anthropic, SF, February 2026"
-                  fill
-                  sizes="(max-width: 768px) 100vw, 50vw"
-                  className="object-cover"
-                />
-                <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-charcoal-50/40 dark:to-charcoal-500/60" />
-                <div className="absolute top-4 left-4 right-4 flex items-baseline justify-between">
-                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-white/90 drop-shadow">
-                    Workshop № 01
-                  </span>
-                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/80 drop-shadow">
-                    Hands-on · 2 hr
-                  </span>
-                </div>
-                <div className="absolute bottom-4 left-4 right-4 font-serif text-[28px] md:text-[36px] font-bold leading-[1.05] tracking-tight text-white drop-shadow">
-                  Claude Cowork — <span className="text-amber-400">build</span>, don&apos;t watch.
-                </div>
-              </div>
-              <div className="p-6 md:p-8 flex flex-col gap-5">
-                <div className="flex items-start justify-between gap-4">
-                  <h3 className="font-serif text-[22px] font-bold leading-tight text-charcoal-50 dark:text-parchment-100">
-                    Claude Cowork Workshop
-                  </h3>
-                  <div className="font-mono text-[11px] uppercase tracking-[0.14em] border border-burnt-400/40 dark:border-amber-400/40 text-burnt-400 dark:text-amber-400 px-2 py-1 rounded-sm whitespace-nowrap">
-                    $750 / pp
-                  </div>
-                </div>
-                <p className="text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300">
-                  Two-hour, hands-on session. Your team builds a full GTM workflow
-                  with Claude Code and Cowork — ICP identification, competitive
-                  analysis, battlecards, cold email, content, and scheduled tasks
-                  that keep producing while you&apos;re offline.
-                </p>
-                <dl className="grid grid-cols-3 gap-4 pt-4 border-t border-parchment-300/50 dark:border-slate-700/50">
-                  <div>
-                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
-                      Format
-                    </dt>
-                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
-                      2-hour, hands-on
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
-                      Team size
-                    </dt>
-                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
-                      Up to 20
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
-                      Level
-                    </dt>
-                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
-                      All levels
-                    </dd>
-                  </div>
-                </dl>
-                <div className="flex items-center justify-between pt-4 border-t border-parchment-300/50 dark:border-slate-700/50 mt-auto">
-                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
-                    Delivered WorkOS × Anthropic · Feb 2026
-                  </span>
-                  <a
-                    href="#flow"
-                    className="font-mono text-[11px] uppercase tracking-[0.14em] text-burnt-400 dark:text-amber-400 hover:underline"
-                  >
-                    Syllabus →
-                  </a>
-                </div>
-              </div>
-            </article>
+            <SectionHead
+              num="01"
+              title={
+                <>
+                  You don&apos;t have an AI problem. You have an <em>adoption</em> problem.
+                </>
+              }
+            />
+            <div className="cw-prose">
+              <p>
+                The license is bought. The pilots are running. Engineering has been on Claude Code for months.
+                But the rest of the org is either making cool emojis with the chat or quietly waiting for someone
+                else to figure it out — and your CEO is asking what&apos;s taking so long.
+              </p>
+              <p>
+                We&apos;ve watched the same pattern at every org we&apos;ve talked to this year. The bottleneck
+                is never the model. It&apos;s the change management — the cultural shift from{" "}
+                <em>&ldquo;AI is a thing engineers do&rdquo;</em> to{" "}
+                <em>&ldquo;AI is how everyone here works.&rdquo;</em> Speakers don&apos;t move that. Office hours
+                don&apos;t move that. A room of your peers shipping something together, with practitioners
+                embedded inside the pods, does.
+              </p>
+            </div>
           </div>
         </section>
 
-        {/* ----- Photo strip ----- */}
-        <section className="py-12">
+        {/* ============ § 02 Format ============ */}
+        <section id="format" className="py-14 editorial-section-alt">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
-              In the room · SF · Feb 2026
+            <SectionHead
+              num="02"
+              title={<>How the workshop runs.</>}
+              moreHref="#engagements"
+              moreLabel="Engagement shapes →"
+            />
+            <div className="cw-prose mb-8">
+              <p>
+                Workshop-shaped, not classroom-shaped. We split your room into pods of{" "}
+                <em>four to five</em>, mixed-skill on purpose — exec next to engineer next to ops next to CS.
+                Each pod has a designated keyboard owner; it rotates every fifteen minutes. The practitioners
+                float, embedded — somebody is sitting next to you when you get stuck, not raising your hand
+                on Zoom.
+              </p>
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {[
-                { src: 'https://zackproser.b-cdn.net/images/workshop-zack-presenting-v2.webp', alt: 'Zack presenting at the Claude Cowork Workshop' },
-                { src: 'https://zackproser.b-cdn.net/images/workshop-audience-coding-v2.webp', alt: 'Workshop attendees building with Claude Cowork' },
-                { src: 'https://zackproser.b-cdn.net/images/workshop-qa-lydia-zack-v2.webp', alt: "Q&A with Lydia from Anthropic's Claude Code team" },
-              ].map((img) => (
-                <div
-                  key={img.src}
-                  className="relative aspect-[4/3] overflow-hidden rounded-sm border border-parchment-300 dark:border-slate-700 shadow-md"
-                >
-                  <Image
-                    src={img.src}
-                    alt={img.alt}
-                    fill
-                    sizes="(max-width: 768px) 100vw, 33vw"
-                    className="object-cover"
-                  />
+
+            <div className="grid gap-6 md:grid-cols-3 mb-8">
+              <article className="editorial-card">
+                <div className="editorial-card-link">
+                  <div className="editorial-card-meta flex items-center justify-between">
+                    <span>F.01 · Pod</span>
+                    <span className="text-burnt-400 dark:text-amber-400">4 – 5</span>
+                  </div>
+                  <div className="editorial-card-body" style={{ padding: "20px" }}>
+                    <h3 className="editorial-card-title">Mixed-skill on purpose</h3>
+                    <p className="editorial-card-desc" style={{ WebkitLineClamp: 4 }}>
+                      Engineer + exec + ops + curious. Nobody is the most senior or the most junior at the table.
+                      Awkwardness has nowhere to land.
+                    </p>
+                    <div className="editorial-card-footer">
+                      <span className="editorial-card-read">Pod size</span>
+                      <span className="editorial-card-index">F.01</span>
+                    </div>
+                  </div>
                 </div>
+              </article>
+
+              <article className="editorial-card">
+                <div className="editorial-card-link">
+                  <div className="editorial-card-meta flex items-center justify-between">
+                    <span>F.02 · Keyboard</span>
+                    <span className="text-burnt-400 dark:text-amber-400">~15 min</span>
+                  </div>
+                  <div className="editorial-card-body" style={{ padding: "20px" }}>
+                    <h3 className="editorial-card-title">Hot seat rotates</h3>
+                    <p className="editorial-card-desc" style={{ WebkitLineClamp: 4 }}>
+                      You build, watch, build again. No &ldquo;stand up and demo to the whole room.&rdquo; The hot
+                      seat moves long enough to feel something, short enough that nobody owns the failure.
+                    </p>
+                    <div className="editorial-card-footer">
+                      <span className="editorial-card-read">Rotation</span>
+                      <span className="editorial-card-index">F.02</span>
+                    </div>
+                  </div>
+                </div>
+              </article>
+
+              <article className="editorial-card">
+                <div className="editorial-card-link">
+                  <div className="editorial-card-meta flex items-center justify-between">
+                    <span>F.03 · Crew</span>
+                    <span className="text-burnt-400 dark:text-amber-400">1 – 3</span>
+                  </div>
+                  <div className="editorial-card-body" style={{ padding: "20px" }}>
+                    <h3 className="editorial-card-title">Practitioners, not speakers</h3>
+                    <p className="editorial-card-desc" style={{ WebkitLineClamp: 4 }}>
+                      We float through the pods, embedded. Roughly seven pods per practitioner at full scale, but
+                      in practice we go where the action is.
+                    </p>
+                    <div className="editorial-card-footer">
+                      <span className="editorial-card-read">Crew size</span>
+                      <span className="editorial-card-index">F.03</span>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            </div>
+
+            <div className="grid gap-8 md:grid-cols-2 mt-8">
+              <div>
+                <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+                  What we won&apos;t do
+                </div>
+                <ul className="cw-ticks">
+                  <li>Run a deck for an hour</li>
+                  <li>Single anyone out</li>
+                  <li>Make the engineers sit through a &ldquo;what is an LLM&rdquo; slide</li>
+                  <li>Leave you with a recording and a wave goodbye</li>
+                </ul>
+              </div>
+              <div>
+                <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
+                  What we always do
+                </div>
+                <ul className="cw-ticks">
+                  <li>
+                    Build inside <em>your</em> codebase, docs, and brand
+                  </li>
+                  <li>Pair exec + IC inside each pod</li>
+                  <li>Ship org-specific skills live, in your repo</li>
+                  <li>Surface your hottest internal champions</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ============ § 03 Pre-flight ============ */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="03"
+              title={
+                <>
+                  Pre-flight. <em>The part that makes day-of work.</em>
+                </>
+              }
+            />
+            <div className="cw-prose mb-8">
+              <p>
+                The most expensive thing a workshop can do is burn the first ninety minutes on env setup.
+                We&apos;ve watched it kill rooms. So we don&apos;t.
+              </p>
+            </div>
+            <div className="cw-preflight">
+              <div className="cw-preflight-step">
+                <div className="cw-preflight-when">T-2 weeks</div>
+                <h5>Spec drop</h5>
+                <p>
+                  Laptop image, install script, account checklist. Your IT team runs it; we&apos;re on Slack
+                  if they get stuck.
+                </p>
+              </div>
+              <div className="cw-preflight-step">
+                <div className="cw-preflight-when">T-3 days</div>
+                <h5>Dry run</h5>
+                <p>
+                  We log into three random machines remotely and verify. Never goes clean on the first
+                  pass — that&apos;s the point.
+                </p>
+              </div>
+              <div className="cw-preflight-step">
+                <div className="cw-preflight-when">T-0</div>
+                <h5>Day-of</h5>
+                <p>We arrive 90 min early. Tables labeled. Pods pre-assigned, mixed-skill on purpose.</p>
+              </div>
+              <div className="cw-preflight-step">
+                <div className="cw-preflight-when">T+7 days</div>
+                <h5>Wrap</h5>
+                <p>
+                  Recordings posted. Skills merged. Playbook delivered. Sync with your AI lead — we don&apos;t
+                  disappear.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ============ § 04 The arc ============ */}
+        <section id="arc" className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="04"
+              title={
+                <>
+                  The arc · <em>chat</em> to <em>code</em>, inside one afternoon.
+                </>
+              }
+            />
+            <div className="cw-prose mb-6">
+              <p>
+                The single biggest shift for non-engineering leaders is realizing that the wall between
+                &ldquo;chat with Claude&rdquo; and &ldquo;Claude is building software for me&rdquo; is about{" "}
+                <em>thirty minutes of practice</em>. We walk every pod across it. Two-day intensives double up
+                on Phase 03 and Phase 04 — that&apos;s where the real organizational compounding happens.
+              </p>
+            </div>
+            {phases.map((p) => (
+              <div className="cw-phase" key={p.code}>
+                <div className="cw-phase-head">
+                  <span className="code">
+                    P{p.code} · {p.kind}
+                  </span>
+                  <span className="time">{p.time}</span>
+                </div>
+                <div className="cw-phase-body">
+                  <h4>{p.title}</h4>
+                  <p>{p.desc}</p>
+                </div>
+                <div className="cw-phase-tools">
+                  {p.tools.map((t) => (
+                    <span key={t}>{t}</span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ============ § 05 Compassion ============ */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="05"
+              title={
+                <>
+                  We&apos;re still the ones who <em>sweat.</em>
+                </>
+              }
+            />
+            <div className="cw-prose mb-2">
+              <p>
+                We&apos;ve each spent fifteen years learning to type fast. Now we dictate. Nick and I still text
+                each other when something feels strange about that — when we realize we&apos;ve lost a skill we
+                used to be proud of. We get the whiplash personally. So when your hundredth leader puts their
+                hands on Claude Code for the first time and freezes, we know exactly what they&apos;re feeling.
+              </p>
+              <p>
+                Compassion isn&apos;t a posture we put on for the workshop. It&apos;s the <em>only</em> reason
+                any of this works. People learn when they feel safe. They feel safe when nobody at the table
+                is going to be ridiculed for what they don&apos;t know. The room is calibrated around that,
+                deliberately, top to bottom.
+              </p>
+            </div>
+
+            <div className="cw-principles">
+              <div>
+                <div className="label">Principle 01</div>
+                <h4>Mixed-skill pods. Always.</h4>
+                <p>
+                  Each pod has an exec, an engineer who&apos;s been on Claude Code for months, and a couple of
+                  curious neutrals. Nobody is the most senior or the most junior at the table.
+                </p>
+              </div>
+              <div>
+                <div className="label">Principle 02</div>
+                <h4>The keyboard rotates.</h4>
+                <p>
+                  You build, you watch, you build again. There is no &ldquo;stand up and demo to the whole
+                  room.&rdquo; The hot seat moves every fifteen minutes by design.
+                </p>
+              </div>
+              <div>
+                <div className="label">Principle 03</div>
+                <h4>We&apos;ve been in the seat.</h4>
+                <p>
+                  Every practitioner has personally been bad at Claude in front of someone who was better at it.
+                  We remember exactly what it felt like. We lead with that memory.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ============ § 06 Artifacts ============ */}
+        <section className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="06"
+              title={
+                <>
+                  The workshop is the <em>spark.</em> The artifacts are the <em>fire.</em>
+                </>
+              }
+            />
+            <div className="cw-prose mb-6">
+              <p>
+                A workshop that ends when the room empties is worth roughly nothing thirty days later. Every
+                engagement ships a kit your champions can carry forward — built during the session, signed off
+                by you, ready to share on Monday morning. The biggest of these is the <em>tailored playbook</em>,
+                written for your org by name.
+              </p>
+            </div>
+            <div className="grid gap-6 md:grid-cols-2">
+              {artifacts.map((a) => (
+                <article className="editorial-card" key={a.n}>
+                  <div className="editorial-card-link">
+                    <div className="editorial-card-meta flex items-center justify-between">
+                      <span>A.{a.n} · Artifact</span>
+                      <span className="text-burnt-400 dark:text-amber-400">{a.tag}</span>
+                    </div>
+                    <div className="editorial-card-body" style={{ padding: "20px" }}>
+                      <h3 className="editorial-card-title">{a.title}</h3>
+                      <p className="editorial-card-desc" style={{ WebkitLineClamp: 6 }}>
+                        {a.desc}
+                      </p>
+                      <div className="editorial-card-footer">
+                        <span className="editorial-card-read">Artifact {a.n}</span>
+                        <span className="editorial-card-index">A.{a.n}</span>
+                      </div>
+                    </div>
+                  </div>
+                </article>
               ))}
             </div>
-            <p className="mt-3 text-[11px] font-mono uppercase tracking-wider text-parchment-600 dark:text-slate-400 text-center">
-              Photos by Mark Robinson
+          </div>
+        </section>
+
+        {/* ============ § 07 Team ============ */}
+        <section id="team" className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="07"
+              title={
+                <>
+                  Three practitioners. <em>One shipping crew.</em>
+                </>
+              }
+            />
+            <div className="cw-prose mb-2">
+              <p>
+                You&apos;re not hiring a speaker. You&apos;re hiring three full-time builders at companies that
+                use Claude in anger every day. We run workshops as the side of our job that translates what we
+                do daily into something your team can pick up by 5pm.
+              </p>
+            </div>
+
+            {people.map((person) => (
+              <div className="cw-person" key={person.id}>
+                <div className="cw-person-av">
+                  {person.photo ? (
+                    <Image
+                      src={person.photo}
+                      alt={person.id}
+                      fill
+                      sizes="140px"
+                      className="object-cover"
+                    />
+                  ) : (
+                    <div className="cw-person-av-placeholder">Photo</div>
+                  )}
+                </div>
+                <div>
+                  <div className="cw-person-meta">
+                    <span className="tag">{person.tag}</span>
+                    <span className="role">{person.role}</span>
+                  </div>
+                  <h4>{person.name}</h4>
+                  <div className="cw-person-bio">{person.bio}</div>
+                  <dl className="cw-creds">
+                    {person.creds.map((c, i) => (
+                      <div key={c} className="contents">
+                        <dt>{String(i + 1).padStart(2, "0")}</dt>
+                        <dd>{c}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ============ § 08 Engagements (pricing) ============ */}
+        <section id="engagements" className="py-14 editorial-section-alt">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
+            <SectionHead
+              num="08"
+              title={
+                <>
+                  Engagements · <em>three shapes</em>, one shipping crew.
+                </>
+              }
+              moreHref="/contact"
+              moreLabel="Book a scoping call →"
+            />
+            <div className="cw-prose mb-8">
+              <p>
+                Every engagement is fixed-scope, fixed-price, held the moment you sign. No hourly. No discovery
+                phase before you can plan a budget. You pick a shape, we hold the date, we ship.
+              </p>
+            </div>
+
+            {engagements.map((e) => (
+              <article className={`cw-engagement ${e.feature ? "feature" : ""}`} key={e.n}>
+                <div className="cw-engagement-left">
+                  <div className="meta">
+                    <b>Workshop № {e.n}</b>
+                    <span>
+                      {e.kind} · {e.when}
+                    </span>
+                  </div>
+                  <div className="title">{e.title}</div>
+                  <span className="price">{e.price}</span>
+                </div>
+                <div className="cw-engagement-right">
+                  <p className="desc">{e.desc}</p>
+                  <dl className="info">
+                    <div>
+                      <dt>Who</dt>
+                      <dd>{e.who}</dd>
+                    </div>
+                    <div>
+                      <dt>Crew</dt>
+                      <dd>{e.crew}</dd>
+                    </div>
+                    <div>
+                      <dt>Format</dt>
+                      <dd>Hands-on</dd>
+                    </div>
+                  </dl>
+                  <ul className="cw-ticks">
+                    {e.bullets.map((b) => (
+                      <li key={b}>{b}</li>
+                    ))}
+                  </ul>
+                  <div className="cw-engagement-footer">
+                    <span>Scope &amp; held in 48 hr</span>
+                    <Link href="/contact" className="cw-cta-mono">
+                      Scope this →
+                    </Link>
+                  </div>
+                </div>
+              </article>
+            ))}
+
+            <div className="cw-retainer">
+              <div className="cw-retainer-meta">
+                <b>§ 08.½ · Ongoing partnership</b>
+                <span className="right">Available · post-workshop only</span>
+              </div>
+              <h3>For orgs we&apos;ve already shipped with.</h3>
+              <p>
+                Once we&apos;ve run a workshop together and the foundation is in place, some orgs ask us to
+                keep showing up — running monthly champion office hours, reviewing skill PRs, sitting in on
+                quarterly AI strategy. We&apos;re selective about retainers: we only take them after a
+                workshop, because <em>that&apos;s how we know we can actually move the needle for your team.</em>{" "}
+                Monthly, scoped to your scale, starting in the low five figures.
+              </p>
+              <Link href="/contact" className="cw-cta-mono">
+                Mention it on the scoping call →
+              </Link>
+            </div>
+
+            <p className="mt-8 text-[14px] leading-relaxed text-parchment-500 dark:text-slate-400 max-w-[68ch]">
+              Travel for the crew is billed at cost, separately. Venue, catering, and per-diems are on you. We
+              can deliver remote — it&apos;s effective at smaller sizes; we&apos;ll be straight with you about
+              what changes.
             </p>
           </div>
         </section>
 
-        {/* ----- The pitch (serif pull quote) ----- */}
-        <section className="py-14 editorial-section-alt">
-          <div className="container mx-auto max-w-4xl px-4 md:px-6">
+        {/* ============ § 09 In the room (photo strip) ============ */}
+        <section className="py-14">
+          <div className="container mx-auto max-w-6xl px-4 md:px-6">
             <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
-              The pitch
+              In the room · AIE · WorkOS × Anthropic
             </div>
-            <blockquote className="font-serif text-2xl md:text-[32px] leading-[1.25] tracking-tight text-charcoal-50 dark:text-parchment-100">
-              I&apos;ve been shipping production code with Claude Code daily for over
-              a year — watchOS apps, MCP integrations, full-stack features. This
-              workshop compresses months of hard-won patterns into a single
-              hands-on session. You&apos;ll walk in knowing Claude exists. You&apos;ll
-              walk out knowing how to{' '}
-              <span className="text-burnt-400 dark:text-amber-400">make it do real work</span>
-              {' '}— and how to set up Cowork tasks that keep producing while
-              you&apos;re offline.
-            </blockquote>
-            <div className="mt-6 font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
-              — Zachary Proser · Applied AI @ WorkOS
+            <div className="grid gap-4 md:grid-cols-3">
+              {[
+                { src: ZACK_PHOTO, alt: "Workshop opening", caption: "Workshop opening" },
+                { src: AUDIENCE_PHOTO, alt: "The room mid-build", caption: "The room mid-build" },
+                { src: QA_PHOTO, alt: "Q&A · Anthropic · Feb 2026", caption: "Q&A · Anthropic · Feb 2026" },
+              ].map((img) => (
+                <figure key={img.src} className="m-0">
+                  <div className="relative aspect-[4/3] overflow-hidden rounded-sm border border-parchment-300 dark:border-slate-700 shadow-sm">
+                    <Image
+                      src={img.src}
+                      alt={img.alt}
+                      fill
+                      sizes="(max-width: 768px) 100vw, 33vw"
+                      className="object-cover"
+                    />
+                  </div>
+                  <figcaption className="mt-3 font-mono text-[11px] tracking-[0.1em] uppercase text-parchment-600 dark:text-slate-400">
+                    {img.caption}
+                  </figcaption>
+                </figure>
+              ))}
             </div>
+            <p className="mt-4 text-center font-mono text-[11px] tracking-[0.1em] uppercase text-parchment-500 dark:text-slate-500">
+              AI Engineer World&apos;s Fair · New York &amp; London · WorkOS internal Claude Day · SF
+            </p>
           </div>
         </section>
 
-        {/* ----- § 01 Workshop flow ----- */}
-        <section id="flow" className="py-14">
+        {/* ============ § 10 FAQ ============ */}
+        <section className="py-14">
           <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <SectionHead num="02" title="What you'll build" moreHref="/contact" moreLabel="Book a session →" />
-            <div className="grid gap-6 md:grid-cols-3">
-              {workshopPhases.map((phase) => (
-                <article key={phase.num} className="editorial-card">
-                  <div className="editorial-card-link">
-                    <div className="editorial-card-meta flex items-center justify-between">
-                      <span>P{phase.num} · {phase.phase}</span>
-                      <span className="text-burnt-400 dark:text-amber-400">{phase.duration}</span>
-                    </div>
-                    <div className="editorial-card-body" style={{ padding: '20px' }}>
-                      <h3 className="editorial-card-title">{phase.title}</h3>
-                      <ul className="mt-2 space-y-2 text-[14px] leading-snug text-parchment-600 dark:text-slate-300">
-                        {phase.items.map((item) => (
-                          <li key={item} className="flex items-start gap-2">
-                            <span className="text-burnt-400 dark:text-amber-400 font-mono mt-0.5">▸</span>
-                            <span>{item}</span>
-                          </li>
-                        ))}
-                      </ul>
-                      <div className="editorial-card-footer">
-                        <span className="editorial-card-read">Phase {phase.num}</span>
-                        <span className="editorial-card-index">P.{phase.num}</span>
-                      </div>
-                    </div>
+            <SectionHead num="10" title={<>Frequently — and reasonably — asked.</>} />
+            <div className="cw-faq-list">
+              {faqs.map((f, i) => (
+                <div className="cw-faq-item" key={f.q}>
+                  <div className="cw-faq-meta">Q.{String(i + 1).padStart(2, "0")}</div>
+                  <div>
+                    <h4>{f.q}</h4>
+                    <p>{f.a}</p>
                   </div>
-                </article>
+                </div>
               ))}
             </div>
           </div>
         </section>
 
-        {/* ----- § 02 Who it's for ----- */}
-        <section className="py-14 editorial-section-alt">
-          <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <SectionHead num="03" title="Who this is for" moreHref="/contact" moreLabel="Tell me about your team →" />
-            <div className="grid gap-6 md:grid-cols-3">
-              {audiences.map((a) => (
-                <article key={a.idx} className="editorial-card">
-                  <div className="editorial-card-link">
-                    <div className="editorial-card-meta flex items-center justify-between">
-                      <span>{a.idx} · Audience</span>
-                    </div>
-                    <div className="editorial-card-body" style={{ padding: '20px' }}>
-                      <h3 className="editorial-card-title">{a.title}</h3>
-                      <p className="editorial-card-desc" style={{ WebkitLineClamp: 4 }}>{a.description}</p>
-                      <div className="editorial-card-footer">
-                        <span className="editorial-card-read">Fit check →</span>
-                        <span className="editorial-card-index">{a.idx}</span>
-                      </div>
-                    </div>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* ----- § 04 Custom engagement upsell ----- */}
-        <section className="py-14">
-          <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <SectionHead num="04" title="Not in the catalog?" moreHref="/contact" moreLabel="Scope a project →" />
-            <article className="editorial-card grid md:grid-cols-[1.1fr_1fr] overflow-hidden">
-              <div className="relative min-h-[260px] md:min-h-[360px] bg-gradient-to-br from-burnt-400/25 via-parchment-200 to-parchment-100 dark:from-amber-400/20 dark:via-slate-800 dark:to-slate-900 flex items-center justify-center">
-                <div className="absolute top-4 left-4 right-4 flex items-baseline justify-between">
-                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
-                    Bespoke
-                  </span>
-                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
-                    Custom scope
-                  </span>
-                </div>
-                <span className="font-serif text-[160px] md:text-[220px] leading-none text-burnt-400 dark:text-amber-400 select-none">
-                  ✱
-                </span>
-                <div className="absolute bottom-4 left-4 right-4 font-serif text-[22px] md:text-[28px] font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100">
-                  Designed around <span className="text-burnt-400 dark:text-amber-400">your stack</span>, your team, your deadline.
-                </div>
-              </div>
-              <div className="p-6 md:p-8 flex flex-col gap-5">
-                <div className="flex items-start justify-between gap-4">
-                  <h3 className="font-serif text-[22px] font-bold leading-tight text-charcoal-50 dark:text-parchment-100">
-                    Custom engagement
-                  </h3>
-                  <div className="font-mono text-[11px] uppercase tracking-[0.14em] border border-parchment-400 dark:border-slate-600 text-charcoal-50 dark:text-parchment-100 px-2 py-1 rounded-sm whitespace-nowrap">
-                    On request
-                  </div>
-                </div>
-                <p className="text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300">
-                  When Claude Cowork isn&apos;t the right shape — different team,
-                  different stack, different definition of done — we scope a
-                  workshop tuned to your codebase and the artifact you actually
-                  want to walk away with. Tell me what your team needs and when.
-                </p>
-                <dl className="grid grid-cols-3 gap-4 pt-4 border-t border-parchment-300/50 dark:border-slate-700/50">
-                  <div>
-                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
-                      Starts with
-                    </dt>
-                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
-                      30-min scoping call
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
-                      Delivered
-                    </dt>
-                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
-                      Live + recorded
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500">
-                      Leave with
-                    </dt>
-                    <dd className="mt-1 font-mono text-[13px] font-semibold text-charcoal-50 dark:text-parchment-100">
-                      Code + playbook
-                    </dd>
-                  </div>
-                </dl>
-                <div className="flex items-center justify-between pt-4 border-t border-parchment-300/50 dark:border-slate-700/50 mt-auto">
-                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
-                    Reply within 48 hours
-                  </span>
-                  <Link
-                    href="/contact"
-                    className="font-mono text-[11px] uppercase tracking-[0.14em] text-burnt-400 dark:text-amber-400 hover:underline"
-                  >
-                    Scope a project →
-                  </Link>
-                </div>
-              </div>
-            </article>
-          </div>
-        </section>
-
-        {/* ----- Instructor colophon ----- */}
-        <section className="py-14">
-          <div className="container mx-auto max-w-6xl px-4 md:px-6">
-            <div className="editorial-rule-label text-parchment-600 dark:text-slate-400">
-              Your instructor
-            </div>
-            <div className="grid gap-10 md:grid-cols-[1fr_1.2fr] items-start">
-              <div>
-                <h3 className="font-serif text-3xl font-bold leading-tight tracking-tight text-charcoal-50 dark:text-parchment-100">
-                  Zachary <span className="text-burnt-400 dark:text-amber-400">Proser</span>
-                </h3>
-                <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.14em] text-parchment-600 dark:text-slate-400">
-                  Applied AI · WorkOS
-                </p>
-                <p className="mt-5 text-[15px] leading-relaxed text-parchment-600 dark:text-slate-300 max-w-[48ch]">
-                  I ship production systems daily with Claude Code, Cowork, and voice-first
-                  tooling. I teach the patterns I actually use — no vapor.
-                </p>
-              </div>
-              <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-3 text-[14px] border-t border-parchment-300 dark:border-slate-700 pt-5">
-                {credentials.map((c, i) => (
-                  <div key={c} className="contents">
-                    <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment-500 dark:text-slate-500 pt-1">
-                      {String(i + 1).padStart(2, '0')}
-                    </dt>
-                    <dd className="text-charcoal-50 dark:text-parchment-100">{c}</dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-          </div>
-        </section>
-
-        {/* ----- Final CTA ----- */}
-        <section className="py-20 editorial-section-alt">
+        {/* ============ § 11 Closing CTA ============ */}
+        <section id="book" className="py-20 editorial-section-alt">
           <div className="container mx-auto max-w-4xl px-4 md:px-6 text-center">
             <div className="editorial-eyebrow text-parchment-600 dark:text-slate-400">
               Ready when you are
             </div>
-            <h2 className="font-serif text-3xl md:text-4xl font-bold leading-tight tracking-tight mt-4 text-charcoal-50 dark:text-parchment-100">
-              On-site, virtual, conference, or private team session —
-              tell me what you need and when.
+            <h2 className="font-serif text-3xl md:text-4xl font-extrabold leading-tight tracking-tight mt-4 text-charcoal-50 dark:text-parchment-100">
+              Tell us when your <em className="text-burnt-400 dark:text-amber-400 italic">collaboration week</em> is.
             </h2>
+            <p className="editorial-lede text-parchment-600 dark:text-slate-300 mx-auto mt-4">
+              30-minute scoping call. We send you a proposal within 48 hours. We hold the date the moment you
+              sign — typically booked out 6–10 weeks.
+            </p>
             <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
               <Link
                 href="/contact"
                 className="inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-md text-white bg-burnt-400 hover:bg-burnt-500 dark:bg-amber-400 dark:hover:bg-amber-500 dark:text-charcoal-500 transition-colors"
               >
-                Book a workshop →
+                Book a 30-min scoping call →
               </Link>
               <Link
                 href="/speaking"
                 className="inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-md border border-parchment-400 dark:border-slate-600 text-charcoal-50 dark:text-parchment-100 hover:border-burnt-400 dark:hover:border-amber-400 hover:text-burnt-400 dark:hover:text-amber-400 transition-colors"
               >
-                View all talks →
+                View all workshops &amp; talks
               </Link>
+            </div>
+
+            <div className="cw-close-kit">
+              <div className="cw-close-kit-label">What to send in the first email</div>
+              <ul className="cw-ticks">
+                <li>Headcount and mix (eng / non-eng / leadership ratios)</li>
+                <li>Target date range or collaboration-week dates</li>
+                <li>What&apos;s already been rolled out internally</li>
+                <li>The CEO&apos;s actual phrasing of what they want</li>
+              </ul>
             </div>
           </div>
         </section>

--- a/src/components/SectionHead.tsx
+++ b/src/components/SectionHead.tsx
@@ -1,9 +1,10 @@
 import Link from 'next/link'
 import type { Route } from 'next'
+import type { ReactNode } from 'react'
 
 interface SectionHeadProps {
   num: string
-  title: string
+  title: ReactNode
   moreHref?: string
   moreLabel?: string
 }

--- a/src/styles/claude-cowork.css
+++ b/src/styles/claude-cowork.css
@@ -143,6 +143,7 @@ ul.cw-ticks li em { color: #2c3e50; font-style: italic; font-weight: 600; }
 @media (max-width: 640px) {
   .cw-preflight { grid-template-columns: 1fr; }
   .cw-preflight-step { border-right: 0; border-bottom: 1px solid rgba(139, 115, 85, 0.2); }
+  .dark .cw-preflight-step { border-bottom-color: rgba(148, 163, 184, 0.18); }
   .cw-preflight-step:last-child { border-bottom: 0; }
 }
 

--- a/src/styles/claude-cowork.css
+++ b/src/styles/claude-cowork.css
@@ -12,13 +12,11 @@
  *   - 4-up preflight grid
  * ============================================================ */
 
-/* Italic accent inside the section title and other shared headers */
-.editorial-section-title em,
+/* Italic accent inside hero headers */
 .cw-hero h1 em {
   color: #e67e22;
   font-style: italic;
 }
-.dark .editorial-section-title em,
 .dark .cw-hero h1 em {
   color: #f39c12;
 }

--- a/src/styles/claude-cowork.css
+++ b/src/styles/claude-cowork.css
@@ -1,0 +1,656 @@
+/* ============================================================
+ * Claude Workshops page — page-local classes that extend the
+ * editorial-home.css primitives and Tailwind tokens with
+ * patterns specific to /workshops/claude-cowork:
+ *   - phase rows (P01 timeline)
+ *   - engagement rows (Workshop № 01 / 02 / 03 pricing slabs)
+ *   - retainer block
+ *   - compassion principles grid
+ *   - person rows
+ *   - photo strip
+ *   - FAQ rows
+ *   - 4-up preflight grid
+ * ============================================================ */
+
+/* Italic accent inside the section title and other shared headers */
+.editorial-section-title em,
+.cw-hero h1 em {
+  color: #e67e22;
+  font-style: italic;
+}
+.dark .editorial-section-title em,
+.dark .cw-hero h1 em {
+  color: #f39c12;
+}
+
+/* ---------------- Crumb above hero ---------------- */
+.cw-crumb {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8b7355;
+}
+.dark .cw-crumb { color: #94a3b8; }
+.cw-crumb a { color: inherit; text-decoration: none; }
+.cw-crumb a:hover { color: #e67e22; }
+.dark .cw-crumb a:hover { color: #f39c12; }
+.cw-crumb .sep { opacity: 0.4; }
+.cw-crumb b { color: #2c3e50; font-weight: 600; }
+.dark .cw-crumb b { color: #fbf7f0; }
+
+/* ---------------- Inline mono CTA ---------------- */
+.cw-cta-mono {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #e67e22;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(230, 126, 34, 0.4);
+  padding-bottom: 2px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.cw-cta-mono:hover { color: #d35400; border-color: #d35400; }
+.dark .cw-cta-mono { color: #f39c12; border-bottom-color: rgba(243, 156, 18, 0.4); }
+.dark .cw-cta-mono:hover { color: #fcd34d; border-color: #fcd34d; }
+
+/* ---------------- Tick list (▸) ---------------- */
+ul.cw-ticks {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+ul.cw-ticks li {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  color: #8b7355;
+  font-size: 15px;
+  line-height: 1.55;
+}
+.dark ul.cw-ticks li { color: #cbd5e1; }
+ul.cw-ticks li::before {
+  content: "▸";
+  color: #e67e22;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 13px;
+  flex: 0 0 auto;
+  transform: translateY(1px);
+}
+.dark ul.cw-ticks li::before { color: #f39c12; }
+ul.cw-ticks li em { color: #2c3e50; font-style: italic; font-weight: 600; }
+.dark ul.cw-ticks li em { color: #fbf7f0; }
+
+/* ---------------- Pre-flight 4-up grid ---------------- */
+.cw-preflight {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border: 1px solid rgba(139, 115, 85, 0.25);
+  border-radius: 4px;
+  overflow: hidden;
+  background: #fefdfb;
+}
+.dark .cw-preflight {
+  border-color: rgba(148, 163, 184, 0.2);
+  background: #1e293b;
+}
+.cw-preflight-step {
+  padding: 24px;
+  border-right: 1px solid rgba(139, 115, 85, 0.2);
+}
+.dark .cw-preflight-step { border-right-color: rgba(148, 163, 184, 0.18); }
+.cw-preflight-step:last-child { border-right: 0; }
+.cw-preflight-when {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #e67e22;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+.dark .cw-preflight-when { color: #f39c12; }
+.cw-preflight-step h5 {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0 0 8px;
+  color: #2c3e50;
+}
+.dark .cw-preflight-step h5 { color: #fbf7f0; }
+.cw-preflight-step p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: #8b7355;
+}
+.dark .cw-preflight-step p { color: #cbd5e1; }
+@media (max-width: 980px) {
+  .cw-preflight { grid-template-columns: repeat(2, 1fr); }
+  .cw-preflight-step:nth-child(2) { border-right: 0; }
+  .cw-preflight-step:nth-child(1),
+  .cw-preflight-step:nth-child(2) { border-bottom: 1px solid rgba(139, 115, 85, 0.2); }
+  .dark .cw-preflight-step:nth-child(1),
+  .dark .cw-preflight-step:nth-child(2) { border-bottom-color: rgba(148, 163, 184, 0.18); }
+}
+@media (max-width: 640px) {
+  .cw-preflight { grid-template-columns: 1fr; }
+  .cw-preflight-step { border-right: 0; border-bottom: 1px solid rgba(139, 115, 85, 0.2); }
+  .cw-preflight-step:last-child { border-bottom: 0; }
+}
+
+/* ---------------- Phase rows (Arc) ---------------- */
+.cw-phase {
+  display: grid;
+  grid-template-columns: 160px 1fr 220px;
+  gap: 32px;
+  align-items: start;
+  padding: 28px 0;
+  border-top: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .cw-phase { border-top-color: rgba(148, 163, 184, 0.18); }
+.cw-phase:last-of-type {
+  border-bottom: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .cw-phase:last-of-type { border-bottom-color: rgba(148, 163, 184, 0.18); }
+.cw-phase-head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.cw-phase-head .code { color: #2c3e50; font-weight: 600; }
+.dark .cw-phase-head .code { color: #fbf7f0; }
+.cw-phase-head .time { color: #e67e22; }
+.dark .cw-phase-head .time { color: #f39c12; }
+.cw-phase-body h4 {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: #2c3e50;
+  margin: 0 0 8px;
+}
+.dark .cw-phase-body h4 { color: #fbf7f0; }
+.cw-phase-body p {
+  margin: 0;
+  color: #8b7355;
+  font-size: 16px;
+  line-height: 1.6;
+  max-width: 56ch;
+}
+.dark .cw-phase-body p { color: #cbd5e1; }
+.cw-phase-tools {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+.cw-phase-tools span {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1px solid rgba(139, 115, 85, 0.3);
+  background: #fefdfb;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  color: #8b7355;
+  white-space: nowrap;
+  border-radius: 4px;
+}
+.dark .cw-phase-tools span {
+  background: #1e293b;
+  border-color: rgba(148, 163, 184, 0.25);
+  color: #cbd5e1;
+}
+@media (max-width: 780px) {
+  .cw-phase { grid-template-columns: 1fr; gap: 14px; }
+}
+
+/* ---------------- Compassion principles ---------------- */
+.cw-principles {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(3, 1fr);
+  margin-top: 32px;
+  border-top: 1px solid rgba(139, 115, 85, 0.25);
+  border-bottom: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .cw-principles {
+  border-top-color: rgba(148, 163, 184, 0.18);
+  border-bottom-color: rgba(148, 163, 184, 0.18);
+}
+.cw-principles > div {
+  padding: 28px 24px;
+  border-right: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .cw-principles > div { border-right-color: rgba(148, 163, 184, 0.18); }
+.cw-principles > div:last-child { border-right: 0; }
+.cw-principles .label {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #e67e22;
+  font-weight: 600;
+}
+.dark .cw-principles .label { color: #f39c12; }
+.cw-principles h4 {
+  margin: 10px 0 10px;
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: #2c3e50;
+}
+.dark .cw-principles h4 { color: #fbf7f0; }
+.cw-principles p {
+  margin: 0;
+  color: #8b7355;
+  font-size: 15px;
+  line-height: 1.55;
+}
+.dark .cw-principles p { color: #cbd5e1; }
+@media (max-width: 980px) {
+  .cw-principles { grid-template-columns: 1fr; }
+  .cw-principles > div {
+    border-right: 0;
+    border-bottom: 1px solid rgba(139, 115, 85, 0.25);
+  }
+  .dark .cw-principles > div { border-bottom-color: rgba(148, 163, 184, 0.18); }
+  .cw-principles > div:last-child { border-bottom: 0; }
+}
+
+/* ---------------- Engagement rows (pricing) ---------------- */
+.cw-engagement {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 0;
+  overflow: hidden;
+  border-radius: 4px;
+  border: 1px solid rgba(139, 115, 85, 0.25);
+  background: #fefdfb;
+  margin-bottom: 20px;
+  box-shadow: 0 1px 2px 0 rgba(24, 24, 40, 0.04);
+}
+.dark .cw-engagement {
+  background: #1e293b;
+  border-color: rgba(148, 163, 184, 0.2);
+}
+.cw-engagement.feature {
+  border-color: #e67e22;
+  box-shadow: 0 0 0 1px #e67e22, 0 4px 10px -2px rgba(24, 24, 40, 0.08);
+}
+.dark .cw-engagement.feature {
+  border-color: #f39c12;
+  box-shadow: 0 0 0 1px #f39c12, 0 4px 10px -2px rgba(0, 0, 0, 0.5);
+}
+.cw-engagement-left {
+  position: relative;
+  min-height: 280px;
+  padding: 26px;
+  background:
+    linear-gradient(to bottom right,
+      rgba(230, 126, 34, 0.08),
+      transparent 60%,
+      rgba(230, 126, 34, 0.04)
+    ),
+    #f5f0e6;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 18px;
+}
+.dark .cw-engagement-left {
+  background:
+    linear-gradient(to bottom right,
+      rgba(243, 156, 18, 0.1),
+      transparent 60%,
+      rgba(243, 156, 18, 0.05)
+    ),
+    #141428;
+}
+.cw-engagement-left .meta {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8b7355;
+}
+.dark .cw-engagement-left .meta { color: #cbd5e1; }
+.cw-engagement-left .meta b { color: #2c3e50; font-weight: 600; }
+.dark .cw-engagement-left .meta b { color: #fbf7f0; }
+.cw-engagement.feature .cw-engagement-left .meta b { color: #e67e22; }
+.dark .cw-engagement.feature .cw-engagement-left .meta b { color: #f39c12; }
+.cw-engagement-left .title {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 800;
+  font-size: 30px;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  color: #2c3e50;
+}
+.dark .cw-engagement-left .title { color: #fbf7f0; }
+.cw-engagement-left .title em { color: #e67e22; font-style: italic; }
+.dark .cw-engagement-left .title em { color: #f39c12; }
+.cw-engagement-left .price {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #e67e22;
+  font-weight: 600;
+  border: 1px solid rgba(230, 126, 34, 0.4);
+  padding: 5px 10px;
+  border-radius: 4px;
+  width: fit-content;
+  background: rgba(230, 126, 34, 0.1);
+}
+.dark .cw-engagement-left .price {
+  color: #f39c12;
+  border-color: rgba(243, 156, 18, 0.4);
+  background: rgba(243, 156, 18, 0.12);
+}
+.cw-engagement-right {
+  padding: 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.cw-engagement-right .desc {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.6;
+  color: #8b7355;
+}
+.dark .cw-engagement-right .desc { color: #cbd5e1; }
+.cw-engagement-right .info {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  padding: 14px 0;
+  border-top: 1px solid rgba(139, 115, 85, 0.25);
+  border-bottom: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .cw-engagement-right .info {
+  border-top-color: rgba(148, 163, 184, 0.18);
+  border-bottom-color: rgba(148, 163, 184, 0.18);
+}
+.cw-engagement-right .info dt {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #b8a88f;
+  margin: 0 0 4px;
+}
+.dark .cw-engagement-right .info dt { color: #94a3b8; }
+.cw-engagement-right .info dd {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 12px;
+  font-weight: 600;
+  color: #2c3e50;
+  margin: 0;
+}
+.dark .cw-engagement-right .info dd { color: #fbf7f0; }
+.cw-engagement-footer {
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8b7355;
+}
+.dark .cw-engagement-footer { color: #cbd5e1; }
+@media (max-width: 880px) {
+  .cw-engagement { grid-template-columns: 1fr; }
+  .cw-engagement-left { min-height: 200px; }
+  .cw-engagement-right .info { grid-template-columns: 1fr 1fr; gap: 12px; }
+}
+
+/* ---------------- Retainer block ---------------- */
+.cw-retainer {
+  margin-top: 32px;
+  padding: 28px;
+  border: 1px dashed #d1c7b7;
+  border-radius: 4px;
+  background: transparent;
+}
+.dark .cw-retainer { border-color: #475569; }
+.cw-retainer-meta {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8b7355;
+  margin-bottom: 14px;
+}
+.dark .cw-retainer-meta { color: #cbd5e1; }
+.cw-retainer-meta b { color: #2c3e50; font-weight: 600; }
+.dark .cw-retainer-meta b { color: #fbf7f0; }
+.cw-retainer-meta .right { color: #e67e22; }
+.dark .cw-retainer-meta .right { color: #f39c12; }
+.cw-retainer h3 {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 700;
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  color: #2c3e50;
+  margin: 0 0 12px;
+}
+.dark .cw-retainer h3 { color: #fbf7f0; }
+.cw-retainer p {
+  margin: 0 0 16px;
+  color: #8b7355;
+  font-size: 16px;
+  line-height: 1.6;
+  max-width: 66ch;
+}
+.dark .cw-retainer p { color: #cbd5e1; }
+.cw-retainer p em { color: #2c3e50; font-style: italic; font-weight: 600; }
+.dark .cw-retainer p em { color: #fbf7f0; }
+
+/* ---------------- Person rows ---------------- */
+.cw-person {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 32px;
+  padding: 32px 0;
+  border-top: 1px solid rgba(139, 115, 85, 0.25);
+  align-items: start;
+}
+.dark .cw-person { border-top-color: rgba(148, 163, 184, 0.18); }
+.cw-person:last-of-type {
+  border-bottom: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .cw-person:last-of-type { border-bottom-color: rgba(148, 163, 184, 0.18); }
+.cw-person-av {
+  width: 140px;
+  aspect-ratio: 4/5;
+  border: 1px solid rgba(139, 115, 85, 0.3);
+  border-radius: 2px;
+  overflow: hidden;
+  background: #f5f0e6;
+  position: relative;
+}
+.dark .cw-person-av {
+  background: #1e293b;
+  border-color: rgba(148, 163, 184, 0.25);
+}
+.cw-person-av .cw-person-av-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #b8a88f;
+}
+.dark .cw-person-av .cw-person-av-placeholder { color: #94a3b8; }
+.cw-person-meta {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.cw-person-meta .tag { color: #e67e22; font-weight: 600; }
+.dark .cw-person-meta .tag { color: #f39c12; }
+.cw-person-meta .role { color: #8b7355; }
+.dark .cw-person-meta .role { color: #cbd5e1; }
+.cw-person h4 {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 800;
+  font-size: 32px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: #2c3e50;
+  margin: 0 0 12px;
+}
+.dark .cw-person h4 { color: #fbf7f0; }
+.cw-person h4 em { color: #e67e22; font-style: italic; }
+.dark .cw-person h4 em { color: #f39c12; }
+.cw-person-bio {
+  font-size: 16px;
+  line-height: 1.6;
+  color: #8b7355;
+  max-width: 62ch;
+}
+.dark .cw-person-bio { color: #cbd5e1; }
+.cw-creds {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 16px;
+  row-gap: 6px;
+  font-size: 14px;
+}
+.cw-creds dt {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #b8a88f;
+  padding-top: 2px;
+}
+.dark .cw-creds dt { color: #94a3b8; }
+.cw-creds dd { margin: 0; color: #2c3e50; }
+.dark .cw-creds dd { color: #fbf7f0; }
+@media (max-width: 720px) {
+  .cw-person { grid-template-columns: 1fr; gap: 18px; }
+}
+
+/* ---------------- FAQ ---------------- */
+.cw-faq-list { display: flex; flex-direction: column; }
+.cw-faq-item {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 24px;
+  padding: 26px 0;
+  border-top: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .cw-faq-item { border-top-color: rgba(148, 163, 184, 0.18); }
+.cw-faq-list .cw-faq-item:last-child {
+  border-bottom: 1px solid rgba(139, 115, 85, 0.25);
+}
+.dark .cw-faq-list .cw-faq-item:last-child { border-bottom-color: rgba(148, 163, 184, 0.18); }
+.cw-faq-meta {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #e67e22;
+  font-weight: 600;
+  padding-top: 3px;
+}
+.dark .cw-faq-meta { color: #f39c12; }
+.cw-faq-item h4 {
+  font-family: var(--font-serif, 'Source Serif 4'), Georgia, serif;
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  margin: 0 0 8px;
+  color: #2c3e50;
+}
+.dark .cw-faq-item h4 { color: #fbf7f0; }
+.cw-faq-item p {
+  margin: 0;
+  color: #8b7355;
+  font-size: 16px;
+  line-height: 1.6;
+  max-width: 68ch;
+}
+.dark .cw-faq-item p { color: #cbd5e1; }
+@media (max-width: 720px) {
+  .cw-faq-item { grid-template-columns: 1fr; gap: 8px; }
+}
+
+/* ---------------- Close kit ---------------- */
+.cw-close-kit {
+  margin: 56px auto 0;
+  padding: 24px 28px;
+  text-align: left;
+  border: 1px solid rgba(139, 115, 85, 0.25);
+  border-radius: 4px;
+  background: #fefdfb;
+  max-width: 640px;
+}
+.dark .cw-close-kit {
+  background: #1e293b;
+  border-color: rgba(148, 163, 184, 0.2);
+}
+.cw-close-kit-label {
+  font-family: var(--font-mono, 'JetBrains Mono'), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #e67e22;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+.dark .cw-close-kit-label { color: #f39c12; }
+
+/* Wider prose-style helpers used inline */
+.cw-prose {
+  max-width: 64ch;
+  font-size: 18px;
+  line-height: 1.65;
+  color: #2c3e50;
+}
+.dark .cw-prose { color: #fbf7f0; }
+.cw-prose p { margin: 0 0 1em; }
+.cw-prose p:last-child { margin-bottom: 0; }
+.cw-prose em {
+  font-style: italic;
+  color: #e67e22;
+  font-weight: 600;
+}
+.dark .cw-prose em { color: #f39c12; }


### PR DESCRIPTION
## Summary

- Replaces `/workshops/claude-cowork` with an editorial long-form enterprise offering (three practitioners, $15k/$45k/$90k engagement shapes, format mechanics, chat→code arc, compassion/principles, artifacts, FAQ, retainer block) — built against the canonical editorial DS.
- Homepage: moves the workshops to the top "Featured engagement" slot and demotes the RAG tutorial into an "Also from the catalog" row between rails § 01 and § 02. RAG keeps its full headline + spec strip + Buy/Demo links — analytics retagged `location: secondary_catalog`.
- New `src/styles/claude-cowork.css` with page-local primitives (phase rows, engagement slabs, retainer, principles grid, person rows, FAQ, pre-flight).
- `SectionHead` now accepts `ReactNode` for `title` so heads can carry the italic burnt `<em>` accents the design uses (backward-compatible — existing string callers unchanged).

Implemented from two Claude Design handoff bundles:
1. `Claude Workshops.html` — the workshop page itself
2. `Homepage Feature Slot.html` — the homepage swap with the booking-card right-column variant

## Test plan

- [ ] `npm run build` clean (verified locally)
- [ ] Visual: `/workshops/claude-cowork` — hero, stat slab, all 11 sections render, dark-mode toggle flips correctly, photo strip pulls from Bunny CDN
- [ ] Visual: `/` — top "Featured engagement" block renders with booking calendar; "Also from the catalog" row appears between § 01 and § 02 with RAG + newsletter cards
- [ ] Click-through: `Book a workshop →` and `Engagement shapes →` jump to the right anchors on the workshops page
- [ ] Click-through: RAG `Buy — \$149` and `Try the live demo →` still work; analytics events fire with the new `secondary_catalog` location
- [ ] Mobile: hero collapses cleanly at ≤780px; engagement rows stack at ≤880px; preflight grid stacks at ≤640px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a large rewrite of the `/workshops/claude-cowork` page structure and new global stylesheet import, which could introduce layout/regression issues across pages if CSS selectors collide.
> 
> **Overview**
> Replaces `/workshops/claude-cowork` with a new long-form enterprise workshops landing page (new content structure, engagement/pricing sections, team bios, FAQ, and anchor-based CTAs), and adds a new page-specific stylesheet `claude-cowork.css` loaded globally via `layout.tsx`.
> 
> Updates the homepage to promote workshops in the primary featured slot (new booking/availability card, updated links and analytics event name), and moves the RAG tutorial into a new "Also from the catalog" section with its tracking `location` changed to `secondary_catalog`.
> 
> Extends `SectionHead` to accept a `ReactNode` `title` so section headings can include inline emphasis/markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c21ac5af402bef498f2be1b8aea6d6e6f2f201d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->